### PR TITLE
Default rail visibility: hide ground rails on startup

### DIFF
--- a/fypa/altium_viewer.py
+++ b/fypa/altium_viewer.py
@@ -5801,10 +5801,11 @@ class PdnViewer(QMainWindow):
             self.rail_list.setItemWidget(item, row)
             self._rail_eye_buttons.append((rail, eye))
 
-        # Default: first rail visible, others hidden — matches the previous
-        # combo's behaviour of starting at index 0.
-        if self._rail_eye_buttons:
-            self._rail_eye_buttons[0][1].setVisibleState(True, emit=False)
+        # Default: every rail visible except generic ground names (GND,
+        # 0V, …) so a fresh import shows all power rails at once.
+        _ground_rails = {"0v", "gnd", "ground", "vss"}
+        for rail, eye in self._rail_eye_buttons:
+            eye.setVisibleState(rail.lower() not in _ground_rails, emit=False)
         self._sync_all_rails_eye()
 
         approx_rail_h = self.rail_list.sizeHintForRow(0) or 22


### PR DESCRIPTION
On project load, the rails list now shows all non-ground rails by default and hides common ground names (GND, 0V, GROUND, VSS).