### PR TITLE
reused sheet local net mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,11 @@ For `SERIES`, auto-inferred P/N nets (2-pin parts) apply only when the
 part carries a single channel; multi-channel SERIES requires explicit
 `PDNn_P_NET` / `PDNn_N_NET` or `PDNn_P_PINS` / `PDNn_N_PINS` per channel.
 
+On **repeated schematic sheets** (Altium `REPEAT`), `PDN_*_NET` may use
+the local child-sheet net label; FYPA maps each PCB instance to its slot
+net via pin connectivity (not via `ChannelDesignatorFormatString`). See
+[User guide — Local net names](docs/user-guide/01-sources-and-sinks.md#local-net-names-hierarchical--reused-sheets).
+
 ### Mixed-role parts (a source and a sink on one component)
 
 `PDN_ROLE` is the part-wide **default** role, but any channel may override

--- a/docs/user-guide/01-sources-and-sinks.md
+++ b/docs/user-guide/01-sources-and-sinks.md
@@ -287,16 +287,65 @@ placing them on every symbol:
 
 `PDN_P_NET`, `PDN_N_NET`, and `PDN_NET` may use the **local net name
 as it appears on the schematic sheet** where the directive applies
-(for example `+3V3` on a child sheet). FYPA compiles the schematic
-netlist and resolves the name to the correct PCB pads per component
-instance. Physical PCB net names still work unchanged — FYPA tries a
-direct PCB match first, then falls back to local-name resolution.
+(for example `VCC_EFUSE` on `efuse.SchDoc`, or `+3V3` on a child
+sheet). FYPA compiles the schematic netlist and maps that label to the
+correct PCB pads **per component instance** — independent of how
+Altium names channels on the PCB (`R63.4`, `J3_SL8M7`, `CAN.RX1`, …).
 
-> On hierarchical designs you no longer need to look up the flattened
-> PCB net name manually when the local sheet name is unambiguous on
-> that sheet. If resolution fails, check that the project compiles
-> cleanly and that the component’s schematic designator matches the
-> PCB `source_designator`.
+Resolution order:
+
+1. **Direct PCB net name** — if the parameter already names a flattened
+   PCB net (e.g. `VCC_EFUSE.4`), FYPA uses it as-is.
+2. **Local name via schematic pins** — the compiled netlist finds which
+   pin(s) carry the local label on the inferred sheet; FYPA selects the
+   matching pad(s) on that PCB instance (primary path for repeated sheets).
+3. **Netlist aliases** — when Altium compiles channel-qualified aliases
+   (`VDD_5V0.4`, `MDI.TD_P4`, …), FYPA cross-checks pad connectivity.
+
+Physical PCB net names still work unchanged. You do **not** need to look
+up flattened PCB net names when authoring on a child sheet.
+
+#### Repeated sheets (REPEAT)
+
+A sheet symbol placed multiple times (e.g. `vip-port.SchDoc` × 4, each
+containing `efuse.SchDoc`) creates several PCB instances of the same
+schematic designator (`R63` → `R63.1` … `R63.4`). Use the **local**
+net label from the child sheet in `PDN_*_NET` — FYPA binds each
+instance to its own slot net (`VCC_EFUSE.1` … `VCC_EFUSE.4`) via pin
+connectivity, not by parsing your `ChannelDesignatorFormatString`.
+
+Example — a 0 Ω link `R63` on `efuse.SchDoc` inside a repeated VIP port:
+
+| Parameter      | Value        |
+|----------------|--------------|
+| `PDN_ROLE`     | `SERIES`     |
+| `PDN1_R`       | `0.01`       |
+| `PDN1_P_NET`   | `VDD_5V0`    |
+| `PDN1_N_NET`   | `VCC_EFUSE`  |
+
+The same parameters on every instance; FYPA resolves `VCC_EFUSE` to
+`VCC_EFUSE.N` per placement. A log line such as
+`resolved local net 'VCC_EFUSE' via schematic pins ['2'] → PCB net(s) VCC_EFUSE.4`
+is expected and not an error.
+
+#### PCB-only parameters (Blanket / ECO)
+
+When `PDN_*` parameters are pushed to the PCB only (Blanket rule or ECO),
+FYPA infers the originating schematic sheet from pad ↔ netlist
+connectivity so local-net resolution stays scoped to that instance.
+
+#### Troubleshooting local nets
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `net 'FOO' does not exist on the PCB and could not be resolved as a local schematic net` | Project does not compile / netlist unavailable | Compile the schematic; re-open the project in FYPA |
+| Same message, project compiles | Wrong local label or wrong sheet | Check the net label on the child sheet matches `PDN_*_NET` exactly |
+| `component … has no pad on net FOO` | Slot-qualified name on the wrong instance (e.g. `FOO.3` on channel 1) | Use the local name `FOO` instead of a channel suffix |
+| `resolved local net … via schematic pins` (warning) | Normal for repeated sheets | No action needed — mapping succeeded |
+
+> If resolution still fails, verify that the component's schematic
+> designator matches the PCB `source_designator` and that the project
+> compiles without errors.
 
 ## 1.6 Importing into FYPA
 

--- a/docs/user-guide/03-series-elements.md
+++ b/docs/user-guide/03-series-elements.md
@@ -120,6 +120,19 @@ Once a SERIES directive is in place:
 > Editor SERIES is component-bound only (it bridges two real pads on
 > the same part) and uses an SI-units value (`0.01` for 10 mΩ).
 
+## 3.4 Repeated sheets and local net names
+
+On hierarchical designs with **repeated sheet symbols** (Altium
+`REPEAT(...)`), use the **local** net label from the child sheet in
+`PDN_P_NET` / `PDN_N_NET` — not the flattened PCB name (`VCC_EFUSE.4`).
+FYPA maps each PCB instance to its slot net via schematic pin
+connectivity. See [Section 1.5 — Local net names](01-sources-and-sinks.md#local-net-names-hierarchical--reused-sheets)
+for the full explanation, VIP example, and troubleshooting table.
+
+Auto-inference of P/N nets on 2-pin SERIES parts (Section 3.2) works per
+PCB instance the same way: each repeated `R63.N` infers from its own
+pads.
+
 ## 3.5 Troubleshooting
 
 | Message or symptom                                       | Likely cause                                                                | Fix                                                                          |
@@ -127,7 +140,8 @@ Once a SERIES directive is in place:
 | `PDN_R must be positive`                                  | `PDN_R = 0` or a negative value.                                            | Enter a small positive resistance (milliohms is fine).                       |
 | `SERIES on R7: ambiguous nets — please set PDN_P_NET / PDN_N_NET` | A 3+ pin part with auto-inference, or a 2-pin part with both pads on the same net. | Add `PDN_P_NET` and `PDN_N_NET` explicitly.                                  |
 | `multi-channel SERIES requires explicit PDNn_P_NET / …` | Two or more `PDNn_R` channels without per-channel nets or pin overrides. | Add `PDNn_P_NET` / `PDNn_N_NET` or `PDNn_P_PINS` / `PDNn_N_PINS` for each channel. |
-| `component … has no pad on net …` on a `SERIES` part | `PDN_P_NET` / `PDN_N_NET` name a net none of this part's pads sit on. | Match the parameter to the PCB net on each pad (see [1.8](01-sources-and-sinks.md#18-troubleshooting)). |
+| `component … has no pad on net …` on a `SERIES` part | `PDN_P_NET` / `PDN_N_NET` name a net none of this part's pads sit on. | Match the parameter to the PCB net on each pad, or use a [local net name](01-sources-and-sinks.md#local-net-names-hierarchical--reused-sheets) on repeated sheets. |
+| `net … could not be resolved as a local schematic net` on a repeated sheet | Flattened PCB name used instead of the local child-sheet label. | Use the local name (e.g. `VCC_EFUSE`, not `VCC_EFUSE.4`). |
 | The two nets are still not connected in the solve         | The SERIES part was placed on the schematic but does not actually bridge the two nets on the PCB. | Check the PCB netlist: each pad of the SERIES part must be on the corresponding net. |
 
 ## Next steps

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -134,9 +134,9 @@ parse ``ChannelDesignatorFormatString`` — resolution is **pin-driven**:
 4. Degraded fallback (no compiled netlist): weak suffix heuristics only.
 
 :class:`InstanceLocalNetResolver` (cached per :class:`ExtractedProject`) performs
-sheet inference for PCB-only directives, local-net expansion for bridge groups,
-and the steps above. See the user guide section *Local net names* in
-``docs/user-guide/01-sources-and-sinks.md``.
+sheet inference for PCB-only directives, instance-scoped local-net expansion
+for SERIES bridge validation, and the steps above. See the user guide section
+*Local net names* in ``docs/user-guide/01-sources-and-sinks.md``.
 """
 from __future__ import annotations
 
@@ -667,7 +667,8 @@ class InstanceLocalNetResolver:
     ) -> str:
         if not lookup_des:
             return ""
-        target_des = lookup_des.upper()
+        pcb_designator = self.proj.pcb_components[pcb_index].designator
+        des_candidates = _designator_candidates(lookup_des, pcb_designator)
         if pads_by_component is None:
             pads_by_component = _build_pads_by_component(self.proj)
         routed_pads = pads_by_component.get(pcb_index, {})
@@ -682,16 +683,17 @@ class InstanceLocalNetResolver:
                 )
             for pin_key, pad in routed_pads.items():
                 pcb_net_upper = self.proj.nets[pad.net_index].name.upper()
-                for nl_pin, names, sheets in netlist_index.get(target_des, ()):
-                    if nl_pin != pin_key:
-                        continue
-                    vote_weight = 1
-                    if pcb_net_upper in names:
-                        vote_weight = 2
-                    for sheet in sheets:
-                        key = sheet.replace("\\", "/").lower()
-                        sheet_votes[key] = sheet_votes.get(key, 0) + vote_weight
-                        sheet_paths.setdefault(key, sheet)
+                for des_key in des_candidates:
+                    for nl_pin, names, sheets in netlist_index.get(des_key, ()):
+                        if nl_pin != pin_key:
+                            continue
+                        vote_weight = 1
+                        if pcb_net_upper in names:
+                            vote_weight = 2
+                        for sheet in sheets:
+                            key = sheet.replace("\\", "/").lower()
+                            sheet_votes[key] = sheet_votes.get(key, 0) + vote_weight
+                            sheet_paths.setdefault(key, sheet)
 
         if sheet_votes:
             best = max(sorted(sheet_votes), key=lambda k: sheet_votes[k])
@@ -707,7 +709,7 @@ class InstanceLocalNetResolver:
 
         sch_matches = [
             c.schdoc_name for c in self.proj.sch_components
-            if c.designator.upper() == target_des
+            if c.designator.upper() == lookup_des.upper()
         ]
         if len(sch_matches) == 1:
             return sch_matches[0]
@@ -718,13 +720,25 @@ class InstanceLocalNetResolver:
         local_name: str,
         pcb_index: int | None = None,
     ) -> tuple[str, ...]:
-        """All PCB / netlist labels equivalent to a local schematic net name."""
+        """All PCB / netlist labels equivalent to a local schematic net name.
+
+        Always pass ``pcb_index`` for production resolution paths. The
+        ``pcb_index is None`` mode scans every placement and seeds from the
+        unscoped netlist label family — it can merge unrelated channel slots
+        (e.g. ``VCC_EFUSE.1`` and ``VCC_EFUSE.4``) and is intended for tests
+        and diagnostics only.
+        """
         cache_key = f"{local_name.upper()}\0{pcb_index}"
         cached = self._expanded_cache.get(cache_key)
         if cached is not None:
             return cached
 
         if pcb_index is None:
+            log.debug(
+                "expand_net_names(%r) without pcb_index: unscoped label-family "
+                "expansion — prefer pcb_index= for instance-safe resolution",
+                local_name,
+            )
             names: set[str] = set(_netlist_label_family(
                 self.proj.compiled_netlist, local_name,
             ))
@@ -1313,9 +1327,11 @@ def _collect_bridge_groups(
     Transitive: if A↔B and B↔C are both bridged, A, B, C all belong to one
     group. Net names are upper-cased for case-insensitive comparison.
 
-    Used by :func:`_validate_directive_groups` and the solver to treat
-    SERIES-bridged nets as electrically connected. Terminal pin resolution
-    uses direct pad-to-net connectivity only — see :func:`_resolve_terminal`.
+    Name-level equivalence only — used in unit tests. Cross-directive
+    validation unions PCB net indices via
+    :func:`_union_series_bridge_net_indices` (instance-scoped expansion).
+    Terminal pin resolution uses direct pad-to-net connectivity only — see
+    :func:`_resolve_terminal`.
     """
     parent: dict[str, str] = {}
 
@@ -1726,7 +1742,7 @@ def _has_single_net_params(params: dict[str, str],
     return False
 
 
-def _parse_source(comp, proj, enabled_layers, result, bridge_groups=None,
+def _parse_source(comp, proj, enabled_layers, result,
                   net_remap=None, supply_map=None, only_indices=None):
     # ``only_indices`` (from the per-channel role dispatcher) restricts this
     # parser to the channels whose effective role is SOURCE; when ``None`` the
@@ -1803,7 +1819,7 @@ def _parse_source(comp, proj, enabled_layers, result, bridge_groups=None,
     return specs
 
 
-def _parse_sink(comp, proj, enabled_layers, result, bridge_groups=None,
+def _parse_sink(comp, proj, enabled_layers, result,
                 net_remap=None, supply_map=None, only_indices=None):
     # ``only_indices`` restricts this parser to the part's SINK-role channels;
     # see _parse_source.
@@ -1884,7 +1900,7 @@ def _parse_sink(comp, proj, enabled_layers, result, bridge_groups=None,
     return specs
 
 
-def _parse_resistance(comp, proj, enabled_layers, result, bridge_groups=None,
+def _parse_resistance(comp, proj, enabled_layers, result,
                       net_remap=None, supply_map=None, only_indices=None):
     # This parser only ever handles SERIES-role channels (part-wide or a
     # PDN<n>_ROLE=SERIES override), so the role for diagnostics is always
@@ -2142,7 +2158,7 @@ def _resolve_regulator_gain(
     return gain, reg_type, eff, True
 
 
-def _parse_regulator(comp, proj, enabled_layers, result, bridge_groups=None,
+def _parse_regulator(comp, proj, enabled_layers, result,
                      net_remap=None, supply_map=None, only_indices=None):
     role_diag_base = f"REGULATOR on {comp.designator}"
     if _has_single_net_params(comp.parameters, only_indices):
@@ -2555,8 +2571,6 @@ def parse_annotations(proj: ExtractedProject,
 
     parameter_sources = _iter_pdn_parameter_sources(proj)
 
-    # SERIES bridge equivalence for cross-directive validation and the solver.
-    bridge_groups = _collect_bridge_groups(parameter_sources, proj)
     supply_map = _collect_supply_voltages_by_net(parameter_sources)
 
     for comp in parameter_sources:
@@ -2605,7 +2619,6 @@ def parse_annotations(proj: ExtractedProject,
             if not role:
                 continue
             specs = _PARSER_BY_ROLE[role](comp, proj, enabled_layers, result,
-                                          bridge_groups=bridge_groups,
                                           net_remap=net_remap,
                                           supply_map=supply_map)
             result.directives.extend(specs)
@@ -2613,7 +2626,7 @@ def parse_annotations(proj: ExtractedProject,
             for chan_role, idxs in channel_roles.items():
                 specs = _PARSER_BY_ROLE[chan_role](
                     comp, proj, enabled_layers, result,
-                    bridge_groups=bridge_groups, net_remap=net_remap,
+                    net_remap=net_remap,
                     supply_map=supply_map, only_indices=idxs,
                 )
                 # Every parser returns a list — empty if the directive failed

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -119,6 +119,24 @@ and N_NET automatically from the two nets the component sits on. When a
 part carries more than one SERIES channel (``PDN1_R`` + ``PDN2_R``, …),
 each channel must name its nets or pin overrides explicitly — auto-inference
 is not attempted.
+
+Local net resolution (multi-channel / reused sheets)
+----------------------------------------------------
+``PDN_P_NET``, ``PDN_N_NET``, and ``PDN_NET`` may name a **local sheet label**
+(e.g. ``VCC_EFUSE`` on ``efuse.SchDoc``) even when the PCB net is channel-
+qualified (``VCC_EFUSE.4``, ``S00A_SL8M7``, ``CAN.RX1``, …). FYPA does **not**
+parse ``ChannelDesignatorFormatString`` — resolution is **pin-driven**:
+
+1. Direct PCB net-name match when the parameter already names a flattened net.
+2. Compiled schematic netlist → schematic pin(s) for the local label on the
+   inferred sheet → PCB pad(s) on that component instance (primary path).
+3. Pad net names cross-checked against netlist ``aliases`` for that pin.
+4. Degraded fallback (no compiled netlist): weak suffix heuristics only.
+
+:class:`InstanceLocalNetResolver` (cached per :class:`ExtractedProject`) performs
+sheet inference for PCB-only directives, local-net expansion for bridge groups,
+and the steps above. See the user guide section *Local net names* in
+``docs/user-guide/01-sources-and-sinks.md``.
 """
 from __future__ import annotations
 
@@ -541,51 +559,222 @@ def _schdoc_for_pcb_instance(
     to reuse the indexes across many directives; otherwise they are built
     on demand for this single call.
     """
-    if not lookup_des:
+    return _instance_resolver(proj).infer_schdoc(
+        pcb_index,
+        lookup_des,
+        pads_by_component=pads_by_component,
+        netlist_index=netlist_index,
+    )
+
+
+def _designator_candidates(
+    sch_designator: str,
+    pcb_designator: str | None = None,
+) -> set[str]:
+    candidates = {sch_designator.upper()}
+    if pcb_designator:
+        candidates.add(pcb_designator.upper())
+    return candidates
+
+
+def _local_net_label_matches(
+    label: str | None,
+    local_net_name: str,
+    des_candidates: set[str] | None = None,
+) -> bool:
+    """True when ``label`` names the same local net class as ``local_net_name``.
+
+    With ``des_candidates``, channel-mangled aliases (``S00A_SL8M7``, ``S00A.4``)
+    are accepted only when an instance designator carries the same channel token.
+    Without ``des_candidates`` (bridge-group expansion), any alias sharing the
+    local prefix is accepted.
+    """
+    if not label:
+        return False
+    ln = local_net_name.upper()
+    lu = label.upper()
+    if lu == ln:
+        return True
+    if des_candidates is None:
+        return lu.startswith((ln + ".", ln + "_"))
+    if lu.startswith(ln + "."):
+        channel = lu[len(ln) + 1:]
+        if channel and any(d.endswith("." + channel) for d in des_candidates):
+            return True
+    if lu.startswith(ln + "_"):
+        channel = lu[len(ln) + 1:]
+        if channel and any(d.endswith("_" + channel) for d in des_candidates):
+            return True
+    return False
+
+
+def _netlist_label_family(netlist, local_net_name: str) -> set[str]:
+    """All netlist labels (name + aliases) in the same family as a local name."""
+    if netlist is None:
+        return {local_net_name.upper()}
+    family: set[str] = set()
+    for net in netlist.nets:
+        names = [net.name, *getattr(net, "aliases", ())]
+        if any(_local_net_label_matches(n, local_net_name) for n in names):
+            family.update(n.upper() for n in names if n)
+    if not family:
+        family.add(local_net_name.upper())
+    return family
+
+
+def _channel_suffix_from_pcb_designator(pcb_designator: str) -> str | None:
+    """Numeric channel tail from a flattened PCB designator (degraded mode only).
+
+    Altium's ``$Component.$ChannelIndex`` room style yields ``R63.4`` → ``4``.
+    Non-numeric tails (``J3_SL8M7``) are handled via netlist aliases, not here.
+    """
+    if "." not in pcb_designator:
+        return None
+    suffix = pcb_designator.rsplit(".", 1)[-1]
+    return suffix if suffix.isdigit() else None
+
+
+def _degraded_pcb_net_candidates(
+    local_net_name: str,
+    pcb_designator: str,
+) -> list[str]:
+    """Last-resort PCB net names when the compiled netlist is unavailable."""
+    names = [local_net_name]
+    if "." not in local_net_name:
+        suffix = _channel_suffix_from_pcb_designator(pcb_designator)
+        if suffix:
+            names.append(f"{local_net_name}.{suffix}")
+    return names
+
+
+@dataclass
+class InstanceLocalNetResolver:
+    """Pin-driven local-net resolution for one :class:`ExtractedProject`."""
+
+    proj: ExtractedProject
+    _expanded_cache: dict[str, tuple[str, ...]] = field(
+        default_factory=dict, repr=False,
+    )
+
+    def infer_schdoc(
+        self,
+        pcb_index: int,
+        lookup_des: str,
+        *,
+        pads_by_component: dict[int, dict[str, RawPad]] | None = None,
+        netlist_index: dict[str, list[tuple[str, tuple[str, ...], tuple[str, ...]]]]
+        | None = None,
+    ) -> str:
+        if not lookup_des:
+            return ""
+        target_des = lookup_des.upper()
+        if pads_by_component is None:
+            pads_by_component = _build_pads_by_component(self.proj)
+        routed_pads = pads_by_component.get(pcb_index, {})
+
+        sheet_votes: dict[str, int] = {}
+        sheet_paths: dict[str, str] = {}
+
+        if routed_pads:
+            if netlist_index is None:
+                netlist_index = _build_netlist_designator_index(
+                    self.proj.compiled_netlist,
+                )
+            for pin_key, pad in routed_pads.items():
+                pcb_net_upper = self.proj.nets[pad.net_index].name.upper()
+                for nl_pin, names, sheets in netlist_index.get(target_des, ()):
+                    if nl_pin != pin_key:
+                        continue
+                    vote_weight = 1
+                    if pcb_net_upper in names:
+                        vote_weight = 2
+                    for sheet in sheets:
+                        key = sheet.replace("\\", "/").lower()
+                        sheet_votes[key] = sheet_votes.get(key, 0) + vote_weight
+                        sheet_paths.setdefault(key, sheet)
+
+        if sheet_votes:
+            best = max(sorted(sheet_votes), key=lambda k: sheet_votes[k])
+            top = sheet_votes[best]
+            if sum(1 for v in sheet_votes.values() if v == top) > 1:
+                log.debug(
+                    "Ambiguous sheet vote for %s (pcb_index=%d): %s; choosing %s",
+                    lookup_des, pcb_index,
+                    sorted(k for k, v in sheet_votes.items() if v == top),
+                    sheet_paths[best],
+                )
+            return sheet_paths[best]
+
+        sch_matches = [
+            c.schdoc_name for c in self.proj.sch_components
+            if c.designator.upper() == target_des
+        ]
+        if len(sch_matches) == 1:
+            return sch_matches[0]
         return ""
-    target_des = lookup_des.upper()
-    if pads_by_component is None:
-        pads_by_component = _build_pads_by_component(proj)
-    routed_pads = pads_by_component.get(pcb_index, {})
 
-    sheet_votes: dict[str, int] = {}
-    sheet_paths: dict[str, str] = {}
+    def expand_net_names(
+        self,
+        local_name: str,
+        pcb_index: int | None = None,
+    ) -> tuple[str, ...]:
+        """All PCB / netlist labels equivalent to a local schematic net name."""
+        cache_key = f"{local_name.upper()}\0{pcb_index}"
+        cached = self._expanded_cache.get(cache_key)
+        if cached is not None:
+            return cached
 
-    if routed_pads:
-        if netlist_index is None:
-            netlist_index = _build_netlist_designator_index(proj.compiled_netlist)
-        for pin_key, names, sheets in netlist_index.get(target_des, ()):
-            pad = routed_pads.get(pin_key)
-            if pad is None:
-                continue
-            if proj.nets[pad.net_index].name.upper() not in names:
-                continue
-            for sheet in sheets:
-                key = sheet.replace("\\", "/").lower()
-                sheet_votes[key] = sheet_votes.get(key, 0) + 1
-                sheet_paths.setdefault(key, sheet)
+        names: set[str] = set(_netlist_label_family(
+            self.proj.compiled_netlist, local_name,
+        ))
 
-    if sheet_votes:
-        # Deterministic tie-break: highest vote, ties broken by the
-        # lexicographically smallest sheet key (sorted() before max()).
-        best = max(sorted(sheet_votes), key=lambda k: sheet_votes[k])
-        top = sheet_votes[best]
-        if sum(1 for v in sheet_votes.values() if v == top) > 1:
-            log.debug(
-                "Ambiguous sheet vote for %s (pcb_index=%d): %s; choosing %s",
-                lookup_des, pcb_index,
-                sorted(k for k, v in sheet_votes.items() if v == top),
-                sheet_paths[best],
+        if self.proj.compiled_netlist is not None:
+            indices = (
+                [pcb_index] if pcb_index is not None
+                else range(len(self.proj.pcb_components))
             )
-        return sheet_paths[best]
+            pads_by = _build_pads_by_component(self.proj)
+            for idx in indices:
+                pcb = self.proj.pcb_components[idx]
+                lookup_des = pcb.source_designator or pcb.designator
+                schdoc = self.infer_schdoc(
+                    idx, lookup_des, pads_by_component=pads_by,
+                )
+                routed = pads_by.get(idx, {})
+                if not routed:
+                    continue
+                routed_keys = set(routed)
+                local_pins = _resolve_local_net_pins(
+                    self.proj.compiled_netlist,
+                    lookup_des,
+                    schdoc,
+                    local_name,
+                    routed_pin_keys=routed_keys,
+                    pcb_designator=pcb.designator,
+                )
+                if not local_pins:
+                    continue
+                wanted = {p.upper() for p in local_pins}
+                for pin_key, pad in routed.items():
+                    if pin_key in wanted and pad.net_index != NO_NET:
+                        names.add(self.proj.nets[pad.net_index].name.upper())
 
-    sch_matches = [
-        c.schdoc_name for c in proj.sch_components
-        if c.designator.upper() == target_des
-    ]
-    if len(sch_matches) == 1:
-        return sch_matches[0]
-    return ""
+        result = tuple(sorted(names))
+        self._expanded_cache[cache_key] = result
+        return result
+
+
+_resolver_cache: dict[int, tuple[ExtractedProject, InstanceLocalNetResolver]] = {}
+
+
+def _instance_resolver(proj: ExtractedProject) -> InstanceLocalNetResolver:
+    entry = _resolver_cache.get(id(proj))
+    if entry is None or entry[0] is not proj:
+        _resolver_cache.clear()
+        resolver = InstanceLocalNetResolver(proj)
+        _resolver_cache[id(proj)] = (proj, resolver)
+        return resolver
+    return entry[1]
 
 
 def _iter_pdn_parameter_sources(proj: ExtractedProject) -> list[PdnParameterSource]:
@@ -681,40 +870,14 @@ def _resolve_local_net_pins(
     """
     if netlist is None:
         return []
-    # Netlist terminal designators may be the base schematic designator or the
-    # channel-flattened instance designator depending on the design; accept
-    # both. The channel token lives on the flattened form.
-    des_candidates = {sch_designator.upper()}
-    if pcb_designator:
-        des_candidates.add(pcb_designator.upper())
-    ln = local_net_name.upper()
-
-    def _label_matches(label: str | None) -> bool:
-        # Exact label, or the channel-mangled form Altium generates inside a
-        # repeated ("multi-channel") sheet: a local label ``S00A`` in sheet
-        # instance ``SL8M3`` compiles to ``S00A_SL8M3`` (carried as an alias of
-        # the flattened physical net, e.g. ``IOUT3``). The flattened instance
-        # designator gains the same suffix (``J3`` → ``J3_SL8M3``), so accept a
-        # ``<net>_<channel>`` alias only when one of this instance's designators
-        # ends with ``_<channel>``. That binds the alias to this connector's own
-        # channel and stops sibling instances (``S00A_SL8M0``) from matching.
-        if not label:
-            return False
-        lu = label.upper()
-        if lu == ln:
-            return True
-        if lu.startswith(ln + "_"):
-            channel = lu[len(ln) + 1:]
-            if channel and any(d.endswith("_" + channel) for d in des_candidates):
-                return True
-        return False
+    des_candidates = _designator_candidates(sch_designator, pcb_designator)
 
     pins: list[str] = []
     seen: set[str] = set()
     unscoped_used = False
     for net in netlist.nets:
         names = [net.name, *getattr(net, "aliases", ())]
-        if not any(_label_matches(n) for n in names):
+        if not any(_local_net_label_matches(n, local_net_name, des_candidates) for n in names):
             continue
         net_sheets = list(getattr(net, "source_sheets", ()) or ())
         if not _sheet_name_matches(schdoc_name, net_sheets):
@@ -855,6 +1018,45 @@ def _resolve_terminal(
                             f"{net_name!r} via schematic pins "
                             f"{sorted(local_pins)} → PCB net(s) {nets_text}"
                         )
+
+        if (
+            not matched
+            and sch_lookup_designator
+            and proj.compiled_netlist is not None
+        ):
+            family = _netlist_label_family(proj.compiled_netlist, net_name)
+            netlist_index = _build_netlist_designator_index(proj.compiled_netlist)
+            alias_matched: list[RawPad] = []
+            for pad in component_pads:
+                if pad.net_index == NO_NET:
+                    continue
+                pcb_n = proj.nets[pad.net_index].name.upper()
+                if pcb_n in family:
+                    alias_matched.append(pad)
+                    continue
+                pin_key = pad.designator.upper()
+                for nl_pin, names, sheets in netlist_index.get(
+                    sch_lookup_designator.upper(), (),
+                ):
+                    if nl_pin != pin_key or pcb_n not in names:
+                        continue
+                    if _sheet_name_matches(schdoc_name or "", list(sheets)):
+                        alias_matched.append(pad)
+                        break
+            if alias_matched:
+                matched = alias_matched
+
+        if not matched and proj.compiled_netlist is None:
+            for candidate in _degraded_pcb_net_candidates(net_name, designator):
+                net_indices = _net_indices_by_name(proj, candidate)
+                if not net_indices:
+                    continue
+                if net_remap:
+                    net_indices = [net_remap.get(ix, ix) for ix in net_indices]
+                wanted_nets = set(net_indices)
+                matched = [p for p in component_pads if p.net_index in wanted_nets]
+                if matched:
+                    break
 
         if not matched and not net_indices:
             # Common authoring slip is a near-miss spelling (e.g. "+3.3V" vs
@@ -2012,10 +2214,12 @@ def _validate_directive_groups(result: AnnotationResult,
             union(nets[0], other)
     # SERIES bridges (ferrite / 0 Ω link) join the nets they span, so a
     # point-to-point check across one stays a single group.
+    resolver = _instance_resolver(proj)
     for group in bridge_groups.values():
         idxs: list[int] = []
         for name in group:
-            idxs.extend(_net_indices_by_name(proj, name))
+            for expanded in resolver.expand_net_names(name):
+                idxs.extend(_net_indices_by_name(proj, expanded))
         for other in idxs[1:]:
             union(idxs[0], other)
 

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -1283,36 +1283,66 @@ def _series_channel_has_net_params(
     )
 
 
+def _resolve_series_channel_nets(
+    comp: PdnParameterSource,
+    proj: ExtractedProject,
+    ch_idx: int,
+    pcb_idx: int,
+    ch_indices: list[int],
+) -> tuple[str, str] | None:
+    """P/N net names for one SERIES channel on one PCB placement."""
+    p_net = _ci_get(comp.parameters, _channel_key("P_NET", ch_idx))
+    n_net = _ci_get(comp.parameters, _channel_key("N_NET", ch_idx))
+    if p_net is None and n_net is None and not _series_channel_has_net_params(
+        comp, ch_idx,
+    ):
+        if len(ch_indices) != 1:
+            return None
+        return _autoinfer_2pin_nets(proj, pcb_idx)
+    if p_net and n_net:
+        return p_net, n_net
+    return None
+
+
 def _iter_series_bridge_pairs(
     parameter_sources: list[PdnParameterSource],
     proj: ExtractedProject,
-) -> Iterator[tuple[str, str]]:
-    """Yield ``(p_net, n_net)`` name pairs for each SERIES bridge.
+    *,
+    per_placement: bool,
+) -> Iterator[tuple[int | None, str, str]]:
+    """Yield ``(pcb_index, p_net, n_net)`` for each SERIES bridge.
 
-    Explicit ``PDN<n>_P_NET`` / ``PDN<n>_N_NET`` pairs are yielded as-is.
-    A single-channel SERIES part with no net/pin parameters replicates the
-    per-directive 2-pin auto-inference so the bridge graph stays consistent
-    with the parser. A multi-channel SERIES part bridges a different net
-    pair in each channel, so every channel yields its own pair — stopping
-    at the first would strand the other channels.
+    ``pcb_index`` is ``None`` only for parameter-level name pairs
+    (``per_placement=False``). Placement-scoped iteration is used by
+    cross-directive validation; parameter-level pairs build the transitive
+    name equivalence map in :func:`_collect_bridge_groups`.
     """
     for comp in parameter_sources:
         ch_indices = _series_channel_indices(comp)
         if not ch_indices:
             continue
+        pcb_indices = _pcb_indices_for_source(comp, proj)
         for ch_idx in ch_indices:
+            if per_placement:
+                for pcb_idx in pcb_indices:
+                    pair = _resolve_series_channel_nets(
+                        comp, proj, ch_idx, pcb_idx, ch_indices,
+                    )
+                    if pair is not None:
+                        yield pcb_idx, pair[0], pair[1]
+                continue
             p_net = _ci_get(comp.parameters, _channel_key("P_NET", ch_idx))
             n_net = _ci_get(comp.parameters, _channel_key("N_NET", ch_idx))
             if p_net and n_net:
-                yield p_net, n_net
+                yield None, p_net, n_net
             elif p_net is None and n_net is None and not _series_channel_has_net_params(
                 comp, ch_idx,
             ):
                 if len(ch_indices) == 1:
-                    for pcb_idx in _pcb_indices_for_source(comp, proj):
+                    for pcb_idx in pcb_indices:
                         pair = _autoinfer_2pin_nets(proj, pcb_idx)
                         if pair is not None:
-                            yield pair
+                            yield pcb_idx, pair[0], pair[1]
 
 
 def _collect_bridge_groups(
@@ -1327,9 +1357,8 @@ def _collect_bridge_groups(
     Transitive: if A↔B and B↔C are both bridged, A, B, C all belong to one
     group. Net names are upper-cased for case-insensitive comparison.
 
-    Name-level equivalence only — used in unit tests. Cross-directive
-    validation unions PCB net indices via
-    :func:`_union_series_bridge_net_indices` (instance-scoped expansion).
+    Name-level equivalence for unit tests. Cross-directive validation unions
+    PCB net indices via :func:`_union_series_bridge_net_indices`.
     Terminal pin resolution uses direct pad-to-net connectivity only — see
     :func:`_resolve_terminal`.
     """
@@ -1346,7 +1375,9 @@ def _collect_bridge_groups(
         if ra != rb:
             parent[rb] = ra
 
-    for p_net, n_net in _iter_series_bridge_pairs(parameter_sources, proj):
+    for _pcb_idx, p_net, n_net in _iter_series_bridge_pairs(
+        parameter_sources, proj, per_placement=False,
+    ):
         union(p_net.upper(), n_net.upper())
 
     # Materialise each equivalence class as a frozenset and map every net to it.
@@ -1369,44 +1400,20 @@ def _union_series_bridge_net_indices(
     channels in analysis-group validation.
     """
     resolver = _instance_resolver(proj)
-    for comp in parameter_sources:
-        part_role_raw = _ci_get(comp.parameters, ROLE_KEY)
-        if part_role_raw is None:
+    for pcb_idx, p_net, n_net in _iter_series_bridge_pairs(
+        parameter_sources, proj, per_placement=True,
+    ):
+        if pcb_idx is None:
             continue
-        part_role = part_role_raw.strip().upper()
-        ch_indices = [
-            idx for idx in _discover_channel_indices(comp.parameters, "R")
-            if _effective_role(comp.parameters, idx, part_role)
-            in _RESISTOR_LIKE_ROLES
-        ]
-        if not ch_indices:
-            continue
-        for pcb_idx in _pcb_indices_for_source(comp, proj):
-            for ch_idx in ch_indices:
-                p_net = _ci_get(comp.parameters, _channel_key("P_NET", ch_idx))
-                n_net = _ci_get(comp.parameters, _channel_key("N_NET", ch_idx))
-                if p_net is None and n_net is None and \
-                        _ci_get(comp.parameters, _channel_key("P_PINS", ch_idx)) is None and \
-                        _ci_get(comp.parameters, _channel_key("N_PINS", ch_idx)) is None:
-                    if len(ch_indices) == 1:
-                        inferred = _autoinfer_2pin_nets(proj, pcb_idx)
-                        if inferred is not None:
-                            p_net, n_net = inferred
-                        else:
-                            continue
-                    else:
-                        continue
-                if not p_net or not n_net:
-                    continue
-                idxs: list[int] = []
-                for name in (p_net, n_net):
-                    for expanded in resolver.expand_net_names(
-                        name, pcb_index=pcb_idx,
-                    ):
-                        idxs.extend(_net_indices_by_name(proj, expanded))
-                unique_idxs = list(dict.fromkeys(idxs))
-                for other in unique_idxs[1:]:
-                    union(unique_idxs[0], other)
+        idxs: list[int] = []
+        for name in (p_net, n_net):
+            for expanded in resolver.expand_net_names(
+                name, pcb_index=pcb_idx,
+            ):
+                idxs.extend(_net_indices_by_name(proj, expanded))
+        unique_idxs = list(dict.fromkeys(idxs))
+        for other in unique_idxs[1:]:
+            union(unique_idxs[0], other)
 
 
 def _autoinfer_2pin_nets(proj: ExtractedProject, pcb_index: int) -> tuple[str, str] | None:

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -142,7 +142,7 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
@@ -724,9 +724,12 @@ class InstanceLocalNetResolver:
         if cached is not None:
             return cached
 
-        names: set[str] = set(_netlist_label_family(
-            self.proj.compiled_netlist, local_name,
-        ))
+        if pcb_index is None:
+            names: set[str] = set(_netlist_label_family(
+                self.proj.compiled_netlist, local_name,
+            ))
+        else:
+            names = {local_name.upper()}
 
         if self.proj.compiled_netlist is not None:
             indices = (
@@ -943,21 +946,22 @@ def _resolve_alias_fallback_pads(
         if pin_key in seen_pins:
             continue
         pcb_n = proj.nets[pad.net_index].name.upper()
-        for nl_pin, names, sheets in netlist_index.get(
-            sch_lookup_designator.upper(), (),
-        ):
-            if nl_pin != pin_key or pcb_n not in names:
-                continue
-            if not any(
-                _local_net_label_matches(n, net_name, des_candidates)
-                for n in names
-            ):
-                continue
-            if not _sheet_name_matches(schdoc_name, list(sheets)):
-                continue
-            matched.append(pad)
-            seen_pins.add(pin_key)
-            break
+        for des_key in des_candidates:
+            for nl_pin, names, sheets in netlist_index.get(des_key, ()):
+                if nl_pin != pin_key or pcb_n not in names:
+                    continue
+                if not any(
+                    _local_net_label_matches(n, net_name, des_candidates)
+                    for n in names
+                ):
+                    continue
+                if not _sheet_name_matches(schdoc_name, list(sheets)):
+                    continue
+                matched.append(pad)
+                seen_pins.add(pin_key)
+                break
+            if pin_key in seen_pins:
+                break
     return matched
 
 
@@ -1335,6 +1339,58 @@ def _collect_bridge_groups(
         root = find(net)
         classes.setdefault(root, set()).add(net)
     return {net: frozenset(classes[find(net)]) for net in parent}
+
+
+def _union_series_bridge_net_indices(
+    proj: ExtractedProject,
+    parameter_sources: list[PdnParameterSource],
+    union: Callable[[int, int], None],
+) -> None:
+    """Union PCB net indices for each SERIES placement, scoped to that instance.
+
+    Local net names are expanded with :meth:`InstanceLocalNetResolver.expand_net_names`
+    ``pcb_index`` so channel slots from one repeated sheet do not bridge unrelated
+    channels in analysis-group validation.
+    """
+    resolver = _instance_resolver(proj)
+    for comp in parameter_sources:
+        part_role_raw = _ci_get(comp.parameters, ROLE_KEY)
+        if part_role_raw is None:
+            continue
+        part_role = part_role_raw.strip().upper()
+        ch_indices = [
+            idx for idx in _discover_channel_indices(comp.parameters, "R")
+            if _effective_role(comp.parameters, idx, part_role)
+            in _RESISTOR_LIKE_ROLES
+        ]
+        if not ch_indices:
+            continue
+        for pcb_idx in _pcb_indices_for_source(comp, proj):
+            for ch_idx in ch_indices:
+                p_net = _ci_get(comp.parameters, _channel_key("P_NET", ch_idx))
+                n_net = _ci_get(comp.parameters, _channel_key("N_NET", ch_idx))
+                if p_net is None and n_net is None and \
+                        _ci_get(comp.parameters, _channel_key("P_PINS", ch_idx)) is None and \
+                        _ci_get(comp.parameters, _channel_key("N_PINS", ch_idx)) is None:
+                    if len(ch_indices) == 1:
+                        inferred = _autoinfer_2pin_nets(proj, pcb_idx)
+                        if inferred is not None:
+                            p_net, n_net = inferred
+                        else:
+                            continue
+                    else:
+                        continue
+                if not p_net or not n_net:
+                    continue
+                idxs: list[int] = []
+                for name in (p_net, n_net):
+                    for expanded in resolver.expand_net_names(
+                        name, pcb_index=pcb_idx,
+                    ):
+                        idxs.extend(_net_indices_by_name(proj, expanded))
+                unique_idxs = list(dict.fromkeys(idxs))
+                for other in unique_idxs[1:]:
+                    union(unique_idxs[0], other)
 
 
 def _autoinfer_2pin_nets(proj: ExtractedProject, pcb_index: int) -> tuple[str, str] | None:
@@ -2213,8 +2269,9 @@ def _spec_terminals(d: DirectiveSpec) -> list[TerminalSpec]:
 
 
 def _validate_directive_groups(result: AnnotationResult,
-                               proj: ExtractedProject,
-                               bridge_groups: dict[str, frozenset[str]]) -> None:
+                               proj: ExtractedProject | None,
+                               parameter_sources: list[PdnParameterSource]
+                               | None = None) -> None:
     """Cross-directive checks on every analysis group + return-node grouping.
 
     An *analysis group* is a set of directives that share copper (their
@@ -2263,14 +2320,8 @@ def _validate_directive_groups(result: AnnotationResult,
             union(nets[0], other)
     # SERIES bridges (ferrite / 0 Ω link) join the nets they span, so a
     # point-to-point check across one stays a single group.
-    resolver = _instance_resolver(proj)
-    for group in bridge_groups.values():
-        idxs: list[int] = []
-        for name in group:
-            for expanded in resolver.expand_net_names(name):
-                idxs.extend(_net_indices_by_name(proj, expanded))
-        for other in idxs[1:]:
-            union(idxs[0], other)
+    if proj is not None and parameter_sources:
+        _union_series_bridge_net_indices(proj, parameter_sources, union)
 
     groups: dict[int, list[DirectiveSpec]] = {}
     for d in directives:
@@ -2570,7 +2621,7 @@ def parse_annotations(proj: ExtractedProject,
                 result.directives.extend(specs)
 
     # Cross-directive checks (mode consistency, open-loop) + return grouping.
-    _validate_directive_groups(result, proj, bridge_groups)
+    _validate_directive_groups(result, proj, parameter_sources)
     return result
 
 

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -914,6 +914,53 @@ def _terminal_layer_for_pad(pad: RawPad, enabled_layers: list[int]) -> int:
     return pad.layer_id
 
 
+def _resolve_alias_fallback_pads(
+    proj: ExtractedProject,
+    component_pads: list[RawPad],
+    net_name: str,
+    sch_lookup_designator: str,
+    schdoc_name: str,
+    pcb_designator: str,
+) -> list[RawPad]:
+    """Match pads via compiled-netlist aliases when pin-local resolution failed.
+
+    Only accepts a pad when its pin appears on a netlist row for the schematic
+    designator, the row's label class matches ``net_name``, the pad's PCB net is
+    listed on that row, and the row's sheet matches ``schdoc_name``. The broad
+    ``family`` match (all pads on any equivalent label) is intentionally omitted
+    to avoid cross-channel leaks when several channel nets share one local alias.
+    """
+    if proj.compiled_netlist is None:
+        return []
+    netlist_index = _build_netlist_designator_index(proj.compiled_netlist)
+    des_candidates = _designator_candidates(sch_lookup_designator, pcb_designator)
+    matched: list[RawPad] = []
+    seen_pins: set[str] = set()
+    for pad in component_pads:
+        if pad.net_index == NO_NET:
+            continue
+        pin_key = pad.designator.upper()
+        if pin_key in seen_pins:
+            continue
+        pcb_n = proj.nets[pad.net_index].name.upper()
+        for nl_pin, names, sheets in netlist_index.get(
+            sch_lookup_designator.upper(), (),
+        ):
+            if nl_pin != pin_key or pcb_n not in names:
+                continue
+            if not any(
+                _local_net_label_matches(n, net_name, des_candidates)
+                for n in names
+            ):
+                continue
+            if not _sheet_name_matches(schdoc_name, list(sheets)):
+                continue
+            matched.append(pad)
+            seen_pins.add(pin_key)
+            break
+    return matched
+
+
 def _resolve_terminal(
     proj: ExtractedProject,
     pcb_index: int,
@@ -1024,27 +1071,29 @@ def _resolve_terminal(
             and sch_lookup_designator
             and proj.compiled_netlist is not None
         ):
-            family = _netlist_label_family(proj.compiled_netlist, net_name)
-            netlist_index = _build_netlist_designator_index(proj.compiled_netlist)
-            alias_matched: list[RawPad] = []
-            for pad in component_pads:
-                if pad.net_index == NO_NET:
-                    continue
-                pcb_n = proj.nets[pad.net_index].name.upper()
-                if pcb_n in family:
-                    alias_matched.append(pad)
-                    continue
-                pin_key = pad.designator.upper()
-                for nl_pin, names, sheets in netlist_index.get(
-                    sch_lookup_designator.upper(), (),
-                ):
-                    if nl_pin != pin_key or pcb_n not in names:
-                        continue
-                    if _sheet_name_matches(schdoc_name or "", list(sheets)):
-                        alias_matched.append(pad)
-                        break
+            alias_matched = _resolve_alias_fallback_pads(
+                proj,
+                component_pads,
+                net_name,
+                sch_lookup_designator,
+                schdoc_name or "",
+                designator,
+            )
             if alias_matched:
                 matched = alias_matched
+                if warnings is not None:
+                    pcb_net_names = sorted({
+                        proj.nets[p.net_index].name
+                        for p in matched
+                        if p.net_index != NO_NET
+                    })
+                    nets_text = ", ".join(pcb_net_names) if pcb_net_names else "?"
+                    warnings.append(
+                        f"{role_diagnostic}: resolved local net "
+                        f"{net_name!r} via netlist alias on pin(s) "
+                        f"{sorted(p.designator for p in matched)} "
+                        f"→ PCB net(s) {nets_text}"
+                    )
 
         if not matched and proj.compiled_netlist is None:
             for candidate in _degraded_pcb_net_candidates(net_name, designator):

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -199,7 +199,7 @@ def _two_terminal_sink(p_net: int, n_net: int, des: str = "U2") -> SinkSpec:
 def test_single_net_group_ok_and_shares_return_group():
     result = AnnotationResult(directives=[
         _single_source(0), _single_sink(0)])
-    _validate_directive_groups(result, None, {})
+    _validate_directive_groups(result, None)
     assert not result.errors
     assert {d.return_group for d in result.directives} == {0}
 
@@ -209,13 +209,13 @@ def test_single_net_open_loop_source_without_sink_is_not_an_error():
     # loader._flag_open_loop_rails (so the rail is skipped + warned, not a
     # whole-board hard error). Validation must no longer error here.
     result = AnnotationResult(directives=[_single_source(0)])
-    _validate_directive_groups(result, None, {})
+    _validate_directive_groups(result, None)
     assert not result.errors
 
 
 def test_single_net_open_loop_sink_without_source_is_not_an_error():
     result = AnnotationResult(directives=[_single_sink(0)])
-    _validate_directive_groups(result, None, {})
+    _validate_directive_groups(result, None)
     assert not result.errors
 
 
@@ -223,7 +223,7 @@ def test_group_may_not_mix_single_net_and_two_terminal():
     # Single-net SOURCE and a two-terminal SINK both touch net 0.
     result = AnnotationResult(directives=[
         _single_source(0), _two_terminal_sink(0, 1)])
-    _validate_directive_groups(result, None, {})
+    _validate_directive_groups(result, None)
     assert any("mixes single-net" in e for e in result.errors)
 
 
@@ -231,7 +231,7 @@ def test_independent_single_net_groups_get_distinct_return_groups():
     result = AnnotationResult(directives=[
         _single_source(0, "J1"), _single_sink(0, "U1"),
         _single_source(5, "J2"), _single_sink(5, "U2")])
-    _validate_directive_groups(result, None, {})
+    _validate_directive_groups(result, None)
     assert not result.errors
     by_des = {d.designator: d for d in result.directives}
     assert by_des["J1"].return_group == by_des["U1"].return_group
@@ -245,7 +245,7 @@ def test_two_terminal_only_board_is_unaffected():
         SourceSpec(designator="U1", schdoc_name="s.SchDoc", voltage=5.0,
                    p=_term(0), n=_term(1)),
         _two_terminal_sink(0, 1, des="U2")])
-    _validate_directive_groups(result, None, {})
+    _validate_directive_groups(result, None)
     assert not result.errors
     assert all(d.return_group is None for d in result.directives)
 
@@ -1159,6 +1159,183 @@ def test_alias_fallback_no_cross_channel_family_leak():
     assert len(spec.pins) == 1
     assert spec.pins[0].pad_designator == "2"
     assert spec.pins[0].net_index == 1
+
+
+def test_alias_fallback_flattened_terminal_designator():
+    """Alias fallback must query netlist rows keyed by flattened designators."""
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="IOUT3",
+            aliases=["S00A.4"],
+            source_sheets=["Child.SchDoc"],
+            terminals=[_FakeTerminal("J3.4", "29")],
+        ),
+    ])
+    proj = _minimal_proj(
+        nets=(RawNet("IOUT3"), RawNet("GND")),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J3.4", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="CONN", source_designator="J3",
+            ),
+        ),
+        pads=(_pad(0, "29", 0, 0),),
+        compiled_netlist=netlist,
+    )
+    with patch(
+        "fypa.altium.annotations._resolve_local_net_pins",
+        return_value=[],
+    ):
+        spec, errors = _resolve_terminal(
+            proj, 0, "S00A", None, [1], "SINK P",
+            sch_lookup_designator="J3", schdoc_name="Child.SchDoc",
+        )
+    assert not errors
+    assert spec is not None
+    assert spec.pins[0].pad_designator == "29"
+    assert spec.pins[0].net_index == 0
+
+
+def test_bridge_validation_scoped_per_instance_no_cross_channel_merge():
+    """SERIES bridge expansion must not union slotted nets across channels."""
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="NET_A.1",
+            aliases=["NET_A"],
+            source_sheets=["ch1.schdoc"],
+            terminals=[_FakeTerminal("R1", "1")],
+        ),
+        _FakeNet(
+            name="NET_B.1",
+            aliases=["NET_B"],
+            source_sheets=["ch1.schdoc"],
+            terminals=[
+                _FakeTerminal("R1", "2"),
+                _FakeTerminal("U1", "1"),
+            ],
+        ),
+        _FakeNet(
+            name="NET_A.2",
+            aliases=["NET_A"],
+            source_sheets=["ch2.schdoc"],
+            terminals=[_FakeTerminal("R1", "1")],
+        ),
+        _FakeNet(
+            name="NET_B.2",
+            aliases=["NET_B"],
+            source_sheets=["ch2.schdoc"],
+            terminals=[
+                _FakeTerminal("R1", "2"),
+                _FakeTerminal("U2", "1"),
+            ],
+        ),
+    ])
+    proj = _minimal_proj(
+        nets=(
+            RawNet("NET_A.1"), RawNet("NET_B.1"),
+            RawNet("NET_A.2"), RawNet("NET_B.2"),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="R1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1005R", source_designator="R1",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN1_R": "0.01",
+                    "PDN1_P_NET": "NET_A",
+                    "PDN1_N_NET": "NET_B",
+                },
+            ),
+            RawPcbComponent(
+                designator="R1.2", center=Pt2D(1, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1005R", source_designator="R1",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN1_R": "0.01",
+                    "PDN1_P_NET": "NET_A",
+                    "PDN1_N_NET": "NET_B",
+                },
+            ),
+            RawPcbComponent(
+                designator="U1.1", center=Pt2D(2, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOIC", source_designator="U1",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "10mA",
+                    "PDN_NET": "NET_B",
+                },
+            ),
+            RawPcbComponent(
+                designator="U2.2", center=Pt2D(3, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOIC", source_designator="U2",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "20mA",
+                    "PDN_NET": "NET_B",
+                },
+            ),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="ch1.SchDoc",
+                parameters={"Comment": "IC"}, pin_designators=("1",),
+            ),
+            RawSchComponent(
+                designator="U2", schdoc_name="ch2.SchDoc",
+                parameters={"Comment": "IC"}, pin_designators=("1",),
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 0, 0), _pad(0, "2", 1, 1),
+            _pad(1, "1", 0, 2), _pad(1, "2", 1, 3),
+            _pad(2, "1", 1, 1),
+            _pad(3, "1", 3, 3),
+        ),
+        compiled_netlist=netlist,
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 2
+    by_des = {d.designator: d for d in sinks}
+    assert by_des["U1.1"].return_group != by_des["U2.2"].return_group
+
+
+def test_expand_net_names_scoped_to_pcb_instance():
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="VCC_EFUSE",
+            source_sheets=["efuse.schdoc"],
+            terminals=[_FakeTerminal("R63", "2")],
+        ),
+    ])
+    proj = _minimal_proj(
+        nets=(
+            RawNet("VDD_5V0"),
+            RawNet("VCC_EFUSE.1"),
+            RawNet("VCC_EFUSE.4"),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="R63.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1005R", source_designator="R63",
+            ),
+            RawPcbComponent(
+                designator="R63.4", center=Pt2D(1, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1005R", source_designator="R63",
+            ),
+        ),
+        pads=(
+            _pad(0, "2", 1, 0),
+            _pad(1, "2", 2, 1),
+        ),
+        compiled_netlist=netlist,
+    )
+    resolver = _instance_resolver(proj)
+    assert "VCC_EFUSE.1" in resolver.expand_net_names("VCC_EFUSE", pcb_index=0)
+    assert "VCC_EFUSE.4" not in resolver.expand_net_names("VCC_EFUSE", pcb_index=0)
+    assert "VCC_EFUSE.4" in resolver.expand_net_names("VCC_EFUSE", pcb_index=1)
+    assert "VCC_EFUSE.1" not in resolver.expand_net_names("VCC_EFUSE", pcb_index=1)
 
 
 def test_bridge_groups_expand_slotted_local_names():

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -29,6 +29,7 @@ from fypa.altium.annotations import (
     _resolve_local_net_pins,
     _resolve_terminal,
     _schdoc_for_pcb_instance,
+    _instance_resolver,
     _sheet_name_matches,
     _terminal_mode,
     _validate_directive_groups,
@@ -941,6 +942,234 @@ def test_pcb_sourced_local_net_scoped_per_instance():
     by_des = {d.designator: d for d in sinks}
     assert by_des["U1_CH1"].p.pins[0].net_index == 1
     assert by_des["U1_CH2"].p.pins[0].net_index == 2
+
+
+def test_pcb_sourced_reused_sheet_slotted_local_net():
+    """PCB ECO on a repeated sheet: local net VCC_EFUSE → VCC_EFUSE.N on PCB."""
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="VCC_EFUSE",
+            source_sheets=["efuse.schdoc"],
+            terminals=[_FakeTerminal("R63", "2")],
+        ),
+        _FakeNet(
+            name="VDD_5V0",
+            aliases=["VDD_5V0.1", "VDD_5V0.2", "VDD_5V0.3", "VDD_5V0.4"],
+            source_sheets=["can-phy.schdoc", "efuse.schdoc"],
+            terminals=[_FakeTerminal("R63", "1")],
+        ),
+    ])
+    proj = _minimal_proj(
+        nets=(
+            RawNet("VDD_5V0"),
+            RawNet("VCC_EFUSE.1"),
+            RawNet("VCC_EFUSE.4"),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="R63.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1005R", source_designator="R63",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN1_R": "0.01",
+                    "PDN1_P_NET": "VDD_5V0",
+                    "PDN1_N_NET": "VCC_EFUSE",
+                },
+            ),
+            RawPcbComponent(
+                designator="R63.4", center=Pt2D(3, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1005R", source_designator="R63",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN1_R": "0.01",
+                    "PDN1_P_NET": "VDD_5V0",
+                    "PDN1_N_NET": "VCC_EFUSE",
+                },
+            ),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="R63", schdoc_name="efuse.SchDoc",
+                parameters={"Comment": "0R"}, pin_designators=("1", "2"),
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 0, 0),
+            _pad(0, "2", 1, 1),
+            _pad(1, "1", 0, 2),
+            _pad(1, "2", 2, 3),
+        ),
+        compiled_netlist=netlist,
+    )
+    assert _schdoc_for_pcb_instance(proj, 0, "R63") == "efuse.schdoc"
+    assert _schdoc_for_pcb_instance(proj, 1, "R63") == "efuse.schdoc"
+
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    series = [d for d in result.directives if isinstance(d, ResistorSpec)]
+    assert len(series) == 2
+    by_des = {d.designator: d for d in series}
+    assert by_des["R63.1"].n.pins[0].net_index == 1
+    assert by_des["R63.4"].n.pins[0].net_index == 2
+
+
+def test_resolve_local_net_pins_dot_channel_alias():
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="IOUT3",
+            aliases=["S00A.1", "S00A.4"],
+            source_sheets=["Child.SchDoc"],
+            terminals=[
+                _FakeTerminal("J3.1", "29"),
+                _FakeTerminal("J3.4", "29"),
+            ],
+        ),
+    ])
+    pins = _resolve_local_net_pins(
+        netlist, "J3", "Child.SchDoc", "S00A",
+        pcb_designator="J3.4",
+    )
+    assert pins == ["29"]
+
+
+def test_resolve_local_net_pins_dot_channel_alias_scoped():
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="IOUT_OTHER",
+            aliases=["S00A.1"],
+            source_sheets=["Child.SchDoc"],
+            terminals=[_FakeTerminal("J3.4", "29")],
+        ),
+    ])
+    pins = _resolve_local_net_pins(
+        netlist, "J3", "Child.SchDoc", "S00A",
+        pcb_designator="J3.4",
+    )
+    assert pins == []
+
+
+def test_schdoc_inference_pin_centric_without_net_name_match():
+    """PCB net VCC_EFUSE.4 must not block efuse.SchDoc vote via pin 2 alone."""
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="VCC_EFUSE",
+            source_sheets=["efuse.schdoc"],
+            terminals=[_FakeTerminal("R63", "2")],
+        ),
+        _FakeNet(
+            name="VDD_5V0",
+            aliases=["VDD_5V0.4"],
+            source_sheets=["can-phy.schdoc", "efuse.schdoc"],
+            terminals=[_FakeTerminal("R63", "1")],
+        ),
+    ])
+    proj = _minimal_proj(
+        nets=(RawNet("VDD_5V0"), RawNet("VCC_EFUSE.4")),
+        pcb_components=(
+            RawPcbComponent(
+                designator="R63.4", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1005R", source_designator="R63",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 0, 0),
+            _pad(0, "2", 1, 1),
+        ),
+        compiled_netlist=netlist,
+    )
+    assert _schdoc_for_pcb_instance(proj, 0, "R63") == "efuse.schdoc"
+
+
+def test_variant_alias_pattern_via_pad_netlist():
+    """MDI.TD_P4 style aliases resolve via pad/netlist cross-check."""
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="MDI.TD_P",
+            aliases=["MDI.TD_P4"],
+            source_sheets=["eth.schdoc"],
+            terminals=[_FakeTerminal("R1", "1")],
+        ),
+    ])
+    proj = _minimal_proj(
+        nets=(RawNet("MDI.TD_P4"), RawNet("GND")),
+        pcb_components=(
+            RawPcbComponent(
+                designator="R1_D4", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="0402", source_designator="R1",
+            ),
+        ),
+        pads=(_pad(0, "1", 0, 0), _pad(0, "2", 1, 1)),
+        compiled_netlist=netlist,
+    )
+    spec, errors = _resolve_terminal(
+        proj, 0, "MDI.TD_P", None, [1], "SERIES P",
+        sch_lookup_designator="R1", schdoc_name="eth.schdoc",
+    )
+    assert not errors
+    assert spec is not None
+    assert spec.pins[0].net_index == 0
+
+
+def test_bridge_groups_expand_slotted_local_names():
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="VCC_EFUSE",
+            source_sheets=["efuse.schdoc"],
+            terminals=[_FakeTerminal("R63", "2")],
+        ),
+        _FakeNet(
+            name="VDD_5V0",
+            source_sheets=["efuse.schdoc"],
+            terminals=[_FakeTerminal("R63", "1")],
+        ),
+    ])
+    proj = _minimal_proj(
+        nets=(RawNet("VDD_5V0"), RawNet("VCC_EFUSE.4")),
+        pcb_components=(
+            RawPcbComponent(
+                designator="R63.4", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1005R", source_designator="R63",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN1_R": "0.01",
+                    "PDN1_P_NET": "VDD_5V0",
+                    "PDN1_N_NET": "VCC_EFUSE",
+                },
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 0, 0),
+            _pad(0, "2", 1, 1),
+        ),
+        compiled_netlist=netlist,
+    )
+    expanded = _instance_resolver(proj).expand_net_names("VCC_EFUSE")
+    assert "VCC_EFUSE" in expanded
+    assert "VCC_EFUSE.4" in expanded
+
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+
+
+def test_resolve_terminal_no_double_suffix_on_qualified_net():
+    """Degraded mode must not append another channel suffix to VCC_EFUSE.4."""
+    proj = _minimal_proj(
+        nets=(RawNet("VCC_EFUSE.4"),),
+        pcb_components=(
+            RawPcbComponent(
+                designator="R63.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1005R", source_designator="R63",
+            ),
+        ),
+        pads=(_pad(0, "2", 0, 0),),
+        compiled_netlist=None,
+    )
+    spec, errors = _resolve_terminal(
+        proj, 0, "VCC_EFUSE.4", None, [1], "SERIES N",
+    )
+    assert not errors
+    assert spec is not None
+    assert spec.pins[0].net_index == 0
 
 
 def test_local_fallback_skips_no_net_pad():

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1082,6 +1082,40 @@ def test_schdoc_inference_pin_centric_without_net_name_match():
     assert _schdoc_for_pcb_instance(proj, 0, "R63") == "efuse.schdoc"
 
 
+def test_schdoc_inference_flattened_terminal_designator():
+    """Netlist terminals keyed as J3.4 must vote when lookup designator is J3."""
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="IOUT3",
+            aliases=["S00A.4"],
+            source_sheets=["Child.SchDoc"],
+            terminals=[_FakeTerminal("J3.4", "29")],
+        ),
+    ])
+    proj = _minimal_proj(
+        nets=(RawNet("IOUT3"),),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J3.4", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="CONN", source_designator="J3",
+            ),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="J3", schdoc_name="Other.SchDoc",
+                parameters={"Comment": "CONN"}, pin_designators=("29",),
+            ),
+            RawSchComponent(
+                designator="J3", schdoc_name="Child.SchDoc",
+                parameters={"Comment": "CONN"}, pin_designators=("29",),
+            ),
+        ),
+        pads=(_pad(0, "29", 0, 0),),
+        compiled_netlist=netlist,
+    )
+    assert _schdoc_for_pcb_instance(proj, 0, "J3") == "Child.SchDoc"
+
+
 def test_variant_alias_pattern_via_pad_netlist():
     """MDI.TD_P4 style aliases resolve via pad/netlist cross-check."""
     netlist = _FakeNetlist(nets=[
@@ -1371,7 +1405,9 @@ def test_bridge_groups_expand_slotted_local_names():
         ),
         compiled_netlist=netlist,
     )
-    expanded = _instance_resolver(proj).expand_net_names("VCC_EFUSE")
+    expanded = _instance_resolver(proj).expand_net_names(
+        "VCC_EFUSE", pcb_index=0,
+    )
     assert "VCC_EFUSE" in expanded
     assert "VCC_EFUSE.4" in expanded
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -8,6 +8,8 @@ assignment. See ``fypa.altium.annotations`` for the schema.
 """
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -1108,6 +1110,55 @@ def test_variant_alias_pattern_via_pad_netlist():
     assert not errors
     assert spec is not None
     assert spec.pins[0].net_index == 0
+
+
+def test_alias_fallback_no_cross_channel_family_leak():
+    """Alias fallback must not match every pad in an unscoped label family."""
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="CH1_+3V3",
+            aliases=["+3V3"],
+            source_sheets=["child1.schdoc"],
+            terminals=[
+                _FakeTerminal("U1", "1"),
+                _FakeTerminal("U1", "2"),
+            ],
+        ),
+        _FakeNet(
+            name="CH2_+3V3",
+            aliases=["+3V3"],
+            source_sheets=["child2.schdoc"],
+            terminals=[_FakeTerminal("U1", "2")],
+        ),
+    ])
+    proj = _minimal_proj(
+        nets=(RawNet("CH1_+3V3"), RawNet("CH2_+3V3"), RawNet("GND")),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1_PLACED", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOIC", source_designator="U1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 0, 0),
+            _pad(0, "2", 1, 1),
+            _pad(0, "3", 2, 2),
+        ),
+        compiled_netlist=netlist,
+    )
+    with patch(
+        "fypa.altium.annotations._resolve_local_net_pins",
+        return_value=[],
+    ):
+        spec, errors = _resolve_terminal(
+            proj, 0, "+3V3", None, [1], "SINK P",
+            sch_lookup_designator="U1", schdoc_name="child2.schdoc",
+        )
+    assert not errors
+    assert spec is not None
+    assert len(spec.pins) == 1
+    assert spec.pins[0].pad_designator == "2"
+    assert spec.pins[0].net_index == 1
 
 
 def test_bridge_groups_expand_slotted_local_names():


### PR DESCRIPTION
## Summary

Fixes **local net name resolution** when the same schematic sheet is reused (multi-instance / multi-channel designs). A schematic local name like `VCC_PORT` must map to the correct PCB net per instance (`VCC_PORT.1`, `VCC_PORT.2`, …), not a blanket alias across all placements.

Introduces `InstanceLocalNetResolver` for pin-driven, instance-scoped netlist lookup and uses it for terminal resolution and SERIES bridge validation. SERIES bridge expansion is now **per PCB placement** so repeated sheets do not cross-bridge unrelated channels.

Also includes indexed-only SERIES channel support in bridge iteration and related annotation hardening.

## Changes

- **`annotations.py`**: `InstanceLocalNetResolver`, scoped alias fallback, per-placement `_iter_series_bridge_pairs`, schdoc inference improvements
- **`loader.py`**: minor wiring for instance-scoped resolution
- **Docs**: local net names section in user guide
- **Tests**: extensive coverage for reused sheets, dot-channel aliases, PCB-sourced ECO parameters, multi-channel SERIES bridges
