### PR TITLE
indexed pdn roles without part role

### DIFF
--- a/.cursor/rules/anonymize-examples.mdc
+++ b/.cursor/rules/anonymize-examples.mdc
@@ -1,0 +1,37 @@
+---
+description: Use generic names in docs, tests, and comments — never leak real project identifiers
+alwaysApply: true
+---
+
+# Anonymize project-specific names
+
+When writing or editing **documentation**, **tests**, **comments**, or **commit/PR text**, never use identifiers from a real board or customer project — even when debugging started from that project.
+
+## Replace with generic equivalents
+
+| Avoid (project-specific) | Use instead (generic) |
+|---|---|
+| Board/product names (`VIP-Connector`, `rudder_main`, …) | `example board`, `Pwr.SchDoc`, `Main.SchDoc` |
+| Part numbers (`MP5048`, …) | `power-switch IC`, `LDO`, `e-fuse` (type only, no MPN) |
+| Project net names (`VCC_EFUSE`, `VDD_48V_PORT`, `S00A_SL8M7`) | `VIN`, `VOUT`, `VCC`, `+5V`, `GND` |
+| Project sheet names (`efuse.SchDoc`) | `Pwr.SchDoc`, `Supply.SchDoc` |
+| Debug probe paths (`_probe/vip-connector-module`) | Refer to behaviour, not probe folder names, in committed artifacts |
+
+Generic designators (`U2`, `J1`) and standard rail names (`+3V3`, `GND`) are fine.
+
+## Where this applies
+
+- `docs/**` — user guide, README examples
+- `tests/**` — fixtures, docstrings, inline comments
+- `fypa/**` — module docstrings and inline comments (not parsed Altium data)
+- PR descriptions and commit messages
+
+## Allowed exceptions
+
+- `_probe/` and other gitignored debug output (not committed)
+- Tests that intentionally load `_probe/*.pkl` regression fixtures (path only; no project names in assertions/docs)
+- Code that reads real project files at runtime (no hard-coded project names in examples)
+
+## Before finishing
+
+Scan changed files for names that appeared only in the triggering debug session. If unsure, prefer the smallest generic example that still exercises the behaviour.

--- a/docs/user-guide/01-sources-and-sinks.md
+++ b/docs/user-guide/01-sources-and-sinks.md
@@ -228,6 +228,23 @@ channels 2–3 override to `SOURCE` (the two outputs). Only the channels
 that differ from the default carry a `PDN<n>_ROLE` — a plain two-sink part
 needs no role overrides at all.
 
+When every active channel has its own role, you may omit `PDN_ROLE`
+entirely and set only `PDN<n>_ROLE` on each indexed channel — for example
+a part that SERIES-bridges the input rail and SINKs quiescent current on
+a separate IC supply:
+
+| Name         | Value          | Name          | Value          |
+|--------------|----------------|---------------|----------------|
+| `PDN1_ROLE`  | `SERIES`       | `PDN1_R`      | `7m`           |
+|              |                | `PDN1_P_NET`  | `VIN`          |
+|              |                | `PDN1_N_NET`  | `VOUT`         |
+| `PDN2_ROLE`  | `SINK`         | `PDN2_I`      | `10mA`         |
+|              |                | `PDN2_P_NET`  | `VCC`          |
+|              |                | `PDN2_N_NET`  | `GND`          |
+
+Each indexed channel must then declare its role explicitly; channels
+without `PDN<n>_ROLE` and without a part-wide `PDN_ROLE` are rejected.
+
 A few things to keep in mind:
 
 - Mix roles across **different** nets. A source and a sink on the *same*

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -86,6 +86,12 @@ just ``PDN_ROLE = SINK`` plus ``PDN_I`` / ``PDN1_I``. Only the channels that
 diverge from the default carry an override, so pick the majority role as
 ``PDN_ROLE`` and override the exceptions.
 
+When every active channel carries its own ``PDN<n>_ROLE``, the part-wide
+``PDN_ROLE`` may be omitted entirely — e.g. a part with a SERIES channel
+(``PDN1_ROLE`` / ``PDN1_R``) and a SINK channel (``PDN2_ROLE`` / ``PDN2_I``)
+on different nets. Each indexed channel must then declare its role explicitly;
+channels without ``PDN<n>_ROLE`` and without a part-wide default are rejected.
+
 Example — a DAC: supply SINK (channels 0/1) plus two output SOURCEs::
 
     PDN_ROLE   = SINK                                    # part-wide default
