### PR TITLE
Improve PDN parse errors and surface annotation failures

### DIFF
--- a/docs/user-guide/01-sources-and-sinks.md
+++ b/docs/user-guide/01-sources-and-sinks.md
@@ -44,6 +44,22 @@ Every source or sink uses the same four parameters on one component:
 
 Net names must match the schematic exactly — same case, same punctuation.
 
+### Pin overrides (single-net vs two-terminal)
+
+Sources and sinks can tie to copper either by **net name** or by **pin
+designator** on the annotated part. The parameter names depend on whether
+you use a single-net check (`PDN_NET`) or a two-terminal check
+(`PDN_P_NET` + `PDN_N_NET`):
+
+| Mode | Net parameters | Pin overrides |
+|------|----------------|---------------|
+| Single-net | `PDN_NET` / `PDNn_NET` | `PDN_PINS` / `PDNn_PINS` |
+| Two-terminal | `PDN_P_NET` + `PDN_N_NET` | **`PDN_P_PINS`** / **`PDNn_P_PINS`** and **`PDN_N_PINS`** / **`PDNn_N_PINS`** |
+
+`PDNn_PINS` is **not** the same as `PDNn_P_PINS` — the former is for
+single-net mode only; for a two-terminal sink or source use `PDNn_P_PINS`
+on the P side.
+
 > The walkthrough below adds the parameters to a placed instance, which
 > is the right starting point. For parts you expect to reuse across
 > designs (a regulator family, a recurring connector, an MCU), it is

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -119,6 +119,20 @@ _RESISTOR_LIKE_ROLES: frozenset[str] = frozenset({"SERIES"})
 
 VALID_ROLES: frozenset[str] = frozenset({"SOURCE", "SINK", "REGULATOR"}) | _RESISTOR_LIKE_ROLES
 
+_COMMON_TERMINAL_SUFFIXES: frozenset[str] = frozenset({
+    "NET", "PINS", "P_NET", "N_NET", "P_PINS", "N_PINS",
+})
+_KNOWN_SUFFIXES_BY_ROLE: dict[str, frozenset[str]] = {
+    "SOURCE": _COMMON_TERMINAL_SUFFIXES | frozenset({"V"}),
+    "SINK": _COMMON_TERMINAL_SUFFIXES | frozenset({"I", "MIN_V"}),
+    "REGULATOR": frozenset({
+        "V", "GAIN", "REGULATOR_TYPE", "REGULATOR_EFFICIENCY", "QUIESCENT",
+        "OUT_P_NET", "OUT_N_NET", "OUT_P_PINS", "OUT_N_PINS",
+        "IN_P_NET", "IN_N_NET", "IN_P_PINS", "IN_N_PINS",
+    }),
+    "SERIES": frozenset({"R", "P_NET", "N_NET", "P_PINS", "N_PINS"}),
+}
+
 
 # --- SI value parsing ---------------------------------------------------------
 
