### PR TITLE
Show physical PCB net names on topology port labels.

### DIFF
--- a/docs/user-guide/05-viewer-tour.md
+++ b/docs/user-guide/05-viewer-tour.md
@@ -68,6 +68,13 @@ This is **not** the PCB layout; for spatial placement use the Heatmap tab.
   the header shows the role colour and designator; the body shows the
   configured value (`PDN_V`, `PDN_I`, `PDN_R`, regulator gain).
 - **Ports** — small connectors on the left (inputs) and right (outputs).
+  Each port is labelled with the **physical PCB net name** from the pad
+  assignment (the same names you see on the Heatmap and in the Nodes
+  table), not the schematic `PDN_*_NET` text or the merged rail name from
+  the Rails list. When one directive terminal ties several pads on
+  different nets (multi-pin part), the port label lists every distinct
+  net, comma-separated. Hub resistors with several channels still show
+  one net per channel row (`N1`, `N2`, …).
 - **Wires** — orthogonal links between ports on the same electrical net,
   each labelled once above the link. Real return nets meet a horizontal
   rail below the diagram, terminated by a schematic **GND** symbol

--- a/fypa/topology/metadata/layout_bridge.py
+++ b/fypa/topology/metadata/layout_bridge.py
@@ -428,6 +428,9 @@ def _column_net(
     bridged downstream nets (VDD_MCU, LED_R, …) do not collapse onto the
     upstream rail.  Other roles keep rail-canonical names so parallel loads
     on a shared rail stay aligned.
+
+    Port labels use :func:`~fypa.topology.metadata.nets.port_display_net`
+    (physical names) — not this function.
     """
     if not term or is_ideal_return(term):
         return None
@@ -827,18 +830,31 @@ def specs_by_column(
     return by_col, max_col
 
 
-def _enrich_resolved_ports(spec: NodeSpec, net_to_rail: dict[str, str]) -> None:
+def _enrich_resolved_ports(spec: NodeSpec) -> None:
+    """Resolve wire net (``wnet``) and display label (``plabel``) per port.
+
+    ``wnet`` always comes from :func:`terminal_net` (first pin when pads
+    disagree) so routing stays on one gutter/bus per connector row.
+    ``plabel`` may list every pad net on multi-pin terminals — see
+    :func:`port_display_net`.
+    """
     resolved: dict[str, ResolvedPort] = {}
     port_directives = spec.get("port_directives") or {}
     terms = spec.get("terms") or {}
     for pname, _, _ in spec["port_defs"]:
         term = terms.get(pname)
         raw = terminal_net(term)
-        cnet = canonical_net(raw, net_to_rail) or "?"
         wnet = wire_net(raw)
         if not wnet:
             continue
-        plabel = truncate_label(port_display_net(term, cnet))
+        plabel = truncate_label(
+            port_display_net(
+                term,
+                raw,
+                role=spec.get("role", ""),
+                port_name=pname,
+            )
+        )
         resolved[pname] = ResolvedPort(
             wnet=wnet,
             plabel=plabel,
@@ -863,7 +879,7 @@ def parse_topology_directives(metadata: TopologyMetadata) -> ParsedLayoutInput:
     node_specs = directives_to_component_specs(directives, errors, net_to_rail)
     needs_gnd = False
     for spec in node_specs:
-        _enrich_resolved_ports(spec, net_to_rail)
+        _enrich_resolved_ports(spec)
         for pname, _, _ in spec["port_defs"]:
             term = (spec["terms"] or {}).get(pname)
             if canonical_net(terminal_net(term), net_to_rail) == GND_NET:

--- a/fypa/topology/metadata/nets.py
+++ b/fypa/topology/metadata/nets.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 
 from fypa.topology.constants import GND_NET, IDEAL_RETURN_RAIL
 from fypa.topology.metadata_schema import TerminalDict
@@ -14,6 +15,11 @@ log = logging.getLogger(__name__)
 # each inconsistent terminal once per process rather than per call.
 _warned_terminal_nets: set[tuple] = set()
 
+_PASSIVE_CHANNEL_PORT = re.compile(r"^(?:P|N)\d+$")
+# Passive channel rows from specs._suffix_for_channel (P1, N2, …) only.
+# Regulator rows (IN_P1, OUT_P2, …) are not matched — multi-pin there
+# lists every pad net.
+
 
 def net_to_rail_map(rail_to_members: dict[str, list[str]]) -> dict[str, str]:
     out: dict[str, str] = {}
@@ -23,6 +29,14 @@ def net_to_rail_map(rail_to_members: dict[str, list[str]]) -> dict[str, str]:
     return out
 
 
+def terminal_pin_nets(term: TerminalDict | None) -> list[str]:
+    """Distinct PCB net names on a terminal's pads, sorted for display."""
+    if not term:
+        return []
+    pins = term.get("pins") or []
+    return sorted({p.get("net") for p in pins if p.get("net")})
+
+
 def terminal_net(term: TerminalDict | None) -> str | None:
     if not term:
         return None
@@ -30,15 +44,15 @@ def terminal_net(term: TerminalDict | None) -> str | None:
         return IDEAL_RETURN_RAIL
     req = term.get("requested_net")
     pins = term.get("pins") or []
-    pin_nets = sorted({p.get("net") for p in pins if p.get("net")})
+    pin_nets = terminal_pin_nets(term)
     if len(pin_nets) > 1 or (req and pin_nets and req not in pin_nets):
         key = (req, tuple(pin_nets))
         if key not in _warned_terminal_nets:
             _warned_terminal_nets.add(key)
             if len(pin_nets) > 1:
                 log.warning(
-                    "Terminal pins disagree on net (%s); using the first pin's "
-                    "net %r (requested_net=%r).",
+                    "Terminal pins disagree on net (%s); routing uses the first "
+                    "pin's net %r (requested_net=%r).",
                     ", ".join(pin_nets), pins[0].get("net"), req,
                 )
             else:
@@ -86,10 +100,53 @@ def canonical_net(
     return net_to_rail.get(net, net)
 
 
-def port_display_net(term: TerminalDict | None, canonical: str) -> str:
+def _port_display_single_net(
+    term: TerminalDict | None,
+    physical_net: str | None,
+) -> str:
     if not term:
-        return canonical
+        return physical_net or "?"
     req = term.get("requested_net")
-    if req and canonical == GND_NET:
+    if req and physical_net and (
+        physical_net == GND_NET or is_gnd_alias(physical_net)
+    ):
         return req
-    return req or canonical
+    if physical_net and physical_net != "?":
+        return physical_net
+    return req or physical_net or "?"
+
+
+def port_display_net(
+    term: TerminalDict | None,
+    physical_net: str | None = None,
+    *,
+    role: str = "",
+    port_name: str = "",
+) -> str:
+    """Label text for a topology port — physical PCB net name(s).
+
+    ``physical_net`` is normally :func:`terminal_net` (first pin when pads
+    disagree). Rail grouping (:func:`canonical_net`, :func:`_column_net`) is
+    used only for column placement and wire grouping — not for labels — so
+    rail members keep distinct names (e.g. ``VDD_48V_PORT.1`` vs
+    ``VDD_48V_RP``).
+
+    Multi-pin terminals list every distinct pad net (comma-separated) unless
+    the port is a channel-split passive row (``N1``, ``P2``, … — ``P``/``N``
+    plus a channel index from :func:`specs._suffix_for_channel`) where each
+    row drives one gutter net. Regulator channel ports (``IN_P1``, ``OUT_P2``,
+    …) are not in that exception and list all pad nets when they disagree.
+    GND aliases still show the schematic ``requested_net`` when present.
+
+    Routing (:func:`terminal_net` → ``ResolvedPort.wnet``) always uses the
+    first pin net so each connector row still drives one wire/bus.
+    """
+    pin_nets = terminal_pin_nets(term)
+    if len(pin_nets) > 1:
+        if role in ("RESISTOR", "SERIES") and _PASSIVE_CHANNEL_PORT.match(port_name):
+            return _port_display_single_net(term, physical_net or terminal_net(term))
+        return ", ".join(pin_nets)
+    return _port_display_single_net(
+        term,
+        physical_net or (pin_nets[0] if pin_nets else None),
+    )

--- a/fypa/topology/metadata/specs.py
+++ b/fypa/topology/metadata/specs.py
@@ -241,6 +241,12 @@ def _channel_number(directive: DirectiveDict, position: int) -> int:
 
 
 def _suffix_for_channel(index: int, *, multi: bool, base: str) -> str:
+    """Suffix passive/SINK channel ports (``P1``, ``N2``, …).
+
+    Names must stay ``{P|N}<digit>`` when ``multi`` — see
+    ``_PASSIVE_CHANNEL_PORT`` in :mod:`fypa.topology.metadata.nets`
+    (hub gutter rows show one net per channel, not every pad net).
+    """
     if not multi:
         return base
     return f"{base}{index}"

--- a/tests/fixtures/topology/svg/column_gnd_feedback.svg
+++ b/tests/fixtures/topology/svg/column_gnd_feedback.svg
@@ -63,7 +63,7 @@
 <text x="500" y="51" fill="#ffffff" font-family="Segoe UI,sans-serif" font-size="10" font-weight="600">SINK</text>
 <text x="612" y="51" fill="#ffffff" text-anchor="end" font-family="Segoe UI,sans-serif" font-size="10" font-weight="600">U1</text>
 <circle cx="492" cy="75" r="5" fill="#3aa8ff" stroke="#555555" stroke-width="1"/>
-<text x="500" y="78" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">VDD_3V3</text>
+<text x="500" y="78" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">VDD_3V3_PWR</text>
 <circle cx="492" cy="93" r="5" fill="#3aa8ff" stroke="#555555" stroke-width="1"/>
 <text x="500" y="96" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">GND</text>
 <rect class="topo-hit" data-label="U3" x="492" y="138" width="128" height="74" rx="6" fill="#333333" stroke="#555555" stroke-width="1"/>
@@ -72,7 +72,7 @@
 <text x="500" y="153" fill="#ffffff" font-family="Segoe UI,sans-serif" font-size="10" font-weight="600">SINK</text>
 <text x="612" y="153" fill="#ffffff" text-anchor="end" font-family="Segoe UI,sans-serif" font-size="10" font-weight="600">U3</text>
 <circle cx="492" cy="177" r="5" fill="#3aa8ff" stroke="#555555" stroke-width="1"/>
-<text x="500" y="180" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">VDD_3V3</text>
+<text x="500" y="180" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">VDD_3V3_PWR</text>
 <circle cx="492" cy="195" r="5" fill="#3aa8ff" stroke="#555555" stroke-width="1"/>
 <text x="500" y="198" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">GND</text>
 <rect class="topo-hit" data-label="U4" x="492" y="240" width="128" height="74" rx="6" fill="#333333" stroke="#555555" stroke-width="1"/>
@@ -81,7 +81,7 @@
 <text x="500" y="255" fill="#ffffff" font-family="Segoe UI,sans-serif" font-size="10" font-weight="600">SINK</text>
 <text x="612" y="255" fill="#ffffff" text-anchor="end" font-family="Segoe UI,sans-serif" font-size="10" font-weight="600">U4</text>
 <circle cx="492" cy="279" r="5" fill="#3aa8ff" stroke="#555555" stroke-width="1"/>
-<text x="500" y="282" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">VDD_3V3</text>
+<text x="500" y="282" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">VDD_3V3_PWR</text>
 <circle cx="492" cy="297" r="5" fill="#3aa8ff" stroke="#555555" stroke-width="1"/>
 <text x="500" y="300" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">GND</text>
 <rect x="211" y="69" width="22" height="12" fill="#2b2b2b" fill-opacity="0.5" stroke="none" rx="2"/>

--- a/tests/fixtures/topology/svg/project_b_compact.svg
+++ b/tests/fixtures/topology/svg/project_b_compact.svg
@@ -55,7 +55,7 @@
 <text x="500" y="51" fill="#ffffff" font-family="Segoe UI,sans-serif" font-size="10" font-weight="600">SERIES</text>
 <text x="612" y="51" fill="#ffffff" text-anchor="end" font-family="Segoe UI,sans-serif" font-size="10" font-weight="600">R1</text>
 <circle cx="492" cy="75" r="5" fill="#1a7a3c" stroke="#555555" stroke-width="1"/>
-<text x="500" y="78" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">VDD_3V3</text>
+<text x="500" y="78" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">VDD_3V3_PWR</text>
 <circle cx="620" cy="75" r="5" fill="#1a7a3c" stroke="#555555" stroke-width="1"/>
 <text x="612" y="78" text-anchor="end" fill="#909090" font-family="Consolas,monospace" font-size="8">LED_R</text>
 <rect class="topo-hit" data-label="U1" x="720" y="36" width="128" height="74" rx="6" fill="#333333" stroke="#555555" stroke-width="1"/>
@@ -64,7 +64,7 @@
 <text x="728" y="51" fill="#ffffff" font-family="Segoe UI,sans-serif" font-size="10" font-weight="600">SINK</text>
 <text x="840" y="51" fill="#ffffff" text-anchor="end" font-family="Segoe UI,sans-serif" font-size="10" font-weight="600">U1</text>
 <circle cx="720" cy="75" r="5" fill="#3aa8ff" stroke="#555555" stroke-width="1"/>
-<text x="728" y="78" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">VDD_3V3</text>
+<text x="728" y="78" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">VDD_3V3_PWR</text>
 <circle cx="720" cy="93" r="5" fill="#3aa8ff" stroke="#555555" stroke-width="1"/>
 <text x="728" y="96" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">GND</text>
 <rect x="211" y="69" width="22" height="12" fill="#2b2b2b" fill-opacity="0.5" stroke="none" rx="2"/>

--- a/tests/fixtures/topology/svg/project_b_hub_vdd.svg
+++ b/tests/fixtures/topology/svg/project_b_hub_vdd.svg
@@ -67,7 +67,7 @@
 <text x="272" y="153" fill="#ffffff" font-family="Segoe UI,sans-serif" font-size="10" font-weight="600">SERIES</text>
 <text x="384" y="153" fill="#ffffff" text-anchor="end" font-family="Segoe UI,sans-serif" font-size="10" font-weight="600">D1</text>
 <circle cx="264" cy="177" r="5" fill="#1a7a3c" stroke="#555555" stroke-width="1"/>
-<text x="272" y="180" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">VDD_3V3</text>
+<text x="272" y="180" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">VDD_3V3_PWR</text>
 <circle cx="392" cy="177" r="5" fill="#1a7a3c" stroke="#555555" stroke-width="1"/>
 <text x="384" y="180" text-anchor="end" fill="#909090" font-family="Consolas,monospace" font-size="8">LED_R</text>
 <circle cx="392" cy="195" r="5" fill="#1a7a3c" stroke="#555555" stroke-width="1"/>
@@ -91,7 +91,7 @@
 <text x="752" y="51" fill="#ffffff" font-family="Segoe UI,sans-serif" font-size="10" font-weight="600">SINK</text>
 <text x="864" y="51" fill="#ffffff" text-anchor="end" font-family="Segoe UI,sans-serif" font-size="10" font-weight="600">U1</text>
 <circle cx="744" cy="75" r="5" fill="#3aa8ff" stroke="#555555" stroke-width="1"/>
-<text x="752" y="78" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">VDD_3V3</text>
+<text x="752" y="78" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">VDD_3V3_PWR</text>
 <circle cx="744" cy="93" r="5" fill="#3aa8ff" stroke="#555555" stroke-width="1"/>
 <text x="752" y="96" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">GND</text>
 <rect class="topo-hit" data-label="U3" x="744" y="138" width="128" height="92" rx="6" fill="#333333" stroke="#555555" stroke-width="1"/>
@@ -102,7 +102,7 @@
 <circle cx="744" cy="177" r="5" fill="#3aa8ff" stroke="#555555" stroke-width="1"/>
 <text x="752" y="180" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">VDD_1V8</text>
 <circle cx="744" cy="195" r="5" fill="#3aa8ff" stroke="#555555" stroke-width="1"/>
-<text x="752" y="198" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">VDD_3V3</text>
+<text x="752" y="198" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">VDD_3V3_PWR</text>
 <circle cx="744" cy="213" r="5" fill="#3aa8ff" stroke="#555555" stroke-width="1"/>
 <text x="752" y="216" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">GND</text>
 <rect class="topo-hit" data-label="U4" x="744" y="258" width="128" height="128" rx="6" fill="#333333" stroke="#555555" stroke-width="1"/>
@@ -117,7 +117,7 @@
 <circle cx="744" cy="333" r="5" fill="#3aa8ff" stroke="#555555" stroke-width="1"/>
 <text x="752" y="336" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">LED_B</text>
 <circle cx="744" cy="351" r="5" fill="#3aa8ff" stroke="#555555" stroke-width="1"/>
-<text x="752" y="354" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">VDD_3V3</text>
+<text x="752" y="354" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">VDD_3V3_PWR</text>
 <circle cx="744" cy="369" r="5" fill="#3aa8ff" stroke="#555555" stroke-width="1"/>
 <text x="752" y="372" text-anchor="start" fill="#909090" font-family="Consolas,monospace" font-size="8">GND</text>
 <rect x="559.1" y="327" width="31" height="12" fill="#2b2b2b" fill-opacity="0.5" stroke="none" rx="2"/>
@@ -128,8 +128,10 @@
 <text x="592" y="297" text-anchor="middle" dominant-baseline="middle" fill="#e6e6e6" font-family="Segoe UI,sans-serif" font-size="8">LED_R</text>
 <rect x="666.7" y="171" width="41.8" height="12" fill="#2b2b2b" fill-opacity="0.5" stroke="none" rx="2"/>
 <text x="687.6" y="177" text-anchor="middle" dominant-baseline="middle" fill="#e6e6e6" font-family="Segoe UI,sans-serif" font-size="8">VDD_1V8</text>
-<rect x="408.7" y="122" width="41.8" height="12" fill="#2b2b2b" fill-opacity="0.5" stroke="none" rx="2"/>
-<text x="429.6" y="128" text-anchor="middle" dominant-baseline="middle" fill="#e6e6e6" font-family="Segoe UI,sans-serif" font-size="8">VDD_3V3</text>
+<g transform="translate(708,213)">
+<rect x="-8" y="-29.7" width="16" height="59.4" fill="#2b2b2b" fill-opacity="0.5" stroke="none" rx="2"/>
+<text transform="rotate(-90)" text-anchor="middle" dominant-baseline="middle" fill="#e6e6e6" font-family="Segoe UI,sans-serif" font-size="8">VDD_3V3_PWR</text>
+</g>
 <rect x="12" y="462" width="10" height="10" rx="2" fill="#ff3030"/>
 <text x="26" y="472" fill="#909090" font-family="Segoe UI,sans-serif" font-size="10">SOURCE</text>
 <rect x="90" y="462" width="10" height="10" rx="2" fill="#3aa8ff"/>

--- a/tests/test_topology_labels.py
+++ b/tests/test_topology_labels.py
@@ -4,10 +4,225 @@ import pickle
 from pathlib import Path
 
 from fypa.topology import build_topology_model, render_topology_svg
-from fypa.topology.constants import BRIDGE_R, WIRE_EPS
+from fypa.topology.constants import BRIDGE_R, LABEL_MAX_LEN, WIRE_EPS
 from fypa.topology.geometry import compute_schematic_geometry, parse_wire_path, path_to_segments
 from fypa.topology.labels import iter_label_candidates, label_text_size
+from fypa.topology.metadata.nets import port_display_net
+from fypa.topology.util import truncate_label
+from fypa.rail_groups import compute_rail_groups
 from tests.topology_fixtures import project_b_compact_metadata, load_topology_fixture
+
+
+def test_port_display_net_prefers_physical_pin_net():
+    term = {
+        "requested_net": "VCC_PORT",
+        "resolved_via_local": True,
+        "pins": [{"net": "VCC_PORT.1", "pad": "1"}],
+    }
+    assert port_display_net(term, "VCC_PORT.1") == "VCC_PORT.1"
+
+
+def test_port_display_net_falls_back_to_requested_without_pins():
+    term = {"requested_net": "VCC_PORT", "pins": []}
+    assert port_display_net(term, "?") == "VCC_PORT"
+
+
+def test_port_display_net_not_rail_canonicalized():
+    term = {
+        "requested_net": "VDD_48V",
+        "pins": [{"net": "VDD_48V_RP", "pad": "1"}],
+    }
+    assert port_display_net(term, "VDD_48V_RP") == "VDD_48V_RP"
+
+
+def test_port_display_net_lists_multi_pin_nets():
+    term = {
+        "requested_net": "LED_R",
+        "pins": [
+            {"net": "LED_B", "pad": "1"},
+            {"net": "LED_G", "pad": "2"},
+            {"net": "LED_R", "pad": "3"},
+        ],
+    }
+    assert port_display_net(term, "LED_B", role="SINK", port_name="P") == (
+        "LED_B, LED_G, LED_R"
+    )
+
+
+def test_port_display_net_channel_passive_keeps_one_net():
+    term = {
+        "requested_net": "LED_R",
+        "pins": [
+            {"net": "LED_R", "pad": "1"},
+            {"net": "LED_B", "pad": "3"},
+            {"net": "LED_G", "pad": "2"},
+        ],
+    }
+    assert port_display_net(term, "LED_R", role="RESISTOR", port_name="N1") == "LED_R"
+
+
+def test_port_display_net_regulator_channel_lists_all_pin_nets():
+    """IN_P1 is outside the passive P/N channel exception."""
+    term = {
+        "requested_net": "VDD_3V3",
+        "pins": [
+            {"net": "VDD_3V3_A", "pad": "1"},
+            {"net": "VDD_3V3_B", "pad": "2"},
+        ],
+    }
+    assert port_display_net(
+        term, "VDD_3V3_A", role="REGULATOR", port_name="IN_P1"
+    ) == "VDD_3V3_A, VDD_3V3_B"
+
+
+def test_truncate_label_shortens_long_multi_pin_port_label():
+    label = ", ".join(["VDD_48V_PORT.1", "VDD_48V_PORT.2", "VDD_48V_PORT.3"])
+    assert len(label) > LABEL_MAX_LEN
+    assert truncate_label(label) == label[: LABEL_MAX_LEN - 1] + "…"
+
+
+def test_topology_single_channel_passive_multi_pin_lists_all_nets():
+    meta = {
+        "directives": [
+            {
+                "role": "RESISTOR",
+                "designator": "R1",
+                "terminals": {
+                    "P": {"requested_net": "VDD", "pins": [{"net": "VDD"}]},
+                    "N": {
+                        "requested_net": "LED_R",
+                        "pins": [
+                            {"net": "LED_R"},
+                            {"net": "LED_G"},
+                            {"net": "LED_B"},
+                        ],
+                    },
+                },
+            },
+        ],
+    }
+    model = build_topology_model(meta)
+    n = next(p for p in model.nodes[0].ports if p.terminal == "N")
+    assert n.label == "LED_B, LED_G, LED_R"
+
+
+def test_topology_sink_multi_pin_port_lists_all_nets():
+    meta = {
+        "directives": [
+            {
+                "role": "SOURCE",
+                "designator": "J1",
+                "terminals": {
+                    "P": {
+                        "requested_net": "VDD_3V3_PWR",
+                        "pins": [{"net": "VDD_3V3_PWR"}],
+                    },
+                    "N": {"requested_net": "GND", "pins": [{"net": "GND"}]},
+                },
+            },
+            {
+                "role": "SINK",
+                "designator": "U1",
+                "terminals": {
+                    "P": {
+                        "requested_net": "LED_R",
+                        "pins": [
+                            {"net": "LED_B"},
+                            {"net": "LED_G"},
+                            {"net": "LED_R"},
+                        ],
+                    },
+                    "N": {"requested_net": "GND", "pins": [{"net": "GND"}]},
+                },
+            },
+        ],
+    }
+    model = build_topology_model(meta)
+    u1 = next(n for n in model.nodes if n.designator == "U1")
+    p = next(p for p in u1.ports if p.terminal == "P")
+    assert p.label == "LED_B, LED_G, LED_R"
+    # Routing uses the first pin net; the label lists every pad net.
+    assert p.net == "LED_B"
+
+
+def test_topology_port_labels_not_rail_primaries():
+    """Pin nets on labels even when rails merge members (not rail primary names)."""
+    meta = {
+        "directives": [
+            {
+                "role": "SOURCE",
+                "designator": "J1",
+                "terminals": {
+                    "P": {
+                        "requested_net": "VDD_48V",
+                        "pins": [{"net": "VDD_48V_IN", "pad": "1"}],
+                    },
+                    "N": {"requested_net": "GND", "pins": [{"net": "GND", "pad": "2"}]},
+                },
+            },
+            {
+                "role": "REGULATOR",
+                "designator": "U1",
+                "terminals": {
+                    "IN_P": {
+                        "requested_net": "VDD_48V",
+                        "pins": [{"net": "VDD_48V_RP", "pad": "1"}],
+                    },
+                    "IN_N": {"requested_net": "GND", "pins": [{"net": "GND", "pad": "2"}]},
+                    "OUT_P": {
+                        "requested_net": "VOUT",
+                        "pins": [{"net": "VOUT", "pad": "3"}],
+                    },
+                    "OUT_N": {"requested_net": "GND", "pins": [{"net": "GND", "pad": "4"}]},
+                },
+            },
+            {
+                "role": "SINK",
+                "designator": "U2",
+                "terminals": {
+                    "P": {
+                        "requested_net": "VOUT",
+                        "pins": [{"net": "VDD_48V_PORT.1", "pad": "1"}],
+                    },
+                    "N": {"requested_net": "GND", "pins": [{"net": "GND", "pad": "2"}]},
+                },
+            },
+        ],
+    }
+    _, members = compute_rail_groups(meta)
+    assert {"VDD_48V_IN", "VDD_48V_RP"} <= set(members["VDD_48V"])
+    assert "VDD_48V_PORT.1" in members["VOUT"]
+    model = build_topology_model(meta)
+    j1 = next(n for n in model.nodes if n.designator == "J1")
+    u1 = next(n for n in model.nodes if n.designator == "U1")
+    u2 = next(n for n in model.nodes if n.designator == "U2")
+    assert next(p for p in j1.ports if p.terminal == "P").label == "VDD_48V_IN"
+    assert next(p for p in u1.ports if p.terminal == "IN_P").label == "VDD_48V_RP"
+    assert next(p for p in u2.ports if p.terminal == "P").label == "VDD_48V_PORT.1"
+    power_labels = [
+        p.label for n in model.nodes for p in n.ports if p.label not in ("GND", "VOUT")
+    ]
+    assert "VDD_48V" not in power_labels
+
+
+def test_topology_hub_passive_channel_ports_keep_distinct_labels():
+    """Hub D1: channel-split N1/N2/N3 rows keep one gutter net each."""
+    model = build_topology_model(load_topology_fixture("project_b_hub_vdd"))
+    d1 = next(n for n in model.nodes if n.designator == "D1")
+    labels = {p.terminal: p.label for p in d1.ports}
+    assert labels["N1"] == "LED_R"
+    assert labels["N2"] == "LED_G"
+    assert labels["N3"] == "LED_B"
+    assert all(", " not in label for label in labels.values())
+
+
+def test_topology_port_labels_use_physical_nets_for_local_resolution():
+    """project_b_compact: locally-named sink shows its PCB pin net, not VDD_3V3."""
+    model = build_topology_model(project_b_compact_metadata())
+    u1 = next(n for n in model.nodes if n.designator == "U1")
+    p_port = next(p for p in u1.ports if p.terminal == "P")
+    assert p_port.label == "VDD_3V3_PWR"
+    assert "VDD_3V3_PWR" in render_topology_svg(model)
 
 
 def _label_on_segment(wire, net_segs) -> bool:


### PR DESCRIPTION
## Show physical PCB net names on topology port labels

### Summary
- Topology port labels now show **physical PCB net names** from pad assignment (matching FEM / Nodes table), not schematic `requested_net` text or rail primary names.
- Rail grouping (`canonical_net`) is used only for **column placement**; labels no longer collapse rail members (e.g. `VDD_48V_PORT.1`, `VDD_48V_RP` instead of all `VDD_48V_IN`).
- **Multi-pin** terminals list every distinct pad net, comma-separated; hub channel rows (`N1`, `P2`, …) still show one net per gutter row.
- User guide §5.3 updated; regression tests and SVG goldens refreshed.