@@ -399,6 +405,34 @@ def _effective_role(params: dict[str, str], index: int | None,
     return part_role
 
 
+def _has_indexed_role_params(params: dict[str, str]) -> bool:
+    """True when at least one non-empty ``PDN<n>_ROLE`` parameter exists (n ≥ 1)."""
+    for k, v in params.items():
+        m = _INDEXED_KEY_RE.match(k.strip())
+        if m is None or not m.group(1):
+            continue
+        if m.group(2).upper() != "ROLE":
+            continue
+        if v is not None and str(v).strip():
+            return True
+    return False
+
+
+def _is_pdn_annotated(params: dict[str, str]) -> bool:
+    """True when the part carries ``PDN_ROLE`` or explicit ``PDN<n>_ROLE`` keys."""
+    if _ci_get(params, ROLE_KEY) is not None:
+        return True
+    return _has_indexed_role_params(params)
+
+
+def _part_role_default(params: dict[str, str]) -> str:
+    """Upper-cased part-wide ``PDN_ROLE``, or ``""`` when only indexed roles are set."""
+    raw = _ci_get(params, ROLE_KEY)
+    if raw is None:
+        return ""
+    return raw.strip().upper()
+
+
 # --- terminal / pin resolution ------------------------------------------------
 
 @dataclass(frozen=True)
@@ -559,7 +593,7 @@ def _iter_pdn_parameter_sources(proj: ExtractedProject) -> list[PdnParameterSour
     sch_with_role: set[str] = set()
 
     for comp in proj.sch_components:
-        if _ci_get(comp.parameters, ROLE_KEY) is None:
+        if not _is_pdn_annotated(comp.parameters):
             continue
         sch_with_role.add(comp.designator.upper())
         sources.append(PdnParameterSource(
@@ -574,7 +608,7 @@ def _iter_pdn_parameter_sources(proj: ExtractedProject) -> list[PdnParameterSour
         dict[str, list[tuple[str, tuple[str, ...], tuple[str, ...]]]] | None
     ) = None
     for idx, pcb in enumerate(proj.pcb_components):
-        if _ci_get(pcb.parameters, ROLE_KEY) is None:
+        if not _is_pdn_annotated(pcb.parameters):
             continue
         lookup_des = pcb.source_designator or pcb.designator
         if lookup_des.upper() in sch_with_role:
@@ -987,10 +1021,7 @@ def _collect_bridge_groups(
             parent[rb] = ra
 
     for comp in parameter_sources:
-        part_role_raw = _ci_get(comp.parameters, ROLE_KEY)
-        if part_role_raw is None:
-            continue
-        part_role = part_role_raw.strip().upper()
+        part_role = _part_role_default(comp.parameters)
         # Only SERIES-role channels bridge nets. On a mixed-role part the
         # part role may be e.g. SINK, so filter by each channel's effective
         # role rather than the part role.
@@ -1640,10 +1671,7 @@ def _collect_supply_voltages_by_net(
         raw.setdefault(net.strip().upper(), set()).add(float(voltage))
 
     for comp in parameter_sources:
-        part_role_raw = _ci_get(comp.parameters, ROLE_KEY)
-        if part_role_raw is None:
-            continue
-        part_role = part_role_raw.strip().upper()
+        part_role = _part_role_default(comp.parameters)
         # Both SOURCE and REGULATOR carry PDN<n>_V; switch on each channel's
         # effective role so a SOURCE (or REGULATOR) channel on a mixed-role
         # part still contributes its nominal rail voltage.
@@ -2120,6 +2148,12 @@ def _resolve_channel_roles(
                 )
                 continue
         else:
+            if not part_role:
+                result.errors.append(
+                    f"{_channel_label(designator, idx)}: missing "
+                    f"{_channel_key('ROLE', idx)} (no part-wide PDN_ROLE)"
+                )
+                continue
             eff = part_role
         value_key = _channel_key(_VALUE_SUFFIX_BY_ROLE[eff], idx)
         if _ci_get(params, value_key) is None:
@@ -2171,18 +2205,20 @@ def parse_annotations(proj: ExtractedProject,
 
     for comp in proj.sch_components:
         stray = [k for k in comp.parameters if k.upper().startswith(PARAM_PREFIX)]
-        if stray and _ci_get(comp.parameters, ROLE_KEY) is None:
+        if stray and not _is_pdn_annotated(comp.parameters):
             result.warnings.append(
                 f"{comp.designator} ({comp.schdoc_name}): has {len(stray)} "
-                f"PDN_* parameter(s) but no PDN_ROLE — directive ignored"
+                f"PDN_* parameter(s) but no PDN_ROLE or PDN<n>_ROLE — "
+                f"directive ignored"
             )
     for pcb in proj.pcb_components:
         stray = [k for k in pcb.parameters if k.upper().startswith(PARAM_PREFIX)]
-        if stray and _ci_get(pcb.parameters, ROLE_KEY) is None:
+        if stray and not _is_pdn_annotated(pcb.parameters):
             lookup = pcb.source_designator or pcb.designator
             result.warnings.append(
                 f"{pcb.designator} (PCB, from {lookup}): has {len(stray)} "
-                f"PDN_* parameter(s) but no PDN_ROLE — directive ignored"
+                f"PDN_* parameter(s) but no PDN_ROLE or PDN<n>_ROLE — "
+                f"directive ignored"
             )
 
     parameter_sources = _iter_pdn_parameter_sources(proj)
@@ -2196,15 +2232,18 @@ def parse_annotations(proj: ExtractedProject,
             continue  # Absorbed by net-merge pre-pass — see fypa.altium.loader.
         role_raw = _ci_get(comp.parameters, ROLE_KEY)
         if role_raw is None:
-            continue
-
-        role = role_raw.strip().upper()
-        if role not in VALID_ROLES:
-            result.errors.append(
-                f"{comp.designator} ({comp.schdoc_name}): unknown PDN_ROLE={role_raw!r} "
-                f"— must be one of {sorted(VALID_ROLES)}"
-            )
-            continue
+            if not _has_indexed_role_params(comp.parameters):
+                continue
+            role = ""
+        else:
+            role = role_raw.strip().upper()
+            if role not in VALID_ROLES:
+                result.errors.append(
+                    f"{comp.designator} ({comp.schdoc_name}): unknown "
+                    f"PDN_ROLE={role_raw!r} — must be one of "
+                    f"{sorted(VALID_ROLES)}"
+                )
+                continue
 
         # A designator with a SOURCE in one schdoc and SINK in another would be
         # ambiguous — flag duplicates (schematic logical designators only).
@@ -2231,6 +2270,8 @@ def parse_annotations(proj: ExtractedProject,
         if not channel_roles:
             # No resolvable channels — call the part-role parser so it emits
             # the role-appropriate "missing PDN_V / PDN_I / …" diagnostic.
+            if not role:
+                continue
             specs = _PARSER_BY_ROLE[role](comp, proj, enabled_layers, result,
                                           bridge_groups=bridge_groups,
                                           net_remap=net_remap,

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -124,7 +124,7 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
@@ -1089,7 +1089,7 @@ def _collect_bridge_groups(
     group. Net names are upper-cased for case-insensitive comparison.
 
     Name-level equivalence for unit tests. Cross-directive validation unions
-    PCB net indices via :func:`_union_series_bridge_net_indices` when present.
+    PCB net indices via :func:`_union_series_bridge_net_indices`.
     Terminal pin resolution uses direct pad-to-net connectivity only — see
     :func:`_resolve_terminal`.
     """

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -124,6 +124,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Iterator
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
@@ -991,6 +992,90 @@ def _pads_by_component_all(proj: ExtractedProject) -> dict[int, list[RawPad]]:
     return entry[1]
 
 
+def _series_channel_indices(
+    comp: PdnParameterSource,
+) -> list[int]:
+    """Indexed SERIES (resistor-like) channel numbers on one parameter source."""
+    part_role = _part_role_default(comp.parameters)
+    return [
+        idx for idx in _discover_channel_indices(comp.parameters, "R")
+        if _effective_role(comp.parameters, idx, part_role)
+        in _RESISTOR_LIKE_ROLES
+    ]
+
+
+def _series_channel_has_net_params(
+    comp: PdnParameterSource,
+    ch_idx: int,
+) -> bool:
+    return (
+        _ci_get(comp.parameters, _channel_key("P_PINS", ch_idx)) is not None
+        or _ci_get(comp.parameters, _channel_key("N_PINS", ch_idx)) is not None
+    )
+
+
+def _resolve_series_channel_nets(
+    comp: PdnParameterSource,
+    proj: ExtractedProject,
+    ch_idx: int,
+    pcb_idx: int,
+    ch_indices: list[int],
+) -> tuple[str, str] | None:
+    """P/N net names for one SERIES channel on one PCB placement."""
+    p_net = _ci_get(comp.parameters, _channel_key("P_NET", ch_idx))
+    n_net = _ci_get(comp.parameters, _channel_key("N_NET", ch_idx))
+    if p_net is None and n_net is None and not _series_channel_has_net_params(
+        comp, ch_idx,
+    ):
+        if len(ch_indices) != 1:
+            return None
+        return _autoinfer_2pin_nets(proj, pcb_idx)
+    if p_net and n_net:
+        return p_net, n_net
+    return None
+
+
+def _iter_series_bridge_pairs(
+    parameter_sources: list[PdnParameterSource],
+    proj: ExtractedProject,
+    *,
+    per_placement: bool,
+) -> Iterator[tuple[int | None, str, str]]:
+    """Yield ``(pcb_index, p_net, n_net)`` for each SERIES bridge.
+
+    ``pcb_index`` is ``None`` only for parameter-level name pairs
+    (``per_placement=False``). Placement-scoped iteration is used by
+    cross-directive validation; parameter-level pairs build the transitive
+    name equivalence map in :func:`_collect_bridge_groups`.
+    """
+    for comp in parameter_sources:
+        ch_indices = _series_channel_indices(comp)
+        if not ch_indices:
+            continue
+        pcb_indices = _pcb_indices_for_source(comp, proj)
+        for ch_idx in ch_indices:
+            if per_placement:
+                for pcb_idx in pcb_indices:
+                    pair = _resolve_series_channel_nets(
+                        comp, proj, ch_idx, pcb_idx, ch_indices,
+                    )
+                    if pair is not None:
+                        yield pcb_idx, pair[0], pair[1]
+                continue
+            p_net = _ci_get(comp.parameters, _channel_key("P_NET", ch_idx))
+            n_net = _ci_get(comp.parameters, _channel_key("N_NET", ch_idx))
+            if p_net and n_net:
+                yield None, p_net, n_net
+            elif p_net is None and n_net is None and not _series_channel_has_net_params(
+                comp, ch_idx,
+            ):
+                if len(ch_indices) == 1:
+                    for pcb_idx in pcb_indices:
+                        pair = _autoinfer_2pin_nets(proj, pcb_idx)
+                        if pair is not None:
+                            yield pcb_idx, pair[0], pair[1]
+
+
 def _collect_bridge_groups(
     parameter_sources: list[PdnParameterSource],
     proj: ExtractedProject,
@@ -1003,9 +1088,10 @@ def _collect_bridge_groups(
     Transitive: if A↔B and B↔C are both bridged, A, B, C all belong to one
     group. Net names are upper-cased for case-insensitive comparison.
 
-    Used by :func:`_validate_directive_groups` and the solver to treat
-    SERIES-bridged nets as electrically connected. Terminal pin resolution
-    uses direct pad-to-net connectivity only — see :func:`_resolve_terminal`.
+    Name-level equivalence for unit tests. Cross-directive validation unions
+    PCB net indices via :func:`_union_series_bridge_net_indices` when present.
+    Terminal pin resolution uses direct pad-to-net connectivity only — see
+    :func:`_resolve_terminal`.
     """
     parent: dict[str, str] = {}
 
@@ -1020,35 +1106,10 @@ def _collect_bridge_groups(
         if ra != rb:
             parent[rb] = ra
 
-    for comp in parameter_sources:
-        part_role = _part_role_default(comp.parameters)
-        # Only SERIES-role channels bridge nets. On a mixed-role part the
-        # part role may be e.g. SINK, so filter by each channel's effective
-        # role rather than the part role.
-        indices = [
-            idx for idx in _discover_channel_indices(comp.parameters, "R")
-            if _effective_role(comp.parameters, idx, part_role)
-            in _RESISTOR_LIKE_ROLES
-        ]
-        if not indices:
-            continue
-        for idx in indices:
-            p_net = _ci_get(comp.parameters, _channel_key("P_NET", idx))
-            n_net = _ci_get(comp.parameters, _channel_key("N_NET", idx))
-            # Replicate auto-infer for 2-pin resistors so the bridge graph stays
-            # consistent with the per-directive parser. A multi-channel SERIES
-            # part bridges a different net pair in each channel, so union every
-            # instance — stopping at the first would strand the other channels.
-            if p_net is None and n_net is None and \
-                    _ci_get(comp.parameters, _channel_key("P_PINS", idx)) is None and \
-                    _ci_get(comp.parameters, _channel_key("N_PINS", idx)) is None:
-                if len(indices) == 1:
-                    for pcb_idx in _pcb_indices_for_source(comp, proj):
-                        inferred = _autoinfer_2pin_nets(proj, pcb_idx)
-                        if inferred is not None:
-                            union(inferred[0].upper(), inferred[1].upper())
-            if p_net and n_net:
-                union(p_net.upper(), n_net.upper())
+    for _pcb_idx, p_net, n_net in _iter_series_bridge_pairs(
+        parameter_sources, proj, per_placement=False,
+    ):
+        union(p_net.upper(), n_net.upper())
 
     # Materialise each equivalence class as a frozenset and map every net to it.
     classes: dict[str, set[str]] = {}

--- a/fypa/topology/layout/columns.py
+++ b/fypa/topology/layout/columns.py
@@ -18,9 +18,12 @@ from fypa.topology.constants import (
 from fypa.topology.layout.stubs import assign_edge_wire_columns, assign_stacked_stub_lengths
 from fypa.topology.layout.vertical_align import (
     assign_vertical_positions,
+    composite_node_height,
     node_height,
     port_layout_rows,
+    section_y_offsets,
 )
+from fypa.topology.metadata.specs import spec_port_role
 from fypa.topology.metadata.layout_bridge import (
     is_return_port_row,
     jump_row_for_directive,
@@ -35,7 +38,7 @@ from fypa.topology.placement import (
     plan_signal_buses,
 )
 from fypa.topology.terminal_roles import is_power_input_port
-from fypa.topology.types import TopologyNode, TopologyPort
+from fypa.topology.types import NodeSection, TopologyNode, TopologyPort
 
 
 def _col_gap_for_gutter_slots(n_slots: int, *, gnd_reserve: bool = True) -> float:
@@ -131,9 +134,13 @@ def _place_columns(
     all_ports: list[TopologyPort] = []
     for c in range(max_col + 1):
         for s in by_col.get(c, []):
-            visible_ports = s["port_defs"]
-            n_layout_rows, return_row_map = port_layout_rows(visible_ports)
-            nh = node_height(n_layout_rows)
+            sections = s.get("sections")
+            if sections:
+                nh = composite_node_height(sections)
+            else:
+                visible_ports = s["port_defs"]
+                n_layout_rows, _ = port_layout_rows(visible_ports)
+                nh = node_height(n_layout_rows)
             nx = col_x[c]
             ny = y_assign[s["node_id"]]
             role = s["role"]
@@ -149,32 +156,72 @@ def _place_columns(
                 config_label="",
                 has_error=s["has_error"],
                 tooltip=s.get("tooltip", ""),
-                single_net=is_single_net_node(role, visible_ports),
+                single_net=is_single_net_node(role, s["port_defs"]) if not sections else False,
                 bounds=(nx, ny, NODE_W, nh),
                 jump_row=jump_row_for_directive(s["directive"]),
             )
             resolved_ports = s.get("resolved_ports") or {}
-            sorted_ports = sorted(visible_ports, key=lambda t: t[2])
-            for pname, side, sort_key in sorted_ports:
-                resolved = resolved_ports.get(pname)
-                if resolved is None:
-                    continue
-                row_i = sort_key if not is_return_port_row(sort_key) else return_row_map[sort_key]
-                py = ny + HEADER_H + BODY_PAD + row_i * PORT_ROW_H + PORT_ROW_H / 2
-                px = nx if side == "left" else nx + NODE_W
-                port = TopologyPort(
-                    terminal=pname,
-                    net=resolved.wnet,
-                    label=resolved.plabel,
-                    side=side,
-                    x=px,
-                    y=py,
-                    node_id=s["node_id"],
-                    is_power_input=is_power_input_port(role, pname),
-                    tooltip=resolved.tooltip,
-                )
-                node.ports.append(port)
-                all_ports.append(port)
+            if sections:
+                for sec, sec_y, sec_h in section_y_offsets(sections):
+                    node.sections.append(
+                        NodeSection(role=sec["role"], y=sec_y, height=sec_h),
+                    )
+                    n_rows, return_row_map = port_layout_rows(sec["port_defs"])
+                    sorted_ports = sorted(sec["port_defs"], key=lambda t: t[2])
+                    for pname, side, sort_key in sorted_ports:
+                        resolved = resolved_ports.get(pname)
+                        if resolved is None:
+                            continue
+                        row_i = (
+                            sort_key
+                            if not is_return_port_row(sort_key)
+                            else return_row_map[sort_key]
+                        )
+                        py = (
+                            ny + sec_y + HEADER_H + BODY_PAD
+                            + row_i * PORT_ROW_H + PORT_ROW_H / 2
+                        )
+                        px = nx if side == "left" else nx + NODE_W
+                        port_role = spec_port_role(s, pname)
+                        port = TopologyPort(
+                            terminal=pname,
+                            net=resolved.wnet,
+                            label=resolved.plabel,
+                            side=side,
+                            x=px,
+                            y=py,
+                            node_id=s["node_id"],
+                            role=port_role,
+                            is_power_input=is_power_input_port(port_role, pname),
+                            tooltip=resolved.tooltip,
+                        )
+                        node.ports.append(port)
+                        all_ports.append(port)
+            else:
+                visible_ports = s["port_defs"]
+                n_layout_rows, return_row_map = port_layout_rows(visible_ports)
+                sorted_ports = sorted(visible_ports, key=lambda t: t[2])
+                for pname, side, sort_key in sorted_ports:
+                    resolved = resolved_ports.get(pname)
+                    if resolved is None:
+                        continue
+                    row_i = sort_key if not is_return_port_row(sort_key) else return_row_map[sort_key]
+                    py = ny + HEADER_H + BODY_PAD + row_i * PORT_ROW_H + PORT_ROW_H / 2
+                    px = nx if side == "left" else nx + NODE_W
+                    port = TopologyPort(
+                        terminal=pname,
+                        net=resolved.wnet,
+                        label=resolved.plabel,
+                        side=side,
+                        x=px,
+                        y=py,
+                        node_id=s["node_id"],
+                        role=role,
+                        is_power_input=is_power_input_port(role, pname),
+                        tooltip=resolved.tooltip,
+                    )
+                    node.ports.append(port)
+                    all_ports.append(port)
             assign_stacked_stub_lengths(node.ports)
             nodes.append(node)
     for node in nodes:

--- a/fypa/topology/layout/stubs.py
+++ b/fypa/topology/layout/stubs.py
@@ -42,9 +42,10 @@ def assign_stacked_stub_lengths(ports: list[TopologyPort]) -> None:
 
 def _port_vertical_bias(port: TopologyPort, role: str) -> str:
     """How a port's wire leaves the symbol edge: up, down, or horizontally."""
+    port_role = port.role or role
     if port.net == GND_NET:
         return "down"
-    if role == "REGULATOR" and port.side == "left" and is_power_input_port(role, port.terminal):
+    if port_role == "REGULATOR" and port.side == "left" and is_power_input_port(port_role, port.terminal):
         return "up"
     return "horizontal"
 

--- a/fypa/topology/layout/vertical_align.py
+++ b/fypa/topology/layout/vertical_align.py
@@ -14,12 +14,39 @@ from fypa.topology.constants import (
     WIRE_EPS,
 )
 from fypa.topology.metadata.layout_bridge import is_return_port_row
-from fypa.topology.metadata_schema import NodeSpec
+from fypa.topology.metadata_schema import NodeSpec, RoleSection
+from fypa.topology.metadata.specs import spec_port_role
 from fypa.topology.terminal_roles import is_output_port
 
 
 def node_height(n_rows: int) -> float:
     return HEADER_H + BODY_PAD + max(n_rows, 1) * PORT_ROW_H + BODY_PAD
+
+
+def section_body_height(n_rows: int) -> float:
+    """Body height for one stacked role block (excludes its header)."""
+    return BODY_PAD + max(n_rows, 1) * PORT_ROW_H + BODY_PAD
+
+
+def composite_node_height(sections: list[RoleSection]) -> float:
+    """Total symbol height for a multi-role component."""
+    total = 0.0
+    for sec in sections:
+        n_rows, _ = port_layout_rows(sec["port_defs"])
+        total += HEADER_H + section_body_height(n_rows)
+    return total
+
+
+def section_y_offsets(sections: list[RoleSection]) -> list[tuple[RoleSection, float, float]]:
+    """Return ``(section, y_offset, section_height)`` for stacked layout."""
+    out: list[tuple[RoleSection, float, float]] = []
+    y = 0.0
+    for sec in sections:
+        n_rows, _ = port_layout_rows(sec["port_defs"])
+        sec_h = HEADER_H + section_body_height(n_rows)
+        out.append((sec, y, sec_h))
+        y += sec_h
+    return out
 
 
 def port_layout_rows(port_defs: list[tuple[str, str, int]]) -> tuple[int, dict[int, int]]:
@@ -43,6 +70,9 @@ def port_layout_rows(port_defs: list[tuple[str, str, int]]) -> tuple[int, dict[i
 
 
 def _spec_layout_height(spec: NodeSpec) -> float:
+    sections = spec.get("sections")
+    if sections:
+        return composite_node_height(sections)
     n_layout_rows, _ = port_layout_rows(spec["port_defs"])
     return node_height(n_layout_rows)
 
@@ -123,7 +153,7 @@ def _pick_downstream_align_partner(
     role = spec["role"]
     output_nets: set[str] = set()
     for pname, side, _ in spec["port_defs"]:
-        if not is_output_port(role, pname, side):
+        if not is_output_port(spec_port_role(spec, pname), pname, side):
             continue
         resolved = (spec.get("resolved_ports") or {}).get(pname)
         if resolved and resolved.wnet:

--- a/fypa/topology/metadata/layout_bridge.py
+++ b/fypa/topology/metadata/layout_bridge.py
@@ -19,6 +19,8 @@ from fypa.topology.metadata.specs import (
     driven_power_nets,
     jump_row_for_directive,
     natural_sort_key,
+    spec_has_series_role,
+    spec_port_role,
 )
 from fypa.topology.metadata.tooltips import port_tooltip
 from fypa.topology.metadata_schema import NodeSpec, TerminalDict, TopologyMetadata
@@ -126,7 +128,7 @@ def _detect_loop_series_parents(
     loop_parent: dict[str, str] = {}
     spec_by_id = {s["node_id"]: s for s in node_specs}
     for s in node_specs:
-        if s["role"] not in ("RESISTOR", "SERIES"):
+        if not spec_has_series_role(s):
             continue
         child_id = s["node_id"]
         for parent_id, parent in spec_by_id.items():
@@ -313,7 +315,7 @@ def _orient_loop_series_ports(
         loop_children[parent_id].append(child_id)
 
     for s in node_specs:
-        if s["role"] not in ("RESISTOR", "SERIES"):
+        if not spec_has_series_role(s):
             continue
         nid = s["node_id"]
         if nid not in loop_parent:
@@ -342,7 +344,7 @@ def _orient_loop_series_ports(
         ] + other_ports
 
     for s in node_specs:
-        if s["role"] not in ("RESISTOR", "SERIES"):
+        if not spec_has_series_role(s):
             continue
         nid = s["node_id"]
         children = loop_children.get(nid)
@@ -437,7 +439,7 @@ def _push_passive_load_columns(
 ) -> None:
     """Loads on a single-channel passive's N net sit one column right of the bridge."""
     for s in node_specs:
-        if s["role"] not in ("RESISTOR", "SERIES"):
+        if not spec_has_series_role(s):
             continue
         nid = s["node_id"]
         if nid in loop_parent:
@@ -480,12 +482,13 @@ def _propagation_edges(
     for s in node_specs:
         nid = s["node_id"]
         for pname, side, _ in s["port_defs"]:
-            if not is_output_port(s["role"], pname, side):
+            port_role = spec_port_role(s, pname)
+            if not is_output_port(port_role, pname, side):
                 continue
             term = (s["terms"] or {}).get(pname)
             if is_ideal_return(term):
                 continue
-            flow_net = _column_net(s["role"], term, net_to_rail, terminal=pname)
+            flow_net = _column_net(port_role, term, net_to_rail, terminal=pname)
             if not flow_net or flow_net == GND_NET:
                 continue
             for other in inputs_by_net.get(flow_net, []):
@@ -568,14 +571,15 @@ def assign_columns(
             term = (s["terms"] or {}).get(pname)
             if is_ideal_return(term):
                 continue
-            flow_net = _column_net(s["role"], term, net_to_rail, terminal=pname)
+            port_role = spec_port_role(s, pname)
+            flow_net = _column_net(port_role, term, net_to_rail, terminal=pname)
             if not flow_net or flow_net == GND_NET:
                 continue
-            if is_output_port(s["role"], pname, side):
+            if is_output_port(port_role, pname, side):
                 outputs_by_net[flow_net].append(nid)
             else:
                 inputs_by_net[flow_net].append(nid)
-            if not is_output_port(s["role"], pname, side):
+            if not is_output_port(port_role, pname, side):
                 cn = canonical_net(terminal_net(term), net_to_rail)
                 if cn and cn != GND_NET:
                     inputs_by_canonical[cn].append(nid)
@@ -595,12 +599,13 @@ def assign_columns(
             nid = s["node_id"]
             base = col.get(nid, 0)
             for pname, side, _ in s["port_defs"]:
-                if not is_output_port(s["role"], pname, side):
+                port_role = spec_port_role(s, pname)
+                if not is_output_port(port_role, pname, side):
                     continue
                 term = (s["terms"] or {}).get(pname)
                 if is_ideal_return(term):
                     continue
-                flow_net = _column_net(s["role"], term, net_to_rail, terminal=pname)
+                flow_net = _column_net(port_role, term, net_to_rail, terminal=pname)
                 if not flow_net or flow_net == GND_NET:
                     continue
                 for other in inputs_by_net.get(flow_net, []):
@@ -624,7 +629,7 @@ def assign_columns(
         col[child_id] = col.get(parent_id, 0) + 1
 
     for s in node_specs:
-        if s["role"] not in ("RESISTOR", "SERIES"):
+        if not spec_has_series_role(s):
             continue
         nid = s["node_id"]
         if nid in loop_parent:
@@ -634,7 +639,7 @@ def assign_columns(
             col[nid] = min(col.get(nid, 0), max(upstream_cols) + 1)
 
     for s in node_specs:
-        if s["role"] not in ("RESISTOR", "SERIES"):
+        if not spec_has_series_role(s):
             continue
         _apply_passive_column_col(
             s,
@@ -648,7 +653,7 @@ def assign_columns(
     # Parallel taps on the P-side rail sit to the right of the bridge (not
     # downstream loads on the N-side nets).
     for s in node_specs:
-        if s["role"] not in ("RESISTOR", "SERIES"):
+        if not spec_has_series_role(s):
             continue
         nid = s["node_id"]
         rcol = col.get(nid, 0)
@@ -689,12 +694,13 @@ def assign_columns(
             nid = s["node_id"]
             base = col.get(nid, 0)
             for pname, side, _ in s["port_defs"]:
-                if not is_output_port(s["role"], pname, side):
+                port_role = spec_port_role(s, pname)
+                if not is_output_port(port_role, pname, side):
                     continue
                 term = (s["terms"] or {}).get(pname)
                 if is_ideal_return(term):
                     continue
-                flow_net = _column_net(s["role"], term, net_to_rail, terminal=pname)
+                flow_net = _column_net(port_role, term, net_to_rail, terminal=pname)
                 if not flow_net or flow_net == GND_NET:
                     continue
                 for other in inputs_by_net.get(flow_net, []):
@@ -713,7 +719,7 @@ def assign_columns(
         col[child_id] = col.get(parent_id, 0) + 1
 
     for s in node_specs:
-        if s["role"] not in ("RESISTOR", "SERIES"):
+        if not spec_has_series_role(s):
             continue
         _apply_passive_column_col(
             s,
@@ -752,7 +758,7 @@ def assign_columns(
     _orient_loop_series_ports(node_specs, col, loop_parent, outputs_by_net, inputs_by_net)
 
     for s in node_specs:
-        if s["role"] not in ("RESISTOR", "SERIES"):
+        if not spec_has_series_role(s):
             continue
         nid = s["node_id"]
         if nid in loop_parent:

--- a/fypa/topology/metadata/specs.py
+++ b/fypa/topology/metadata/specs.py
@@ -23,9 +23,130 @@ from fypa.topology.metadata_schema import (
     JumpRowDict,
     NodeSpec,
     PortDef,
+    RoleSection,
     TerminalDict,
 )
 from fypa.topology.terminal_roles import is_output_port
+
+
+_SECTION_SORT_STRIDE = 100
+
+_ROLE_SECTION_ORDER: dict[str, int] = {
+    "SOURCE": 0,
+    "REGULATOR": 1,
+    "SERIES": 2,
+    "RESISTOR": 2,
+    "SINK": 3,
+}
+
+
+def spec_port_role(spec: NodeSpec, pname: str) -> str:
+    """Effective role for one port — per-port on multi-role symbols."""
+    port_roles = spec.get("port_roles")
+    if port_roles and pname in port_roles:
+        return port_roles[pname]
+    return spec["role"]
+
+
+def spec_has_series_role(spec: NodeSpec) -> bool:
+    """True when the component carries a SERIES / RESISTOR role block."""
+    if spec["role"] in ("RESISTOR", "SERIES"):
+        return True
+    sections = spec.get("sections")
+    return bool(
+        sections
+        and any(sec["role"] in ("RESISTOR", "SERIES") for sec in sections)
+    )
+
+
+def _role_section_sort_key(role: str) -> tuple[int, str]:
+    return (_ROLE_SECTION_ORDER.get(role, 9), role)
+
+
+def _section_sort_key(spec: NodeSpec) -> tuple:
+    """Order stacked sections by PDN channel index (PDN1, PDN2, …)."""
+    indices = [
+        int(d["channel_index"])
+        for d in spec["directives"]
+        if d.get("channel_index") is not None
+    ]
+    if indices:
+        return (0, min(indices))
+    return (1, _role_section_sort_key(spec["role"]))
+
+
+def _merge_specs_for_designator(designator: str, specs: list[NodeSpec]) -> NodeSpec:
+    """Stack multiple role blocks into one composite symbol."""
+    ordered = sorted(specs, key=_section_sort_key)
+    sections: list[RoleSection] = []
+    port_defs: list[PortDef] = []
+    terms: dict[str, TerminalDict] = {}
+    port_directives: dict[str, DirectiveDict] = {}
+    port_roles: dict[str, str] = {}
+    directives: list[DirectiveDict] = []
+    has_error = False
+    tooltip_parts: list[str] = []
+
+    used_names: set[str] = set()
+    for sec_i, s in enumerate(ordered):
+        sec: RoleSection = {
+            "role": s["role"],
+            "port_defs": list(s["port_defs"]),
+            "terms": dict(s["terms"]),
+            "port_directives": dict(s["port_directives"]),
+            "directives": list(s["directives"]),
+        }
+        sections.append(sec)
+        has_error = has_error or s["has_error"]
+        display_role = "SERIES" if s["role"] in ("RESISTOR", "SERIES") else s["role"]
+        tooltip_parts.append(f"{display_role} {designator}")
+        for line in component_tooltip(s["role"], designator, s["directives"]).splitlines()[1:]:
+            if line:
+                tooltip_parts.append(line)
+        offset = sec_i * _SECTION_SORT_STRIDE
+        rename_map: dict[str, str] = {}
+        for pname, side, sk in s["port_defs"]:
+            out_pname = pname
+            d = s["port_directives"].get(pname)
+            ch_idx = d.get("channel_index") if d else None
+            if ch_idx is not None:
+                base = _base_terminal_name(pname)
+                out_pname = _suffix_for_channel(int(ch_idx), multi=True, base=base)
+            if out_pname in used_names:
+                base = _base_terminal_name(out_pname)
+                suffix = int(ch_idx) if ch_idx is not None else sec_i + 1
+                out_pname = _suffix_for_channel(suffix, multi=True, base=base)
+            rename_map[pname] = out_pname
+            used_names.add(out_pname)
+        sec_port_defs: list[PortDef] = []
+        for pname, side, sk in s["port_defs"]:
+            out_pname = rename_map[pname]
+            sec_port_defs.append((out_pname, side, sk))
+            port_roles[out_pname] = s["role"]
+            port_defs.append((out_pname, side, offset + sk))
+            terms[out_pname] = s["terms"][pname]
+            if pname in s["port_directives"]:
+                port_directives[out_pname] = s["port_directives"][pname]
+        sec["port_defs"] = sec_port_defs
+        directives.extend(s["directives"])
+
+    primary = ordered[0]
+    return {
+        "node_id": designator,
+        "label": designator,
+        "designator": designator,
+        "role": primary["role"],
+        "config_label": "",
+        "has_error": has_error,
+        "terms": terms,
+        "port_defs": port_defs,
+        "port_directives": port_directives,
+        "port_roles": port_roles,
+        "sections": sections,
+        "tooltip": "\n".join(tooltip_parts),
+        "directive": primary["directive"],
+        "directives": directives,
+    }
 
 
 def natural_sort_key(label: str) -> tuple:
@@ -375,9 +496,9 @@ def directives_to_component_specs(
         role = str(d.get("role", ""))
         groups[(desig, role)].append(d)
 
-    specs: list[NodeSpec] = []
+    by_designator: dict[str, list[NodeSpec]] = defaultdict(list)
     for desig, role in sorted(groups.keys(), key=lambda k: natural_sort_key(k[0])):
-        specs.append(
+        by_designator[desig].append(
             component_spec_from_directives(
                 desig,
                 role,
@@ -386,6 +507,14 @@ def directives_to_component_specs(
                 net_to_rail,
             )
         )
+
+    specs: list[NodeSpec] = []
+    for desig in sorted(by_designator.keys(), key=natural_sort_key):
+        role_specs = by_designator[desig]
+        if len(role_specs) == 1:
+            specs.append(role_specs[0])
+        else:
+            specs.append(_merge_specs_for_designator(desig, role_specs))
     return specs
 
 
@@ -399,7 +528,7 @@ def driven_power_nets(
             term = (s["terms"] or {}).get(pname)
             if is_ideal_return(term):
                 continue
-            if not is_output_port(s["role"], pname, side):
+            if not is_output_port(spec_port_role(s, pname), pname, side):
                 continue
             cnet = canonical_net(terminal_net(term), net_to_rail)
             if cnet and cnet != GND_NET:

--- a/fypa/topology/metadata_schema.py
+++ b/fypa/topology/metadata_schema.py
@@ -56,6 +56,14 @@ class ResolvedPortDict(TypedDict):
 # ``port_defs`` entries: (terminal name, left/right side, sort key).
 PortDef = tuple[str, str, int]
 
+# One role block inside a multi-role component symbol.
+class RoleSection(TypedDict):
+    role: str
+    port_defs: list[PortDef]
+    terms: dict[str, TerminalDict]
+    port_directives: dict[str, DirectiveDict]
+    directives: list[DirectiveDict]
+
 
 class NodeSpec(TypedDict):
     """One placed component derived from directive metadata."""
@@ -73,6 +81,8 @@ class NodeSpec(TypedDict):
     directive: DirectiveDict
     directives: list[DirectiveDict]
     resolved_ports: NotRequired[dict[str, ResolvedPort]]
+    sections: NotRequired[list[RoleSection]]
+    port_roles: NotRequired[dict[str, str]]
 
 
 class TopologyMetadata(TypedDict, total=False):

--- a/fypa/topology/render.py
+++ b/fypa/topology/render.py
@@ -247,6 +247,55 @@ def _draw_gnd_symbol(
     )
 
 
+def _role_display_title(role: str) -> str:
+    return "SERIES" if role in ("RESISTOR", "SERIES") else role
+
+
+def _role_color(role: str, *, single_net: bool, fg: str) -> str:
+    if single_net:
+        return SINGLE_NET_ROLE_COLORS.get(role, ROLE_COLORS.get(role, fg))
+    return ROLE_COLORS.get(role, fg)
+
+
+def _draw_section_header(
+    parts: list[str],
+    *,
+    x: float,
+    y: float,
+    w: float,
+    role: str,
+    label: str | None,
+    color: str,
+    round_top: bool,
+) -> None:
+    """Draw one role band inside a composite symbol — square bottom, optional rounded top."""
+    if round_top:
+        parts.append(
+            f'<rect x="{x:.1f}" y="{y:.1f}" width="{w:.1f}" height="{HEADER_H:.1f}"'
+            f' rx="6" fill="{esc(color)}"/>'
+        )
+        parts.append(
+            f'<rect x="{x:.1f}" y="{y + HEADER_H - 6:.1f}" width="{w:.1f}"'
+            f' height="6" fill="{esc(color)}"/>'
+        )
+    else:
+        parts.append(
+            f'<rect x="{x:.1f}" y="{y:.1f}" width="{w:.1f}" height="{HEADER_H:.1f}"'
+            f' fill="{esc(color)}"/>'
+        )
+    parts.append(
+        f'<text x="{x + 8:.1f}" y="{y + 15:.1f}" fill="#ffffff"'
+        f' font-family="Segoe UI,sans-serif" font-size="10" font-weight="600">'
+        f"{esc(_role_display_title(role))}</text>"
+    )
+    if label:
+        parts.append(
+            f'<text x="{x + w - 8:.1f}" y="{y + 15:.1f}" fill="#ffffff"'
+            f' text-anchor="end" font-family="Segoe UI,sans-serif"'
+            f' font-size="10" font-weight="600">{esc(label)}</text>'
+        )
+
+
 def _draw_node(
     parts: list[str],
     node: TopologyNode,
@@ -258,11 +307,6 @@ def _draw_node(
     border: str,
     err: str,
 ) -> None:
-    color = ROLE_COLORS.get(node.role, fg)
-    if node.single_net:
-        color = SINGLE_NET_ROLE_COLORS.get(node.role, color)
-    title = "SERIES" if node.role in ("RESISTOR", "SERIES") else node.role
-
     x, y, w, h = node.x, node.y, node.width, node.height
     stroke = err if node.has_error else border
     sw = 1.0
@@ -273,6 +317,49 @@ def _draw_node(
         f' rx="6" fill="{esc(bg_alt)}" stroke="{esc(stroke)}"'
         f' stroke-width="{sw}"/>'
     )
+
+    if node.sections:
+        for i, sec in enumerate(node.sections):
+            sec_color = _role_color(sec.role, single_net=False, fg=fg)
+            _draw_section_header(
+                parts,
+                x=x,
+                y=y + sec.y,
+                w=w,
+                role=sec.role,
+                label=node.label if i == 0 else None,
+                color=sec_color,
+                round_top=(i == 0),
+            )
+        if node.has_error:
+            parts.append(
+                f'<text x="{x + w - 6:.1f}" y="{y + h - 6:.1f}" text-anchor="end"'
+                f' fill="{esc(err)}" font-size="12">⚠</text>'
+            )
+        port_colors = {
+            sec.role: _role_color(sec.role, single_net=False, fg=fg)
+            for sec in node.sections
+        }
+        for port in node.ports:
+            px, py = port.x, port.y
+            color = port_colors.get(port.role or node.role, fg)
+            parts.append(
+                f'<circle cx="{px:.1f}" cy="{py:.1f}" r="{PORT_R:.1f}"'
+                f' fill="{esc(color)}" stroke="{esc(border)}" stroke-width="1"/>'
+            )
+            text_x = px + 8.0 if port.side == "left" else px - 8.0
+            anchor = "start" if port.side == "left" else "end"
+            line = truncate_label(port.label)
+            parts.append(
+                f'<text x="{text_x:.1f}" y="{py + 3:.1f}" text-anchor="{anchor}"'
+                f' fill="{esc(fg_dim)}" font-family="Consolas,monospace"'
+                f' font-size="8">{esc(line)}</text>'
+            )
+        return
+
+    color = _role_color(node.role, single_net=node.single_net, fg=fg)
+    title = _role_display_title(node.role)
+
     parts.append(
         f'<rect x="{x:.1f}" y="{y:.1f}" width="{w:.1f}" height="{HEADER_H:.1f}"'
         f' rx="6" fill="{esc(color)}"/>'

--- a/fypa/topology/types.py
+++ b/fypa/topology/types.py
@@ -8,6 +8,14 @@ from fypa.topology.metadata_schema import JumpRowDict
 
 
 @dataclass
+class NodeSection:
+    """One stacked role block inside a multi-role topology symbol."""
+    role: str
+    y: float
+    height: float
+
+
+@dataclass
 class TopologyPort:
     terminal: str
     net: str
@@ -21,6 +29,7 @@ class TopologyPort:
     tooltip: str = ""
     stub_length: float = 0.0
     wire_x: float | None = None
+    role: str = ""
 
 
 @dataclass
@@ -40,6 +49,7 @@ class TopologyNode:
     ports: list[TopologyPort] = field(default_factory=list)
     bounds: tuple[float, float, float, float] = (0, 0, 0, 0)
     jump_row: JumpRowDict | None = None
+    sections: list[NodeSection] = field(default_factory=list)
 
 
 @dataclass

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1747,6 +1747,147 @@ def test_series_channel_on_mixed_part_registers_bridge():
     assert groups.get("+5V") == frozenset({"+5V", "5V_SW"})
 
 
+def test_indexed_roles_only_mixed_series_and_sink():
+    # SERIES on the input path plus SINK on a separate IC supply — no
+    # part-wide PDN_ROLE required.
+    proj = _minimal_proj(
+        nets=(
+            RawNet("GND"), RawNet("VIN"), RawNet("VOUT"), RawNet("VCC"),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="U2", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN1_ROLE": "SERIES",
+                    "PDN1_R": "7m",
+                    "PDN1_P_NET": "VIN",
+                    "PDN1_N_NET": "VOUT",
+                    "PDN2_ROLE": "SINK",
+                    "PDN2_I": "10mA",
+                    "PDN2_P_NET": "VCC",
+                    "PDN2_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U2", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U2",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1, 0),   # VIN
+            _pad(0, "2", 2, 1),   # VOUT
+            _pad(0, "3", 3, 2),   # VCC
+            _pad(0, "4", 0, 3),   # GND
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    series = [d for d in result.directives if isinstance(d, ResistorSpec)]
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(series) == 1
+    assert len(sinks) == 1
+    assert series[0].channel_index == 1
+    assert sinks[0].channel_index == 2
+    assert series[0].resistance == pytest.approx(0.007)
+    assert sinks[0].current == pytest.approx(0.01)
+
+
+def test_indexed_roles_only_bridge_group_registers():
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("VIN"), RawNet("VOUT"), RawNet("VCC")),
+        sch_components=(
+            RawSchComponent(
+                designator="U2", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN1_ROLE": "SERIES",
+                    "PDN1_R": "7m",
+                    "PDN1_P_NET": "VIN",
+                    "PDN1_N_NET": "VOUT",
+                    "PDN2_ROLE": "SINK",
+                    "PDN2_I": "10mA",
+                    "PDN2_P_NET": "VCC",
+                    "PDN2_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U2", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U2",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1, 0),
+            _pad(0, "2", 2, 1),
+            _pad(0, "3", 3, 2),
+            _pad(0, "4", 0, 3),
+        ),
+    )
+    groups = _collect_bridge_groups(_iter_pdn_parameter_sources(proj), proj)
+    assert groups.get("VIN") == frozenset({"VIN", "VOUT"})
+
+
+def test_indexed_roles_channel_without_role_errors():
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+3V3"), RawNet("OUT")),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="M.SchDoc",
+                parameters={
+                    "PDN1_ROLE": "SINK",
+                    "PDN1_I": "10mA", "PDN1_P_NET": "+3V3", "PDN1_N_NET": "GND",
+                    "PDN2_I": "5mA", "PDN2_P_NET": "OUT", "PDN2_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+            ),
+        ),
+        pads=(_pad(0, "1", 1, 0), _pad(0, "2", 0, 1), _pad(0, "3", 2, 2)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert not result.ok
+    assert any(
+        "PDN2_ROLE" in e and "no part-wide PDN_ROLE" in e
+        for e in result.errors
+    )
+
+
+def test_stray_pdn_params_without_any_role_warns():
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+3V3")),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="M.SchDoc",
+                parameters={
+                    "PDN_I": "10mA",
+                    "PDN_P_NET": "+3V3",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="R", source_designator="U1",
+            ),
+        ),
+        pads=(_pad(0, "1", 1, 0), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert not result.directives
+    assert any("no PDN_ROLE or PDN<n>_ROLE" in w for w in result.warnings)
+
+
 # --- is_solveable: annotation errors are non-fatal ----------------------------
 
 def test_is_solveable_skips_bad_directive_and_solves_the_rest():

--- a/tests/test_metadata_specs.py
+++ b/tests/test_metadata_specs.py
@@ -119,3 +119,65 @@ def test_passive_merge_p_when_shared_pad():
     assert pnames == ["P"]
     n_names = [p[0] for p in specs[0]["port_defs"] if p[0].startswith("N")]
     assert len(n_names) == 2
+
+
+def test_multi_role_same_designator_merges_into_one_spec():
+    """SERIES + SINK on one part → one stacked symbol, not two overlapping nodes."""
+    directives = [
+        {
+            "role": "SERIES",
+            "designator": "U2",
+            "channel_index": 1,
+            "terminals": {
+                "P": {"pins": [{"net": "VIN", "pad": "1"}]},
+                "N": {"pins": [{"net": "VOUT", "pad": "2"}]},
+            },
+        },
+        {
+            "role": "SINK",
+            "designator": "U2",
+            "channel_index": 2,
+            "terminals": {
+                "P": {"pins": [{"net": "VCC", "pad": "3"}]},
+                "N": {"pins": [{"net": "GND", "pad": "4"}]},
+            },
+        },
+    ]
+    specs = directives_to_component_specs(directives, [], {})
+    assert len(specs) == 1
+    spec = specs[0]
+    assert spec["node_id"] == "U2"
+    sections = spec.get("sections")
+    assert sections is not None
+    assert len(sections) == 2
+    assert sections[0]["role"] in ("SERIES", "RESISTOR")
+    assert sections[1]["role"] == "SINK"
+    assert spec["port_roles"]["P1"] in ("SERIES", "RESISTOR")
+    assert spec["port_roles"]["P2"] == "SINK"
+
+
+def test_multi_role_sections_sorted_by_channel_index():
+    directives = [
+        {
+            "role": "SINK",
+            "designator": "U2",
+            "channel_index": 2,
+            "terminals": {
+                "P": {"pins": [{"net": "VCC", "pad": "3"}]},
+                "N": {"pins": [{"net": "GND", "pad": "4"}]},
+            },
+        },
+        {
+            "role": "SERIES",
+            "designator": "U2",
+            "channel_index": 1,
+            "terminals": {
+                "P": {"pins": [{"net": "VIN", "pad": "1"}]},
+                "N": {"pins": [{"net": "VOUT", "pad": "2"}]},
+            },
+        },
+    ]
+    specs = directives_to_component_specs(directives, [], {})
+    sections = specs[0]["sections"]
+    assert sections[0]["role"] in ("SERIES", "RESISTOR")
+    assert sections[1]["role"] == "SINK"


### PR DESCRIPTION
## Summary

- **PDN roles:** `PDN_ROLE` is optional when every channel declares its own `PDN<n>_ROLE` (e.g. VIP e-fuse U2 with only `PDN1_ROLE` / `PDN2_ROLE`).
- **Topology:** Multiple roles on the same designator (e.g. SERIES + SINK) render as a **single stacked symbol** instead of overlapping duplicate nodes.