@@ -718,10 +732,17 @@ def _resolve_terminal(
 
             if bridges_used and warnings is not None:
                 bridge_list = ", ".join(repr(b) for b in bridges_used)
-                warnings.append(
+                msg = (
                     f"{role_diagnostic}: no pad on {net_name!r}; resolved via "
                     f"SERIES bridge to pin(s) on {bridge_list}"
                 )
+                if len(bridges_used) >= 2:
+                    msg += (
+                        ". All listed nets are in the same SERIES bridge "
+                        "group — check SERIES directives (e.g. a "
+                        "multi-channel part bridging VDD to several outputs)"
+                    )
+                warnings.append(msg)
 
         if not matched:
             # List the nets that this component's pads actually sit on, so the
@@ -1100,18 +1121,32 @@ def _terminal_mode(params: dict[str, str], idx: int | None,
     pins_key = _channel_key("PINS", idx)
     p_net_key = _channel_key("P_NET", idx)
     n_net_key = _channel_key("N_NET", idx)
-    has_single = (_ci_get(params, net_key) is not None
-                  or _ci_get(params, pins_key) is not None)
-    has_two = any(
-        _ci_get(params, _channel_key(k, idx)) is not None
-        for k in ("P_NET", "N_NET", "P_PINS", "N_PINS")
-    )
+    p_pins_key = _channel_key("P_PINS", idx)
+    single_set: list[str] = []
+    if _ci_get(params, net_key) is not None:
+        single_set.append(net_key)
+    if _ci_get(params, pins_key) is not None:
+        single_set.append(f"{pins_key} (single-net pin override)")
+    two_set: list[str] = []
+    for suffix in ("P_NET", "N_NET", "P_PINS", "N_PINS"):
+        key = _channel_key(suffix, idx)
+        if _ci_get(params, key) is not None:
+            two_set.append(key)
+    has_single = bool(single_set)
+    has_two = bool(two_set)
     if has_single and has_two:
-        result.errors.append(
-            f"{role_diag}: {net_key} cannot be combined with "
-            f"{p_net_key}/{n_net_key} — use {net_key} alone for a single-net "
-            f"check, or {p_net_key} + {n_net_key} for a two-terminal check"
+        single_text = " + ".join(single_set)
+        two_text = " + ".join(two_set)
+        msg = (
+            f"{role_diag}: {single_text} conflicts with {two_text} "
+            f"(two-terminal). Use either single-net ({net_key} or "
+            f"{pins_key} on a single-net check only) or two-terminal "
+            f"({p_net_key} + {n_net_key}, pins {p_pins_key} / "
+            f"{_channel_key('N_PINS', idx)}), not both."
         )
+        if _ci_get(params, pins_key) is not None:
+            msg += f" For a two-terminal check use {p_pins_key}, not {pins_key}."
+        result.errors.append(msg)
         return None
     if has_single:
         return "single"
@@ -1637,6 +1672,46 @@ def _validate_directive_groups(result: AnnotationResult,
     result.directives = stamped
 
 
+def _warn_unknown_pdn_params(
+    comp: PdnParameterSource,
+    role: str,
+    result: AnnotationResult,
+) -> None:
+    """Warn on PDN_* parameter names that are not recognized for ``role``."""
+    allowed = _KNOWN_SUFFIXES_BY_ROLE.get(role, frozenset())
+    diag = f"{comp.designator} ({comp.schdoc_name})"
+    for key, raw in comp.parameters.items():
+        if raw is None or not str(raw).strip():
+            continue
+        m = _INDEXED_KEY_RE.match(key.strip())
+        if m is None:
+            continue
+        idx_str, suffix = m.group(1), m.group(2)
+        suffix_u = suffix.upper()
+        if suffix_u == "ROLE":
+            continue
+        if suffix_u in allowed:
+            continue
+        idx = int(idx_str) if idx_str else None
+        ch = f"#{idx}" if idx is not None else ""
+        if suffix_u == "PIN":
+            suggest = _channel_key("P_PINS", idx)
+            result.warnings.append(
+                f"{diag}{ch}: unknown parameter {key!r} — did you mean "
+                f"{suggest}?"
+            )
+            continue
+        if suffix_u.startswith("OUT_") and role in ("SOURCE", "SINK"):
+            result.warnings.append(
+                f"{diag}{ch}: {key!r} is a REGULATOR parameter — "
+                f"did you mean to set PDN_ROLE=REGULATOR?"
+            )
+            continue
+        result.warnings.append(
+            f"{diag}{ch}: unknown PDN parameter {key!r} (ignored)"
+        )
+
+
 # --- public entry -------------------------------------------------------------
 
 def parse_annotations(proj: ExtractedProject,
@@ -1723,6 +1798,8 @@ def parse_annotations(proj: ExtractedProject,
             continue
         if comp.pcb_index is None:
             seen_designators.add(key)
+
+        _warn_unknown_pdn_params(comp, role, result)
 
         specs = _PARSER_BY_ROLE[role](comp, proj, enabled_layers, result,
                                       bridge_groups=bridge_groups,

--- a/fypa/altium/loader.py
+++ b/fypa/altium/loader.py
@@ -411,7 +411,7 @@ class LoadedProject:
 
 
 def format_solve_blockers(
-    loaded: "LoadedProject",
+    loaded: LoadedProject,
     *,
     max_errors: int = 15,
     max_warnings: int = 3,

--- a/fypa/altium/loader.py
+++ b/fypa/altium/loader.py
@@ -410,6 +410,55 @@ class LoadedProject:
         return "\n".join(lines)
 
 
+def format_solve_blockers(
+    loaded: "LoadedProject",
+    *,
+    max_errors: int = 15,
+    max_warnings: int = 3,
+) -> str:
+    """Compact, actionable summary for solve-failure dialogs.
+
+    Lists annotation errors (and a few warnings) without the full geometry
+    dump from :meth:`LoadedProject.diagnostic_summary`.
+    """
+    from fypa.cli import _LOG_FILE
+
+    lines = ["Project is not solveable.", ""]
+    errors = list(loaded.annotations.errors)
+    if errors:
+        lines.append("Annotation errors:")
+        for err in errors[:max_errors]:
+            lines.append(f"  • {err}")
+        if len(errors) > max_errors:
+            lines.append(f"  … and {len(errors) - max_errors} more")
+        lines.append("")
+
+    warnings = list(loaded.annotations.warnings)
+    if warnings:
+        lines.append("Warnings:")
+        for warn in warnings[:max_warnings]:
+            lines.append(f"  • {warn}")
+        if len(warnings) > max_warnings:
+            lines.append(f"  … and {len(warnings) - max_warnings} more")
+        lines.append("")
+
+    reasons: list[str] = []
+    if not loaded.extracted.enabled_copper_layer_ids():
+        reasons.append("no enabled copper layers")
+    has_source = any(
+        type(d).__name__ in {"SourceSpec", "RegulatorSpec"}
+        for d in loaded.annotations.directives
+    )
+    if not has_source:
+        reasons.append("no SOURCE or REGULATOR directive")
+    if reasons:
+        lines.append("Other blockers: " + "; ".join(reasons) + ".")
+        lines.append("")
+
+    lines.append(f"Full diagnostic log: {_LOG_FILE}")
+    return "\n".join(lines)
+
+
 def _directive_terminals(d: DirectiveSpec) -> list[TerminalSpec]:
     """Return all PCB-resolved terminals of a directive, regardless of kind.
 

--- a/fypa/altium_viewer.py
+++ b/fypa/altium_viewer.py
@@ -4031,7 +4031,7 @@ class _SolveWorker(QThread):
             # reject both even though the user has placed a SOURCE marker.
             if not loaded.is_solveable:
                 _log = logging.getLogger(__name__)
-                from fypa.cli import _LOG_FILE as _log_file
+                from fypa.altium.loader import format_solve_blockers
                 try:
                     self.stage_changed.emit("Building diagnostic summary…")
                     with _timer.stage("Build diagnostic summary"):
@@ -4049,14 +4049,14 @@ class _SolveWorker(QThread):
                 # Restricted to a plain initial load: overrides / editor
                 # directives mean the user explicitly asked for a re-solve, so
                 # a missing source there is still a hard failure.
-                recoverable = (
+                recoverable_no_source = (
                     bool(loaded.extracted.enabled_copper_layer_ids())
                     and not loaded.annotations.errors
                     and not self._editor_directives
                     and not self._stackup_overrides
                     and not self._sink_overrides
                 )
-                if recoverable:
+                if recoverable_no_source:
                     _log.info(
                         "No SOURCE/REGULATOR directive — opening in editor "
                         "mode (stub solution) for manual setup."
@@ -4068,10 +4068,28 @@ class _SolveWorker(QThread):
                     )
                     return
 
-                self.failed.emit(
-                    f"Project is not solveable.\n\n"
-                    f"See the log file for details:\n{_log_file}"
+                # Annotation errors but copper present — open stub viewer so
+                # the user can inspect Setup → Annotation log and fix Altium
+                # parameters without hunting the log file.
+                recoverable_annotation_errors = (
+                    bool(loaded.extracted.enabled_copper_layer_ids())
+                    and loaded.annotations.errors
+                    and not self._editor_directives
+                    and not self._stackup_overrides
+                    and not self._sink_overrides
                 )
+                if recoverable_annotation_errors:
+                    _log.info(
+                        "Annotation errors — opening design with stub "
+                        "solution for review."
+                    )
+                    self._emit_stub_and_finish(
+                        loaded, pristine_loaded, _timer,
+                        stage_message="Annotation errors — opening design…",
+                    )
+                    return
+
+                self.failed.emit(format_solve_blockers(loaded))
                 return
 
             if self._load_only:
@@ -4935,7 +4953,16 @@ class LauncherWindow(QMainWindow):
 
     def _on_solve_failed(self, message: str) -> None:
         logging.getLogger(__name__).error("Solve failed: %s", message)
-        QMessageBox.critical(self, "Solve failed", message)
+        box = QMessageBox(self)
+        box.setIcon(QMessageBox.Icon.Critical)
+        box.setWindowTitle("Solve failed")
+        lines = message.splitlines()
+        if len(lines) > 10 or len(message) > 500:
+            box.setText(lines[0] if lines else "Solve failed")
+            box.setDetailedText(message)
+        else:
+            box.setText(message)
+        box.exec()
 
     def _on_solve_finished(self, new_solution, metadata: dict,
                            loaded_project, new_settings) -> None:
@@ -4948,6 +4975,7 @@ class LauncherWindow(QMainWindow):
         # stub instead of failing — let the user know it's set up for manual
         # marker placement rather than a finished solve.
         _maybe_warn_needs_directives(new_win or self, new_solution)
+        _maybe_show_annotation_errors(new_win or self, metadata)
         # Rails with only sources or only sinks were skipped — tell the user.
         _maybe_warn_open_loop_rails(new_win or self, metadata)
         # Nets whose source & sink landed on disconnected copper — tell the user.
@@ -5811,6 +5839,7 @@ class PdnViewer(QMainWindow):
             self._render()
 
             _maybe_warn_needs_directives(self, new_solution)
+            _maybe_show_annotation_errors(self, metadata)
             _maybe_warn_open_loop_rails(self, metadata)
             _maybe_warn_connectivity_breaks(self, metadata)
 
@@ -20125,7 +20154,16 @@ class PdnViewer(QMainWindow):
         reload_btn = getattr(self, "_settings_reload_design_btn", None)
         if reload_btn is not None:
             reload_btn.setEnabled(True)
-        QMessageBox.critical(self, "Solve failed", message)
+        box = QMessageBox(self)
+        box.setIcon(QMessageBox.Icon.Critical)
+        box.setWindowTitle("Solve failed")
+        lines = message.splitlines()
+        if len(lines) > 10 or len(message) > 500:
+            box.setText(lines[0] if lines else "Solve failed")
+            box.setDetailedText(message)
+        else:
+            box.setText(message)
+        box.exec()
 
     def _on_solve_finished(
         self, new_solution, metadata: dict, loaded_project,
@@ -22193,6 +22231,30 @@ def _maybe_warn_needs_directives(parent_win, solution) -> None:
         "this design, so there's nothing to solve yet.\n\n"
         "The design has loaded — switch on Edit to place sources / sinks "
         "manually, then press Resolve.",
+    )
+
+
+def _maybe_show_annotation_errors(parent_win, metadata) -> None:
+    """Pop a notice when annotation errors block solving.
+
+    Fired after a stub viewer opens with ``metadata['annotation_errors']``.
+    """
+    if not isinstance(metadata, dict):
+        return
+    errors = metadata.get("annotation_errors") or []
+    if not errors:
+        return
+    max_show = 12
+    body = "\n".join(f"  • {e}" for e in errors[:max_show])
+    if len(errors) > max_show:
+        body += f"\n  … and {len(errors) - max_show} more"
+    QMessageBox.warning(
+        parent_win,
+        "Annotation errors",
+        "These PDN annotation errors must be fixed before the board "
+        "can be solved:\n\n"
+        f"{body}\n\n"
+        "Details also in Setup → Annotation log.",
     )
 
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -28,6 +28,7 @@ from fypa.altium.annotations import (
     _sheet_name_matches,
     _terminal_mode,
     _validate_directive_groups,
+    _warn_unknown_pdn_params,
     parse_annotations,
 )
 from fypa.altium.extract import (
@@ -62,7 +63,18 @@ def test_terminal_mode_rejects_mixing_pdn_net_with_p_net():
     mode = _terminal_mode({"PDN_NET": "VBATT", "PDN_P_NET": "+5V"}, None,
                           "SOURCE on J1", result)
     assert mode is None
-    assert any("cannot be combined" in e for e in result.errors)
+    assert any("conflicts with" in e for e in result.errors)
+
+
+def test_terminal_mode_pins_conflict_suggests_p_pins():
+    result = AnnotationResult()
+    mode = _terminal_mode(
+        {"PDN3_PINS": "A1", "PDN3_P_NET": "LED_R", "PDN3_N_NET": "GND"},
+        3, "SINK on U4#3", result,
+    )
+    assert mode is None
+    assert any("PDN3_PINS" in e for e in result.errors)
+    assert any("PDN3_P_PINS" in e for e in result.errors)
 
 
 def test_terminal_mode_rejects_no_terminal_net():
@@ -77,6 +89,23 @@ def test_terminal_mode_indexed_channel():
     assert _terminal_mode({"PDN2_NET": "VBATT"}, 2, "SINK on U1#2",
                           result) == "single"
     assert not result.errors
+
+
+def test_warn_unknown_pdn_pin_typo():
+    result = AnnotationResult()
+    comp = PdnParameterSource(
+        designator="U4", schdoc_name="Main.SchDoc", pcb_index=0,
+        parameters={
+            "PDN_ROLE": "SINK",
+            "PDN2_I": "100mA",
+            "PDN2_P_NET": "LED_R",
+            "PDN2_N_NET": "GND",
+            "PDN2_PIN": "B2",
+        },
+        sch_lookup_designator="U4",
+    )
+    _warn_unknown_pdn_params(comp, "SINK", result)
+    assert any("PDN2_PIN" in w and "PDN2_P_PINS" in w for w in result.warnings)
 
 
 # --- _validate_directive_groups ----------------------------------------------
@@ -775,3 +804,25 @@ def test_local_fallback_skips_no_net_pad():
     assert spec.pins[0].pad_designator == "2"
     assert spec.pins[0].net_index == 1
 
+
+def test_format_solve_blockers_lists_errors():
+    from types import SimpleNamespace
+
+    from fypa.altium.loader import format_solve_blockers
+
+    loaded = SimpleNamespace(
+        extracted=SimpleNamespace(
+            enabled_copper_layer_ids=lambda: [1],
+        ),
+        annotations=AnnotationResult(
+            errors=["SINK on U4#3: PDN3_PINS conflicts with PDN3_P_NET"],
+            warnings=["U4: unknown parameter 'PDN2_PIN'"],
+            directives=[],
+        ),
+    )
+    text = format_solve_blockers(loaded)
+    assert "Project is not solveable" in text
+    assert "PDN3_PINS" in text
+    assert "PDN2_PIN" in text
+    assert "no SOURCE or REGULATOR" in text
+    assert "fypa.log" in text


### PR DESCRIPTION
### Summary

- Parser reports PDN terminal conflicts more precisely (e.g. PDN3_PINS vs two-terminal mode) and suggests PDNn_P_PINS where appropriate
- Unknown PDN parameters (PDNn_PIN, OUT_* on SINK/SOURCE) emit warnings instead of being silently ignored
- SERIES bridge warnings include extra context when multiple nets are resolved via the same bridge group
- On “not solveable”: error list in the dialog (format_solve_blockers), stub viewer opens on annotation errors, popup via _maybe_show_annotation_errors
- Brief docs on pin overrides (PDNn_PINS ≠ PDNn_P_PINS)