### PR TITLE
multilayer copper with net

### DIFF
--- a/fypa/altium/loader.py
+++ b/fypa/altium/loader.py
@@ -46,7 +46,9 @@ from fypa.altium.extract import (
 import dataclasses
 from fypa.altium_geometry import (
     GeometryLayer,
+    _is_multilayer_copper,
     _pad_outer_shape,
+    _plane_layer_ids,
     build_layer_geometries,
     build_per_net_geometry_layers_split,
 )
@@ -1290,6 +1292,22 @@ def _build_stub_record(piece, layer_id: int, net_name: str) -> dict | None:
     return record
 
 
+def _primitive_visible_layer_ids(
+    prim_layer_id: int,
+    net_index: int,
+    enabled: list[int],
+    plane_layer_ids: set[int],
+) -> list[int]:
+    """Physical copper layer ids a primitive is selectable on in the viewer.
+
+    Multilayer (layer 74) primitives with an assigned net fan out to every
+    enabled signal layer, matching :func:`fypa.altium_geometry._distribute_to_layers`.
+    """
+    if _is_multilayer_copper(prim_layer_id, net_index):
+        return [lid for lid in enabled if lid not in plane_layer_ids]
+    return [int(prim_layer_id)]
+
+
 def _build_all_copper_records(
     per_net_layers: list[GeometryLayer] | None,
     net_name_fn,
@@ -2170,15 +2188,17 @@ def build_solve_metadata(
     # Artwork on a negative internal-plane layer (boundary / split lines) is not
     # copper — it's excluded from the rendered geometry (altium_geometry), so
     # skip it here too, leaving only the selectable plane sheet emitted below.
-    _plane_layer_ids = {s.layer_id for s in proj.stackup if s.is_plane}
+    plane_layer_ids = _plane_layer_ids(proj)
     for i, t in enumerate(proj.tracks):
         _gil_yield(i)
-        if int(t.layer_id) in _plane_layer_ids:
+        if int(t.layer_id) in plane_layer_ids:
             continue
         primitives["tracks"].append({
             "id": len(primitives["tracks"]),
             "kind": "track",
             "layer_id": int(t.layer_id),
+            "layer_ids": _primitive_visible_layer_ids(
+                t.layer_id, t.net_index, enabled, plane_layer_ids),
             "net": _net_name(t.net_index),
             "ax": float(t.a.x), "ay": float(t.a.y),
             "bx": float(t.b.x), "by": float(t.b.y),
@@ -2188,12 +2208,14 @@ def build_solve_metadata(
         })
     for i, a in enumerate(proj.arcs):
         _gil_yield(i)
-        if int(a.layer_id) in _plane_layer_ids:
+        if int(a.layer_id) in plane_layer_ids:
             continue
         primitives["arcs"].append({
             "id": len(primitives["arcs"]),
             "kind": "arc",
             "layer_id": int(a.layer_id),
+            "layer_ids": _primitive_visible_layer_ids(
+                a.layer_id, a.net_index, enabled, plane_layer_ids),
             "net": _net_name(a.net_index),
             "cx": float(a.center.x), "cy": float(a.center.y),
             "radius_mm": float(a.radius_mm),
@@ -2204,12 +2226,14 @@ def build_solve_metadata(
         })
     for i, rg in enumerate(proj.regions):
         _gil_yield(i)
-        if int(rg.layer_id) in _plane_layer_ids:
+        if int(rg.layer_id) in plane_layer_ids:
             continue
         primitives["regions"].append({
             "id": len(primitives["regions"]),
             "kind": "region",
             "layer_id": int(rg.layer_id),
+            "layer_ids": _primitive_visible_layer_ids(
+                rg.layer_id, rg.net_index, enabled, plane_layer_ids),
             "net": _net_name(rg.net_index),
             "outline": [[float(p.x), float(p.y)] for p in rg.outline],
             "holes": [[[float(p.x), float(p.y)] for p in h]
@@ -2226,7 +2250,7 @@ def build_solve_metadata(
     # the properties panel.
     for i, rg in enumerate(proj.shape_based_regions):
         _gil_yield(i)
-        if int(rg.layer_id) in _plane_layer_ids:
+        if int(rg.layer_id) in plane_layer_ids:
             continue
         pts: list[list[float]] = []
         arc_count = 0
@@ -2253,6 +2277,8 @@ def build_solve_metadata(
             "id": len(primitives["shape_based_regions"]),
             "kind": "shape_based_region",
             "layer_id": int(rg.layer_id),
+            "layer_ids": _primitive_visible_layer_ids(
+                rg.layer_id, rg.net_index, enabled, plane_layer_ids),
             "net": _net_name(rg.net_index),
             "outline": pts,
             "holes": [[[float(p.x), float(p.y)] for p in h]
@@ -2266,12 +2292,14 @@ def build_solve_metadata(
         })
     for i, f in enumerate(proj.fills):
         _gil_yield(i)
-        if int(f.layer_id) in _plane_layer_ids:
+        if int(f.layer_id) in plane_layer_ids:
             continue
         primitives["fills"].append({
             "id": len(primitives["fills"]),
             "kind": "fill",
             "layer_id": int(f.layer_id),
+            "layer_ids": _primitive_visible_layer_ids(
+                f.layer_id, f.net_index, enabled, plane_layer_ids),
             "net": _net_name(f.net_index),
             "x1_mm": float(f.x1_mm), "y1_mm": float(f.y1_mm),
             "x2_mm": float(f.x2_mm), "y2_mm": float(f.y2_mm),

--- a/fypa/altium_geometry.py
+++ b/fypa/altium_geometry.py
@@ -16,10 +16,16 @@ Geometry rules
 --------------
 * **Tracks** with ``is_keepout`` or ``is_polygon_outline`` are skipped; the
   remaining tracks are buffered LineStrings of half-width with round caps.
+  Tracks on layer id ``MULTI_LAYER_PAD_LAYER_ID`` (74) with an assigned net
+  appear on every enabled **signal** copper layer; internal planes are
+  excluded. Unassigned (``NO_NET``) ones are omitted.
 * **Arcs** are discretised to a polyline whose chord error is bounded by
-  :data:`ARC_CHORD_TOLERANCE_MM`, then buffered with round caps.
+  :data:`ARC_CHORD_TOLERANCE_MM`, then buffered with round caps. Multi-layer
+  arcs follow the same net-assignment rule as tracks.
 * **Regions** (Altium ``Regions6``) are included when ``kind == 0`` (copper),
-  not a polygon outline, not a keepout, and not a board cutout.
+  not a polygon outline, not a keepout, and not a board cutout. Multi-layer
+  regions and fills with an assigned net appear on every enabled signal copper
+  layer (internal planes excluded).
 * **Pads** on layer id ``MULTI_LAYER_PAD_LAYER_ID`` (74) are through-hole and
   appear on every copper layer; SMT pads appear only on their assigned layer.
   Drill holes are subtracted from the pad shape.
@@ -654,6 +660,38 @@ def _pad_on_layer(p: RawPad, layer_id: int) -> bool:
     return p.layer_id == layer_id
 
 
+def _plane_layer_ids(proj: ExtractedProject) -> set[int]:
+    return {s.layer_id for s in proj.stackup if s.is_plane}
+
+
+def _is_multilayer_copper(layer_id: int, net_index: int) -> bool:
+    return layer_id == MULTI_LAYER_PAD_LAYER_ID and net_index != NO_NET
+
+
+def _copper_primitive_on_layer(prim_layer_id: int, target_layer_id: int,
+                               net_index: int,
+                               plane_layer_ids: set[int] | None = None) -> bool:
+    if _is_multilayer_copper(prim_layer_id, net_index):
+        return not plane_layer_ids or target_layer_id not in plane_layer_ids
+    return prim_layer_id == target_layer_id
+
+
+def _distribute_to_layers(
+    prim_layer_id: int,
+    net_index: int,
+    geom: shapely.geometry.base.BaseGeometry,
+    enabled_layers: list[int],
+    add_fn,
+    plane_layer_ids: set[int],
+) -> None:
+    if _is_multilayer_copper(prim_layer_id, net_index):
+        for lid in enabled_layers:
+            if lid not in plane_layer_ids:
+                add_fn(lid, net_index, geom)
+    else:
+        add_fn(prim_layer_id, net_index, geom)
+
+
 def _via_on_layer(v: RawVia, layer_id: int, enabled: list[int],
                   pos: dict[int, int] | None = None) -> bool:
     """Whether via ``v``'s barrel spans ``layer_id`` in the enabled stack.
@@ -751,6 +789,66 @@ class _ThroughFeatureCache:
         for v, disc in _batch_via_polygons(proj.vias):
             if not disc.is_empty:
                 self.via_feats.append((v, _drop_holes(disc), v.net_index))
+
+
+class _MultilayerCopperCache:
+    """Pre-buffered polygons for layer-74 copper primitives with an assigned net.
+
+    Built once by :func:`build_layer_geometries` and shared across every
+    per-layer call so multilayer tracks / arcs are not re-buffered once per
+    physical layer."""
+
+    __slots__ = ("track_polys", "arc_polys", "region_polys", "sbr_polys",
+                 "fill_polys")
+
+    def __init__(self, proj: ExtractedProject) -> None:
+        ml_tracks = [
+            t for t in proj.tracks
+            if _is_multilayer_copper(t.layer_id, t.net_index)
+            and not t.is_keepout and not t.is_polygon_outline and t.width_mm > 0
+        ]
+        self.track_polys = list(zip(ml_tracks, _batch_buffer_tracks(ml_tracks)))
+
+        ml_arcs = [
+            a for a in proj.arcs
+            if _is_multilayer_copper(a.layer_id, a.net_index)
+            and not a.is_keepout and not a.is_polygon_outline and a.width_mm > 0
+        ]
+        self.arc_polys = list(zip(ml_arcs, _batch_buffer_arcs(ml_arcs)))
+
+        sbr_poly_indices = _shape_based_polygon_indices(proj)
+        self.region_polys: list[tuple[RawRegion, shapely.geometry.base.BaseGeometry]] = []
+        for r in proj.regions:
+            if not _is_multilayer_copper(r.layer_id, r.net_index):
+                continue
+            if (r.is_keepout or r.is_polygon_outline or r.is_board_cutout
+                    or r.kind != 0 or len(r.outline) < 3):
+                continue
+            if _skip_region_as_duplicate(r, sbr_poly_indices):
+                continue
+            poly = _region_polygon(r)
+            if not poly.is_empty:
+                self.region_polys.append((r, poly))
+
+        self.sbr_polys: list[tuple[RawShapeBasedRegion,
+                                    shapely.geometry.base.BaseGeometry]] = []
+        for r in proj.shape_based_regions:
+            if not _is_multilayer_copper(r.layer_id, r.net_index):
+                continue
+            if (r.is_keepout or r.is_polygon_outline or r.is_board_cutout
+                    or r.kind != 0 or len(r.outline) < 3):
+                continue
+            poly = _shape_based_region_polygon(r)
+            if not poly.is_empty:
+                self.sbr_polys.append((r, poly))
+
+        self.fill_polys: list[tuple[RawFill, shapely.geometry.base.BaseGeometry]] = []
+        for f in proj.fills:
+            if not _is_multilayer_copper(f.layer_id, f.net_index) or f.is_keepout:
+                continue
+            poly = _fill_polygon(f)
+            if poly is not None and not poly.is_empty:
+                self.fill_polys.append((f, poly))
 
 
 def _through_features_on_layer(
@@ -960,10 +1058,12 @@ def _plane_sheet_polygon(
 
 def build_layer_geometry(proj: ExtractedProject, layer_id: int,
                          enabled_layers: list[int],
-                         through_cache: _ThroughFeatureCache | None = None
+                         through_cache: _ThroughFeatureCache | None = None,
+                         multilayer_cache: _MultilayerCopperCache | None = None,
                          ) -> GeometryLayer:
     stackup_by_id = {s.layer_id: s for s in proj.stackup}
     stackup = stackup_by_id[layer_id]
+    plane_layers = _plane_layer_ids(proj)
 
     if stackup.is_plane:
         # Planes are negative copper: the board outline (inset by the plane
@@ -995,19 +1095,38 @@ def build_layer_geometry(proj: ExtractedProject, layer_id: int,
     # (The all-nets union below now runs through the Clipper2 fuse seam at the
     # 1 nm lossless scale — see the fuse() call at the end of this function.)
     valid_tracks = [t for t in proj.tracks
-                    if t.layer_id == layer_id and not t.is_keepout
+                    if not _is_multilayer_copper(t.layer_id, t.net_index)
+                    and _copper_primitive_on_layer(
+                        t.layer_id, layer_id, t.net_index, plane_layers)
+                    and not t.is_keepout
                     and not t.is_polygon_outline and t.width_mm > 0]
     pieces.extend(_batch_buffer_tracks(valid_tracks))
 
     valid_arcs = [a for a in proj.arcs
-                  if a.layer_id == layer_id and not a.is_keepout
+                  if not _is_multilayer_copper(a.layer_id, a.net_index)
+                  and _copper_primitive_on_layer(
+                      a.layer_id, layer_id, a.net_index, plane_layers)
+                  and not a.is_keepout
                   and not a.is_polygon_outline
                   and a.width_mm > 0]
     pieces.extend(_batch_buffer_arcs(valid_arcs))
 
+    if multilayer_cache is not None:
+        for t, poly in multilayer_cache.track_polys:
+            if _copper_primitive_on_layer(
+                    t.layer_id, layer_id, t.net_index, plane_layers):
+                pieces.append(poly)
+        for a, poly in multilayer_cache.arc_polys:
+            if _copper_primitive_on_layer(
+                    a.layer_id, layer_id, a.net_index, plane_layers):
+                pieces.append(poly)
+
     sbr_poly_indices = _shape_based_polygon_indices(proj)
     for r in proj.regions:
-        if r.layer_id != layer_id:
+        if _is_multilayer_copper(r.layer_id, r.net_index):
+            continue
+        if not _copper_primitive_on_layer(
+                r.layer_id, layer_id, r.net_index, plane_layers):
             continue
         if r.is_keepout or r.is_polygon_outline or r.is_board_cutout:
             continue
@@ -1020,8 +1139,17 @@ def build_layer_geometry(proj: ExtractedProject, layer_id: int,
             continue
         pieces.append(poly)
 
+    if multilayer_cache is not None:
+        for r, poly in multilayer_cache.region_polys:
+            if _copper_primitive_on_layer(
+                    r.layer_id, layer_id, r.net_index, plane_layers):
+                pieces.append(poly)
+
     for r in proj.shape_based_regions:
-        if r.layer_id != layer_id:
+        if _is_multilayer_copper(r.layer_id, r.net_index):
+            continue
+        if not _copper_primitive_on_layer(
+                r.layer_id, layer_id, r.net_index, plane_layers):
             continue
         if r.is_keepout or r.is_polygon_outline or r.is_board_cutout:
             continue
@@ -1032,12 +1160,29 @@ def build_layer_geometry(proj: ExtractedProject, layer_id: int,
             continue
         pieces.append(poly)
 
+    if multilayer_cache is not None:
+        for r, poly in multilayer_cache.sbr_polys:
+            if _copper_primitive_on_layer(
+                    r.layer_id, layer_id, r.net_index, plane_layers):
+                pieces.append(poly)
+
     for f in proj.fills:
-        if f.layer_id != layer_id or f.is_keepout:
+        if _is_multilayer_copper(f.layer_id, f.net_index):
+            continue
+        if not _copper_primitive_on_layer(
+                f.layer_id, layer_id, f.net_index, plane_layers):
+            continue
+        if f.is_keepout:
             continue
         poly = _fill_polygon(f)
         if poly is not None:
             pieces.append(poly)
+
+    if multilayer_cache is not None:
+        for f, poly in multilayer_cache.fill_polys:
+            if _copper_primitive_on_layer(
+                    f.layer_id, layer_id, f.net_index, plane_layers):
+                pieces.append(poly)
 
     for p in proj.pads:
         if not _pad_on_layer(p, layer_id):
@@ -1098,12 +1243,15 @@ def build_layer_geometries(proj: ExtractedProject) -> list[GeometryLayer]:
         return []
     # Through-feature footprints are layer-independent (see
     # _ThroughFeatureCache): build them ONCE and share across every plane layer
-    # instead of rebuilding all pad/via polygons per plane. Read-only, so safe
-    # to hand to the per-layer thread pool below.
+    # instead of rebuilding all pad/via polygons per plane. Multilayer copper
+    # primitives are pre-buffered once in _MultilayerCopperCache for the same
+    # reason. Read-only, so safe to hand to the per-layer thread pool below.
     through_cache = _ThroughFeatureCache(proj)
+    multilayer_cache = _MultilayerCopperCache(proj)
     # Small boards: thread-pool overhead isn't worth it.
     if len(enabled) < 3:
-        return [build_layer_geometry(proj, lid, enabled, through_cache)
+        return [build_layer_geometry(proj, lid, enabled, through_cache,
+                                     multilayer_cache)
                 for lid in enabled]
 
     # The Clipper2 fuse backend (the default) is GIL-bound — unlike shapely 2's
@@ -1112,7 +1260,8 @@ def build_layer_geometries(proj: ExtractedProject) -> list[GeometryLayer]:
     # the threaded shapely path on large boards (same trade-off as
     # _parallel_union_buckets). The shapely / verify backends keep the pool.
     if _clipper_fuse.backend() == "clipper" and _clipper_fuse.clipper_available():
-        return [build_layer_geometry(proj, lid, enabled, through_cache)
+        return [build_layer_geometry(proj, lid, enabled, through_cache,
+                                     multilayer_cache)
                 for lid in enabled]
 
     import concurrent.futures
@@ -1124,7 +1273,8 @@ def build_layer_geometries(proj: ExtractedProject) -> list[GeometryLayer]:
         # ex.map preserves input order, so the result list lines up with
         # ``enabled`` exactly as the old list comprehension did.
         return list(ex.map(
-            lambda lid: build_layer_geometry(proj, lid, enabled, through_cache),
+            lambda lid: build_layer_geometry(proj, lid, enabled, through_cache,
+                                             multilayer_cache),
             enabled,
         ))
 
@@ -1388,7 +1538,8 @@ def _build_net_layer_buckets(
                     and t.layer_id not in plane_layer_ids]
     track_polys = _batch_buffer_tracks(valid_tracks)
     for t, poly in zip(valid_tracks, track_polys):
-        _add(t.layer_id, t.net_index, poly)
+        _distribute_to_layers(t.layer_id, t.net_index, poly, enabled_layers,
+                              _add, plane_layer_ids)
 
     # Arcs: same vectorised-buffer trick. Exclude polygon-pour *outline* arcs
     # (boundary artwork, not copper) exactly as the track filter above does.
@@ -1398,7 +1549,8 @@ def _build_net_layer_buckets(
                   and a.layer_id not in plane_layer_ids]
     arc_polys = _batch_buffer_arcs(valid_arcs)
     for a, poly in zip(valid_arcs, arc_polys):
-        _add(a.layer_id, a.net_index, poly)
+        _distribute_to_layers(a.layer_id, a.net_index, poly, enabled_layers,
+                              _add, plane_layer_ids)
 
     sbr_poly_indices = _shape_based_polygon_indices(proj)
     for r in proj.regions:
@@ -1408,19 +1560,26 @@ def _build_net_layer_buckets(
             continue
         if _skip_region_as_duplicate(r, sbr_poly_indices):
             continue
-        _add(r.layer_id, r.net_index, _region_polygon(r))
+        poly = _region_polygon(r)
+        _distribute_to_layers(r.layer_id, r.net_index, poly, enabled_layers,
+                              _add, plane_layer_ids)
 
     for r in proj.shape_based_regions:
         if r.is_keepout or r.is_polygon_outline or r.is_board_cutout or r.kind != 0:
             continue
         if len(r.outline) < 3 or r.layer_id in plane_layer_ids:
             continue
-        _add(r.layer_id, r.net_index, _shape_based_region_polygon(r))
+        poly = _shape_based_region_polygon(r)
+        _distribute_to_layers(r.layer_id, r.net_index, poly, enabled_layers,
+                              _add, plane_layer_ids)
 
     for f in proj.fills:
         if f.is_keepout or f.layer_id in plane_layer_ids:
             continue
-        _add(f.layer_id, f.net_index, _fill_polygon(f))
+        poly = _fill_polygon(f)
+        if poly is not None:
+            _distribute_to_layers(f.layer_id, f.net_index, poly, enabled_layers,
+                                  _add, plane_layer_ids)
 
     for p in proj.pads:
         if p.is_through_hole or p.layer_id == MULTI_LAYER_PAD_LAYER_ID:

--- a/fypa/altium_geometry.py
+++ b/fypa/altium_geometry.py
@@ -692,6 +692,44 @@ def _distribute_to_layers(
         add_fn(prim_layer_id, net_index, geom)
 
 
+def _track_is_copper(t: RawTrack, plane_layer_ids: set[int]) -> bool:
+    return (not t.is_keepout and not t.is_polygon_outline and t.width_mm > 0
+            and t.layer_id not in plane_layer_ids)
+
+
+def _arc_is_copper(a: RawArc, plane_layer_ids: set[int]) -> bool:
+    return (not a.is_keepout and not a.is_polygon_outline and a.width_mm > 0
+            and a.layer_id not in plane_layer_ids)
+
+
+def _region_is_copper(
+    r: RawRegion,
+    plane_layer_ids: set[int],
+    sbr_poly_indices: set[int] | None = None,
+) -> bool:
+    if r.is_keepout or r.is_polygon_outline or r.is_board_cutout or r.kind != 0:
+        return False
+    if len(r.outline) < 3 or r.layer_id in plane_layer_ids:
+        return False
+    if sbr_poly_indices is not None and _skip_region_as_duplicate(r, sbr_poly_indices):
+        return False
+    return True
+
+
+def _shape_based_region_is_copper(
+    r: RawShapeBasedRegion, plane_layer_ids: set[int],
+) -> bool:
+    if r.is_keepout or r.is_polygon_outline or r.is_board_cutout or r.kind != 0:
+        return False
+    if len(r.outline) < 3 or r.layer_id in plane_layer_ids:
+        return False
+    return True
+
+
+def _fill_is_copper(f: RawFill, plane_layer_ids: set[int]) -> bool:
+    return not f.is_keepout and f.layer_id not in plane_layer_ids
+
+
 def _via_on_layer(v: RawVia, layer_id: int, enabled: list[int],
                   pos: dict[int, int] | None = None) -> bool:
     """Whether via ``v``'s barrel spans ``layer_id`` in the enabled stack.
@@ -802,17 +840,18 @@ class _MultilayerCopperCache:
                  "fill_polys")
 
     def __init__(self, proj: ExtractedProject) -> None:
+        plane_layer_ids = _plane_layer_ids(proj)
         ml_tracks = [
             t for t in proj.tracks
             if _is_multilayer_copper(t.layer_id, t.net_index)
-            and not t.is_keepout and not t.is_polygon_outline and t.width_mm > 0
+            and _track_is_copper(t, plane_layer_ids)
         ]
         self.track_polys = list(zip(ml_tracks, _batch_buffer_tracks(ml_tracks)))
 
         ml_arcs = [
             a for a in proj.arcs
             if _is_multilayer_copper(a.layer_id, a.net_index)
-            and not a.is_keepout and not a.is_polygon_outline and a.width_mm > 0
+            and _arc_is_copper(a, plane_layer_ids)
         ]
         self.arc_polys = list(zip(ml_arcs, _batch_buffer_arcs(ml_arcs)))
 
@@ -821,10 +860,7 @@ class _MultilayerCopperCache:
         for r in proj.regions:
             if not _is_multilayer_copper(r.layer_id, r.net_index):
                 continue
-            if (r.is_keepout or r.is_polygon_outline or r.is_board_cutout
-                    or r.kind != 0 or len(r.outline) < 3):
-                continue
-            if _skip_region_as_duplicate(r, sbr_poly_indices):
+            if not _region_is_copper(r, plane_layer_ids, sbr_poly_indices):
                 continue
             poly = _region_polygon(r)
             if not poly.is_empty:
@@ -835,8 +871,7 @@ class _MultilayerCopperCache:
         for r in proj.shape_based_regions:
             if not _is_multilayer_copper(r.layer_id, r.net_index):
                 continue
-            if (r.is_keepout or r.is_polygon_outline or r.is_board_cutout
-                    or r.kind != 0 or len(r.outline) < 3):
+            if not _shape_based_region_is_copper(r, plane_layer_ids):
                 continue
             poly = _shape_based_region_polygon(r)
             if not poly.is_empty:
@@ -844,7 +879,9 @@ class _MultilayerCopperCache:
 
         self.fill_polys: list[tuple[RawFill, shapely.geometry.base.BaseGeometry]] = []
         for f in proj.fills:
-            if not _is_multilayer_copper(f.layer_id, f.net_index) or f.is_keepout:
+            if not _is_multilayer_copper(f.layer_id, f.net_index):
+                continue
+            if not _fill_is_copper(f, plane_layer_ids):
                 continue
             poly = _fill_polygon(f)
             if poly is not None and not poly.is_empty:
@@ -1087,6 +1124,8 @@ def build_layer_geometry(proj: ExtractedProject, layer_id: int,
         )
 
     pieces: list[shapely.geometry.base.BaseGeometry] = []
+    if multilayer_cache is None:
+        multilayer_cache = _MultilayerCopperCache(proj)
 
     # Batch the track / arc buffers through one shapely C dispatch each (the
     # same helpers the per-net path uses) instead of a per-primitive
@@ -1098,28 +1137,24 @@ def build_layer_geometry(proj: ExtractedProject, layer_id: int,
                     if not _is_multilayer_copper(t.layer_id, t.net_index)
                     and _copper_primitive_on_layer(
                         t.layer_id, layer_id, t.net_index, plane_layers)
-                    and not t.is_keepout
-                    and not t.is_polygon_outline and t.width_mm > 0]
+                    and _track_is_copper(t, plane_layers)]
     pieces.extend(_batch_buffer_tracks(valid_tracks))
 
     valid_arcs = [a for a in proj.arcs
                   if not _is_multilayer_copper(a.layer_id, a.net_index)
                   and _copper_primitive_on_layer(
                       a.layer_id, layer_id, a.net_index, plane_layers)
-                  and not a.is_keepout
-                  and not a.is_polygon_outline
-                  and a.width_mm > 0]
+                  and _arc_is_copper(a, plane_layers)]
     pieces.extend(_batch_buffer_arcs(valid_arcs))
 
-    if multilayer_cache is not None:
-        for t, poly in multilayer_cache.track_polys:
-            if _copper_primitive_on_layer(
-                    t.layer_id, layer_id, t.net_index, plane_layers):
-                pieces.append(poly)
-        for a, poly in multilayer_cache.arc_polys:
-            if _copper_primitive_on_layer(
-                    a.layer_id, layer_id, a.net_index, plane_layers):
-                pieces.append(poly)
+    for t, poly in multilayer_cache.track_polys:
+        if _copper_primitive_on_layer(
+                t.layer_id, layer_id, t.net_index, plane_layers):
+            pieces.append(poly)
+    for a, poly in multilayer_cache.arc_polys:
+        if _copper_primitive_on_layer(
+                a.layer_id, layer_id, a.net_index, plane_layers):
+            pieces.append(poly)
 
     sbr_poly_indices = _shape_based_polygon_indices(proj)
     for r in proj.regions:
@@ -1128,22 +1163,17 @@ def build_layer_geometry(proj: ExtractedProject, layer_id: int,
         if not _copper_primitive_on_layer(
                 r.layer_id, layer_id, r.net_index, plane_layers):
             continue
-        if r.is_keepout or r.is_polygon_outline or r.is_board_cutout:
-            continue
-        if r.kind != 0 or len(r.outline) < 3:
-            continue
-        if _skip_region_as_duplicate(r, sbr_poly_indices):
+        if not _region_is_copper(r, plane_layers, sbr_poly_indices):
             continue
         poly = _region_polygon(r)
         if poly.is_empty:
             continue
         pieces.append(poly)
 
-    if multilayer_cache is not None:
-        for r, poly in multilayer_cache.region_polys:
-            if _copper_primitive_on_layer(
-                    r.layer_id, layer_id, r.net_index, plane_layers):
-                pieces.append(poly)
+    for r, poly in multilayer_cache.region_polys:
+        if _copper_primitive_on_layer(
+                r.layer_id, layer_id, r.net_index, plane_layers):
+            pieces.append(poly)
 
     for r in proj.shape_based_regions:
         if _is_multilayer_copper(r.layer_id, r.net_index):
@@ -1151,20 +1181,17 @@ def build_layer_geometry(proj: ExtractedProject, layer_id: int,
         if not _copper_primitive_on_layer(
                 r.layer_id, layer_id, r.net_index, plane_layers):
             continue
-        if r.is_keepout or r.is_polygon_outline or r.is_board_cutout:
-            continue
-        if r.kind != 0 or len(r.outline) < 3:
+        if not _shape_based_region_is_copper(r, plane_layers):
             continue
         poly = _shape_based_region_polygon(r)
         if poly.is_empty:
             continue
         pieces.append(poly)
 
-    if multilayer_cache is not None:
-        for r, poly in multilayer_cache.sbr_polys:
-            if _copper_primitive_on_layer(
-                    r.layer_id, layer_id, r.net_index, plane_layers):
-                pieces.append(poly)
+    for r, poly in multilayer_cache.sbr_polys:
+        if _copper_primitive_on_layer(
+                r.layer_id, layer_id, r.net_index, plane_layers):
+            pieces.append(poly)
 
     for f in proj.fills:
         if _is_multilayer_copper(f.layer_id, f.net_index):
@@ -1172,17 +1199,16 @@ def build_layer_geometry(proj: ExtractedProject, layer_id: int,
         if not _copper_primitive_on_layer(
                 f.layer_id, layer_id, f.net_index, plane_layers):
             continue
-        if f.is_keepout:
+        if not _fill_is_copper(f, plane_layers):
             continue
         poly = _fill_polygon(f)
         if poly is not None:
             pieces.append(poly)
 
-    if multilayer_cache is not None:
-        for f, poly in multilayer_cache.fill_polys:
-            if _copper_primitive_on_layer(
-                    f.layer_id, layer_id, f.net_index, plane_layers):
-                pieces.append(poly)
+    for f, poly in multilayer_cache.fill_polys:
+        if _copper_primitive_on_layer(
+                f.layer_id, layer_id, f.net_index, plane_layers):
+            pieces.append(poly)
 
     for p in proj.pads:
         if not _pad_on_layer(p, layer_id):
@@ -1515,7 +1541,7 @@ def _build_net_layer_buckets(
     # e.g. the boundary track is drawn centred on the board edge, so half its
     # width sits outside the outline. The plane's copper is the synthesised
     # sheet alone, so this artwork is excluded from the copper buckets.
-    plane_layer_ids = {s.layer_id for s in proj.stackup if s.is_plane}
+    plane_layer_ids = _plane_layer_ids(proj)
     _t_buckets = time.monotonic()
 
     def _add(layer_id: int, net_index: int, geom):
@@ -1531,11 +1557,7 @@ def _build_net_layer_buckets(
         buckets.setdefault((layer_id, net_index), []).append(geom)
 
     # Tracks: batch-buffer all valid tracks in one shapely call, then route.
-    valid_tracks = [t for t in proj.tracks
-                    if not t.is_keepout
-                    and not t.is_polygon_outline
-                    and t.width_mm > 0
-                    and t.layer_id not in plane_layer_ids]
+    valid_tracks = [t for t in proj.tracks if _track_is_copper(t, plane_layer_ids)]
     track_polys = _batch_buffer_tracks(valid_tracks)
     for t, poly in zip(valid_tracks, track_polys):
         _distribute_to_layers(t.layer_id, t.net_index, poly, enabled_layers,
@@ -1543,10 +1565,7 @@ def _build_net_layer_buckets(
 
     # Arcs: same vectorised-buffer trick. Exclude polygon-pour *outline* arcs
     # (boundary artwork, not copper) exactly as the track filter above does.
-    valid_arcs = [a for a in proj.arcs
-                  if not a.is_keepout and not a.is_polygon_outline
-                  and a.width_mm > 0
-                  and a.layer_id not in plane_layer_ids]
+    valid_arcs = [a for a in proj.arcs if _arc_is_copper(a, plane_layer_ids)]
     arc_polys = _batch_buffer_arcs(valid_arcs)
     for a, poly in zip(valid_arcs, arc_polys):
         _distribute_to_layers(a.layer_id, a.net_index, poly, enabled_layers,
@@ -1554,27 +1573,21 @@ def _build_net_layer_buckets(
 
     sbr_poly_indices = _shape_based_polygon_indices(proj)
     for r in proj.regions:
-        if r.is_keepout or r.is_polygon_outline or r.is_board_cutout or r.kind != 0:
-            continue
-        if len(r.outline) < 3 or r.layer_id in plane_layer_ids:
-            continue
-        if _skip_region_as_duplicate(r, sbr_poly_indices):
+        if not _region_is_copper(r, plane_layer_ids, sbr_poly_indices):
             continue
         poly = _region_polygon(r)
         _distribute_to_layers(r.layer_id, r.net_index, poly, enabled_layers,
                               _add, plane_layer_ids)
 
     for r in proj.shape_based_regions:
-        if r.is_keepout or r.is_polygon_outline or r.is_board_cutout or r.kind != 0:
-            continue
-        if len(r.outline) < 3 or r.layer_id in plane_layer_ids:
+        if not _shape_based_region_is_copper(r, plane_layer_ids):
             continue
         poly = _shape_based_region_polygon(r)
         _distribute_to_layers(r.layer_id, r.net_index, poly, enabled_layers,
                               _add, plane_layer_ids)
 
     for f in proj.fills:
-        if f.is_keepout or f.layer_id in plane_layer_ids:
+        if not _fill_is_copper(f, plane_layer_ids):
             continue
         poly = _fill_polygon(f)
         if poly is not None:

--- a/fypa/altium_viewer.py
+++ b/fypa/altium_viewer.py
@@ -16640,9 +16640,15 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         for bucket in ("tracks", "arcs", "regions",
                        "shape_based_regions", "fills", "planes"):
             for rec in prims.get(bucket, []):
-                key = (int(rec.get("layer_id", -1)),
-                       str(rec.get("net", "")))
-                idx.setdefault(key, []).append(rec)
+                lids = rec.get("layer_ids")
+                if lids:
+                    for lid in lids:
+                        key = (int(lid), str(rec.get("net", "")))
+                        idx.setdefault(key, []).append(rec)
+                else:
+                    key = (int(rec.get("layer_id", -1)),
+                           str(rec.get("net", "")))
+                    idx.setdefault(key, []).append(rec)
         self._primitives_by_layer_net = idx
         return idx
 
@@ -16852,7 +16858,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
             except Exception:
                 continue
             return {"kind": prim["kind"], "record": prim,
-                    "layer_id": int(prim["layer_id"]),
+                    "layer_id": int(cover["layer_id"]),
                     "net": str(prim["net"])}
         return None
 
@@ -16995,7 +17001,13 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
                 names = [self._layer_name_for_id(i) for i in ids]
                 add("Layers", ", ".join(names))
         else:
-            add("Layer", self._layer_name_for_id(hit.get("layer_id")))
+            ids = list(rec.get("layer_ids") or [])
+            if len(ids) > 1:
+                names = [self._layer_name_for_id(i) for i in ids]
+                add("Layers", ", ".join(names))
+            else:
+                add("Layer", self._layer_name_for_id(
+                    ids[0] if ids else hit.get("layer_id")))
 
         if kind == "track":
             ax, ay = float(rec["ax"]), float(rec["ay"])

--- a/tests/test_multilayer_copper.py
+++ b/tests/test_multilayer_copper.py
@@ -193,3 +193,30 @@ def test_build_layer_geometry_without_shared_cache_includes_multilayer():
 
     assert not top.shape.is_empty
     assert not bottom.shape.is_empty
+
+
+def test_multilayer_primitive_layer_ids_signal_layers_only():
+    from fypa.altium.loader import _primitive_visible_layer_ids
+
+    enabled = [1, 39, 32]
+    plane = {39}
+    lids = _primitive_visible_layer_ids(MULTI_LAYER_PAD_LAYER_ID, 0, enabled, plane)
+    assert lids == [1, 32]
+
+
+def test_multilayer_track_primitive_in_solve_metadata():
+    from fypa.altium.annotations import AnnotationResult
+    from fypa.altium.loader import LoadedProject, build_solve_metadata
+    from fypa.altium_geometry import build_per_net_geometry_layers
+
+    proj = _proj(
+        nets=(RawNet("SIG"), RawNet("GND")),
+        stackup=_stackup_with_internal_plane(),
+        tracks=(_horizontal_track(MULTI_LAYER_PAD_LAYER_ID, 0),),
+    )
+    loaded = LoadedProject(proj, AnnotationResult(directives=(), errors=()))
+    per_net = build_per_net_geometry_layers(proj)
+    md = build_solve_metadata(loaded, None, per_net_layers=per_net)
+    tracks = md["primitives"]["tracks"]
+    assert len(tracks) == 1
+    assert tracks[0]["layer_ids"] == [1, 32]

--- a/tests/test_multilayer_copper.py
+++ b/tests/test_multilayer_copper.py
@@ -22,6 +22,7 @@ from fypa.altium.extract import (
 from fypa.altium_geometry import (
     MULTI_LAYER_PAD_LAYER_ID,
     build_layer_geometries,
+    build_layer_geometry,
     build_net_layer_shapes,
 )
 
@@ -183,3 +184,12 @@ def test_multilayer_track_in_build_layer_geometries_signal_layers_only():
     assert not layers[32].shape.is_empty
     assert layers[39].is_plane
     assert (39, 0) not in build_net_layer_shapes(proj, [1, 39, 32])
+
+
+def test_build_layer_geometry_without_shared_cache_includes_multilayer():
+    proj = _proj(tracks=(_horizontal_track(MULTI_LAYER_PAD_LAYER_ID, 0),))
+    top = build_layer_geometry(proj, 1, [1, 32])
+    bottom = build_layer_geometry(proj, 32, [1, 32])
+
+    assert not top.shape.is_empty
+    assert not bottom.shape.is_empty

--- a/tests/test_multilayer_copper.py
+++ b/tests/test_multilayer_copper.py
@@ -1,0 +1,185 @@
+"""Multilayer (layer id 74) copper primitive distribution.
+
+Tracks, regions, and fills placed on Altium's Multi Layer with an assigned
+net must appear on every enabled signal copper layer. Internal planes are
+excluded. Unassigned (NO_NET) multilayer primitives stay excluded from the mesh.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from fypa.altium.extract import (
+    NO_NET,
+    NO_POLYGON,
+    ExtractedProject,
+    Pt2D,
+    RawFill,
+    RawNet,
+    RawRegion,
+    RawStackupLayer,
+    RawTrack,
+)
+from fypa.altium_geometry import (
+    MULTI_LAYER_PAD_LAYER_ID,
+    build_layer_geometries,
+    build_net_layer_shapes,
+)
+
+
+def _two_layer_stackup() -> tuple[RawStackupLayer, ...]:
+    return (
+        RawStackupLayer(
+            layer_id=1, name="Top", copper_thickness_mm=0.035,
+            dielectric_thickness_mm=0.2, next_layer_id=32,
+            is_plane=False, plane_net_name=None, mech_enabled=True,
+        ),
+        RawStackupLayer(
+            layer_id=32, name="Bottom", copper_thickness_mm=0.035,
+            dielectric_thickness_mm=0.0, next_layer_id=0,
+            is_plane=False, plane_net_name=None, mech_enabled=True,
+        ),
+    )
+
+
+def _stackup_with_internal_plane() -> tuple[RawStackupLayer, ...]:
+    return (
+        RawStackupLayer(
+            layer_id=1, name="Top", copper_thickness_mm=0.035,
+            dielectric_thickness_mm=0.2, next_layer_id=39,
+            is_plane=False, plane_net_name=None, mech_enabled=True,
+        ),
+        RawStackupLayer(
+            layer_id=39, name="GND Plane", copper_thickness_mm=0.035,
+            dielectric_thickness_mm=0.2, next_layer_id=32,
+            is_plane=True, plane_net_name="GND", mech_enabled=True,
+        ),
+        RawStackupLayer(
+            layer_id=32, name="Bottom", copper_thickness_mm=0.035,
+            dielectric_thickness_mm=0.0, next_layer_id=0,
+            is_plane=False, plane_net_name=None, mech_enabled=True,
+        ),
+    )
+
+
+def _proj(**overrides) -> ExtractedProject:
+    base = {
+        "prjpcb_path": Path("t.PrjPcb"),
+        "pcbdoc_path": Path("t.PcbDoc"),
+        "tracks": (), "arcs": (), "vias": (), "pads": (), "regions": (),
+        "shape_based_regions": (), "fills": (),
+        "pcb_components": (), "nets": (RawNet("+5V"),), "stackup": _two_layer_stackup(),
+        "sch_components": (), "compiled_netlist": None,
+    }
+    base.update(overrides)
+    return ExtractedProject(**base)
+
+
+def _horizontal_track(layer_id: int, net_index: int) -> RawTrack:
+    return RawTrack(
+        a=Pt2D(0.0, 0.0),
+        b=Pt2D(10.0, 0.0),
+        width_mm=0.5,
+        layer_id=layer_id,
+        net_index=net_index,
+        polygon_index=NO_POLYGON,
+        is_polygon_outline=False,
+        component_index=-1,
+        is_keepout=False,
+    )
+
+
+def _square_region(layer_id: int, net_index: int) -> RawRegion:
+    outline = (
+        Pt2D(0.0, 0.0),
+        Pt2D(5.0, 0.0),
+        Pt2D(5.0, 5.0),
+        Pt2D(0.0, 5.0),
+    )
+    return RawRegion(
+        outline=outline,
+        holes=(),
+        layer_id=layer_id,
+        net_index=net_index,
+        kind=0,
+        is_polygon_outline=False,
+        is_keepout=False,
+        is_board_cutout=False,
+    )
+
+
+def _axis_aligned_fill(layer_id: int, net_index: int) -> RawFill:
+    return RawFill(
+        x1_mm=0.0, y1_mm=0.0, x2_mm=4.0, y2_mm=3.0,
+        rotation_deg=0.0,
+        layer_id=layer_id,
+        net_index=net_index,
+        is_keepout=False,
+    )
+
+
+def test_multilayer_track_with_net_on_all_layers():
+    proj = _proj(tracks=(_horizontal_track(MULTI_LAYER_PAD_LAYER_ID, 0),))
+    enabled = [1, 32]
+    shapes = build_net_layer_shapes(proj, enabled)
+
+    assert (1, 0) in shapes and not shapes[(1, 0)].is_empty
+    assert (32, 0) in shapes and not shapes[(32, 0)].is_empty
+
+
+def test_multilayer_track_no_net_excluded():
+    proj = _proj(tracks=(_horizontal_track(MULTI_LAYER_PAD_LAYER_ID, NO_NET),))
+    enabled = [1, 32]
+    shapes = build_net_layer_shapes(proj, enabled)
+
+    assert (1, NO_NET) not in shapes
+    assert (32, NO_NET) not in shapes
+
+
+def test_multilayer_region_fill_with_net():
+    proj = _proj(regions=(_square_region(MULTI_LAYER_PAD_LAYER_ID, 0),))
+    enabled = [1, 32]
+    region_shapes = build_net_layer_shapes(proj, enabled)
+    assert (1, 0) in region_shapes and not region_shapes[(1, 0)].is_empty
+    assert (32, 0) in region_shapes and not region_shapes[(32, 0)].is_empty
+
+    proj = _proj(fills=(_axis_aligned_fill(MULTI_LAYER_PAD_LAYER_ID, 0),))
+    fill_shapes = build_net_layer_shapes(proj, enabled)
+    assert (1, 0) in fill_shapes and not fill_shapes[(1, 0)].is_empty
+    assert (32, 0) in fill_shapes and not fill_shapes[(32, 0)].is_empty
+
+
+def test_single_layer_track_unchanged():
+    proj = _proj(tracks=(_horizontal_track(1, 0),))
+    enabled = [1, 32]
+    shapes = build_net_layer_shapes(proj, enabled)
+
+    assert (1, 0) in shapes and not shapes[(1, 0)].is_empty
+    assert (32, 0) not in shapes
+
+
+def test_multilayer_track_not_on_internal_plane():
+    proj = _proj(
+        nets=(RawNet("SIG"), RawNet("GND")),
+        stackup=_stackup_with_internal_plane(),
+        tracks=(_horizontal_track(MULTI_LAYER_PAD_LAYER_ID, 0),),
+    )
+    enabled = [1, 39, 32]
+    shapes = build_net_layer_shapes(proj, enabled)
+
+    assert (1, 0) in shapes and not shapes[(1, 0)].is_empty
+    assert (32, 0) in shapes and not shapes[(32, 0)].is_empty
+    assert (39, 0) not in shapes
+
+
+def test_multilayer_track_in_build_layer_geometries_signal_layers_only():
+    proj = _proj(
+        nets=(RawNet("SIG"), RawNet("GND")),
+        stackup=_stackup_with_internal_plane(),
+        tracks=(_horizontal_track(MULTI_LAYER_PAD_LAYER_ID, 0),),
+    )
+    layers = {g.layer_id: g for g in build_layer_geometries(proj)}
+
+    assert not layers[1].shape.is_empty
+    assert not layers[32].shape.is_empty
+    assert layers[39].is_plane
+    assert (39, 0) not in build_net_layer_shapes(proj, [1, 39, 32])


### PR DESCRIPTION
## Summary

Altium can place tracks, arcs, regions, shape-based regions, and fills on the **Multi Layer** (layer id 74). FYPA already fanned that out for pads and vias, but not for other copper primitives — so multilayer routing never reached per-layer geometry or the viewer.

This PR distributes **layer-74 primitives with an assigned net** onto every enabled **signal** copper layer (internal planes excluded). `NO_NET` multilayer primitives stay excluded from the FEM mesh, as before.

The viewer fix indexes primitives under physical layer ids so multilayer tracks are selectable and show correct layer info in the properties panel (they were already in `all_copper` geometry but keyed only at layer 74).

## Changes

- **`altium_geometry.py`**: `_is_multilayer_copper`, `_distribute_to_layers`, shared copper filters, `_MultilayerCopperCache` for `build_layer_geometries`
- **`loader.py`**: `layer_ids` on multilayer primitives in solve metadata
- **`altium_viewer.py`**: primitive index and properties panel use physical layers
- **`tests/test_multilayer_copper.py`**: geometry, plane exclusion, lazy cache, metadata/viewer indexing

