### PR TITLE
mixed role sink column

### DIFF
--- a/fypa/topology/metadata/layout_bridge.py
+++ b/fypa/topology/metadata/layout_bridge.py
@@ -447,7 +447,10 @@ def _push_passive_load_columns(
         n_terms = [
             pname
             for pname, term in (s.get("terms") or {}).items()
-            if pname.startswith("N") and term and not is_ideal_return(term)
+            if pname.startswith("N")
+            and term
+            and not is_ideal_return(term)
+            and _port_role_for_column(s, pname) in ("RESISTOR", "SERIES")
         ]
         if len(n_terms) != 1:
             continue
@@ -541,6 +544,28 @@ def _detect_propagation_back_edges(
     return back
 
 
+def _port_role_for_column(spec: NodeSpec, pname: str) -> str:
+    """Per-port role when a composite symbol carries port_roles."""
+    port_roles = spec.get("port_roles")
+    if port_roles and pname in port_roles:
+        return port_roles[pname]
+    return spec["role"]
+
+
+def _mixed_role_node_ids(node_specs: list[NodeSpec]) -> set[str]:
+    """Designators that carry more than one PDN role (e.g. SERIES + SINK)."""
+    roles_by_id: dict[str, set[str]] = defaultdict(set)
+    for spec in node_specs:
+        nid = spec["node_id"]
+        sections = spec.get("sections")
+        if sections:
+            roles_by_id[nid].update(sec["role"] for sec in sections)
+        else:
+            roles_by_id[nid].add(spec["role"])
+        roles_by_id[nid].update((spec.get("port_roles") or {}).values())
+    return {nid for nid, rs in roles_by_id.items() if len(rs) > 1}
+
+
 def assign_columns(
     node_specs: list[NodeSpec],
     net_to_rail: dict[str, str],
@@ -548,6 +573,7 @@ def assign_columns(
     """Place nodes in columns by propagating from SOURCE outputs along nets."""
     col: dict[str, int] = {}
     role_by_id = {s["node_id"]: s["role"] for s in node_specs}
+    mixed_role_ids = _mixed_role_node_ids(node_specs)
 
     sources = [s for s in node_specs if s["role"] in ("SOURCE",)]
     for s in node_specs:
@@ -734,7 +760,7 @@ def assign_columns(
     if col:
         sink_col = max(col.values())
         for s in node_specs:
-            if s["role"] == "SINK":
+            if s["role"] == "SINK" and s["node_id"] not in mixed_role_ids:
                 col[s["node_id"]] = sink_col
 
     # Orient each SERIES/RESISTOR so the terminal carrying the downstream loads

--- a/tests/test_topology_layout.py
+++ b/tests/test_topology_layout.py
@@ -133,17 +133,104 @@ def test_probe_project_a_stays_compact() -> None:
 
 
 def test_all_sinks_share_rightmost_column():
-    """SINK symbols align in the last column even when propagation stops early."""
-    from fypa.topology.metadata.layout_bridge import parse_topology_directives, specs_by_column
+    """Pure SINK symbols align in the last column even when propagation stops early."""
+    from fypa.topology.metadata.layout_bridge import (
+        _mixed_role_node_ids,
+        parse_topology_directives,
+        specs_by_column,
+    )
 
     parsed = parse_topology_directives(load_topology_fixture("project_b_hub_vdd"))
     _, max_col = specs_by_column(parsed.node_specs, parsed.columns)
+    mixed = _mixed_role_node_ids(parsed.node_specs)
     sink_cols = {
         parsed.columns[s["node_id"]]
         for s in parsed.node_specs
-        if s["role"] == "SINK"
+        if s["role"] == "SINK" and s["node_id"] not in mixed
     }
     assert sink_cols == {max_col}
+
+
+def test_mixed_role_series_sink_keeps_bridge_before_pure_sink():
+    """SERIES+SINK on one part: bridge column from propagation, not sink push."""
+    from fypa.topology.metadata.layout_bridge import parse_topology_directives, specs_by_column
+
+    metadata = {
+        "annotation_errors": [],
+        "net_canonical": {},
+        "directives": [
+            {
+                "role": "SOURCE",
+                "designator": "J1",
+                "label": "J1",
+                "value_str": "12 V",
+                "terminals": {
+                    "P": {
+                        "requested_net": "+12V",
+                        "pins": [{"net": "+12V", "pad": "1"}],
+                    },
+                    "N": {
+                        "requested_net": "GND",
+                        "pins": [{"net": "GND", "pad": "2"}],
+                    },
+                },
+            },
+            {
+                "role": "RESISTOR",
+                "designator": "U1",
+                "label": "U1",
+                "value_str": "0 mOhm",
+                "terminals": {
+                    "P": {
+                        "requested_net": "+12V",
+                        "pins": [{"net": "+12V", "pad": "1"}],
+                    },
+                    "N": {
+                        "requested_net": "+5V",
+                        "pins": [{"net": "+5V", "pad": "2"}],
+                    },
+                },
+            },
+            {
+                "role": "SINK",
+                "designator": "U1",
+                "label": "U1#1",
+                "channel_index": 1,
+                "value_str": "10 mA",
+                "terminals": {
+                    "P": {
+                        "requested_net": "SENSE",
+                        "pins": [{"net": "SENSE", "pad": "3"}],
+                    },
+                    "N": {
+                        "requested_net": "GND",
+                        "pins": [{"net": "GND", "pad": "4"}],
+                    },
+                },
+            },
+            {
+                "role": "SINK",
+                "designator": "J2",
+                "label": "J2",
+                "value_str": "100 mA",
+                "terminals": {
+                    "P": {
+                        "requested_net": "+5V",
+                        "pins": [{"net": "+5V", "pad": "1"}],
+                    },
+                    "N": {
+                        "requested_net": "GND",
+                        "pins": [{"net": "GND", "pad": "2"}],
+                    },
+                },
+            },
+        ],
+    }
+    parsed = parse_topology_directives(metadata)
+    cols = parsed.columns
+    _, max_col = specs_by_column(parsed.node_specs, cols)
+    assert cols["U1"] < cols["J2"]
+    assert cols["J2"] == max_col
 
 
 def test_hub_wires_no_horizontal_backtrack_on_probe() -> None:


### PR DESCRIPTION
## Motivation

For mixed role symbols having a SINK role it's not to good to force placing them in the last column.

## Summary

- Pure SINK symbols still align in the rightmost column; multi-role parts (e.g. SERIES+SINK on one designator) keep their propagated column.
- Detection covers split specs and composite symbols (`sections` / `port_roles`).
- SERIES N-net load push ignores auxiliary SINK return ports on the same symbol.
