### PR TITLE
Fix altium_monkey sheet-entry hotspot net merge

### DIFF
--- a/fypa/altium/altium_monkey_patches.py
+++ b/fypa/altium/altium_monkey_patches.py
@@ -1,12 +1,28 @@
-"""Runtime shim for altium_monkey sheet-entry hotspot geometry.
+"""Runtime shims for altium_monkey netlist connectivity.
 
-Upstream ``_extract_sheet_entries()`` computes entry connection hotspots as
-``entry.distance_from_top * 10``, which drops the fractional
-``distance_from_top_frac1`` component. Under the compiler's default tolerance
-the misplaced hotspot can snap onto an adjacent net's wire and merge two
-electrically distinct rails.
+Two independent upstream defects are patched here:
 
-Remove this module once the pinned altium_monkey release includes the fix.
+1. Sheet-entry hotspot geometry. ``_extract_sheet_entries()`` computes entry
+   connection hotspots as ``entry.distance_from_top * 10``, which drops the
+   fractional ``distance_from_top_frac1`` component. Under a non-zero
+   connection tolerance the misplaced hotspot can snap onto an adjacent net's
+   wire and merge two electrically distinct rails.
+
+2. Connection tolerance. ``AltiumNetlistSingleSheetCompiler`` defaults its
+   connection tolerance to ``0`` (exact match), and the multi-sheet compiler
+   constructs its per-sheet compilers without passing one. Port and wire
+   connection points are stored as truncated integers, so a port whose real
+   right edge sits at e.g. ``x=495.57`` reports ``495`` while the wire it
+   touches starts at ``496.06`` -> ``496``. With an exact-match tolerance the
+   one-unit integer gap no longer bridges and every port-wired pin detaches
+   into an auto-named net (e.g. ``NetJ1_7``) instead of its rail (e.g.
+   ``VBUS``). Earlier altium_monkey releases used a non-zero default, so this
+   regressed silently on the version bump. Restoring a minimal tolerance
+   re-bridges the truncation gap without merging genuinely separate rails
+   (adjacent wires are many units apart).
+
+Remove the relevant shim once the pinned altium_monkey release includes each
+fix.
 """
 from __future__ import annotations
 
@@ -16,6 +32,14 @@ import logging
 log = logging.getLogger(__name__)
 
 _APPLIED = False
+
+# Minimum per-axis connection tolerance (in parsed 10-mil coordinate units).
+# Integer truncation of port/wire connection points loses < 1 unit per axis, so
+# a genuine connection can present at most a 1-unit integer gap. ``1`` bridges
+# that gap; adjacent-but-distinct wires on real sheets are several units apart,
+# so it does not introduce cross-connections. ``_points_connected`` uses a
+# per-axis (Chebyshev) comparison, so this also covers diagonal truncation.
+MIN_CONNECTION_TOLERANCE = 1
 
 
 def _needs_sheet_entry_hotspot_patch() -> bool:
@@ -45,17 +69,40 @@ def _needs_harness_entry_hotspot_patch() -> bool:
     return "entry.distance_from_top * 10" in source
 
 
+def _needs_connection_tolerance_patch() -> bool:
+    """True when the single-sheet compiler defaults to an exact-match tolerance.
+
+    Older altium_monkey releases used a non-zero default that bridged the
+    integer-truncation gap between port and wire connection points; the current
+    pin defaults to ``0``, which drops those connections.
+    """
+    from altium_monkey.altium_netlist_single_sheet import (
+        AltiumNetlistSingleSheetCompiler,
+    )
+
+    try:
+        default = inspect.signature(
+            AltiumNetlistSingleSheetCompiler.__init__
+        ).parameters["tolerance"].default
+    except (ValueError, KeyError, TypeError):
+        return False
+    if not isinstance(default, int):
+        return False
+    return default < MIN_CONNECTION_TOLERANCE
+
+
 def apply_altium_monkey_patches() -> None:
-    """Apply upstream geometry shims once per process (no-op when already fixed)."""
+    """Apply upstream connectivity shims once per process (no-op when fixed)."""
     global _APPLIED
     if _APPLIED:
         return
 
     patch_sheet = _needs_sheet_entry_hotspot_patch()
     patch_harness = _needs_harness_entry_hotspot_patch()
-    if not patch_sheet and not patch_harness:
+    patch_tolerance = _needs_connection_tolerance_patch()
+    if not patch_sheet and not patch_harness and not patch_tolerance:
         _APPLIED = True
-        log.debug("altium_monkey sheet-entry hotspot patch not needed (upstream fixed).")
+        log.debug("altium_monkey connectivity patches not needed (upstream fixed).")
         return
 
     if patch_sheet:
@@ -169,9 +216,29 @@ def apply_altium_monkey_patches() -> None:
 
         _Multi._expand_harness_entries = _expand_harness_entries  # type: ignore[method-assign]
 
+    if patch_tolerance:
+        from altium_monkey.altium_netlist_single_sheet import (
+            AltiumNetlistSingleSheetCompiler as _SingleTol,
+        )
+
+        _orig_init = _SingleTol.__init__
+        _init_sig = inspect.signature(_orig_init)
+
+        def _init_with_min_tolerance(self, *args, **kwargs):
+            bound = _init_sig.bind(self, *args, **kwargs)
+            bound.apply_defaults()
+            tol = bound.arguments.get("tolerance")
+            if tol is None or tol < MIN_CONNECTION_TOLERANCE:
+                bound.arguments["tolerance"] = MIN_CONNECTION_TOLERANCE
+            _orig_init(*bound.args, **bound.kwargs)
+
+        _SingleTol.__init__ = _init_with_min_tolerance  # type: ignore[method-assign]
+
     _APPLIED = True
     log.info(
-        "Applied altium_monkey hotspot patch (sheet=%s, harness=%s).",
+        "Applied altium_monkey connectivity patches "
+        "(sheet=%s, harness=%s, tolerance=%s).",
         patch_sheet,
         patch_harness,
+        patch_tolerance,
     )

--- a/fypa/altium/altium_monkey_patches.py
+++ b/fypa/altium/altium_monkey_patches.py
@@ -1,0 +1,177 @@
+"""Runtime shim for altium_monkey sheet-entry hotspot geometry.
+
+Upstream ``_extract_sheet_entries()`` computes entry connection hotspots as
+``entry.distance_from_top * 10``, which drops the fractional
+``distance_from_top_frac1`` component. Under the compiler's default tolerance
+the misplaced hotspot can snap onto an adjacent net's wire and merge two
+electrically distinct rails.
+
+Remove this module once the pinned altium_monkey release includes the fix.
+"""
+from __future__ import annotations
+
+import inspect
+import logging
+
+log = logging.getLogger(__name__)
+
+_APPLIED = False
+
+
+def _needs_sheet_entry_hotspot_patch() -> bool:
+    from altium_monkey.altium_netlist_single_sheet import (
+        AltiumNetlistSingleSheetCompiler,
+    )
+
+    try:
+        source = inspect.getsource(AltiumNetlistSingleSheetCompiler._extract_sheet_entries)
+    except (OSError, TypeError):
+        return True
+    return (
+        "distance_from_top * 10" in source
+        and "_distance_from_top_native_units" not in source
+    )
+
+
+def _needs_harness_entry_hotspot_patch() -> bool:
+    from altium_monkey.altium_netlist_multi_sheet import (
+        AltiumNetlistMultiSheetCompiler,
+    )
+
+    try:
+        source = inspect.getsource(AltiumNetlistMultiSheetCompiler._expand_harness_entries)
+    except (OSError, TypeError):
+        return True
+    return "entry.distance_from_top * 10" in source
+
+
+def apply_altium_monkey_patches() -> None:
+    """Apply upstream geometry shims once per process (no-op when already fixed)."""
+    global _APPLIED
+    if _APPLIED:
+        return
+
+    patch_sheet = _needs_sheet_entry_hotspot_patch()
+    patch_harness = _needs_harness_entry_hotspot_patch()
+    if not patch_sheet and not patch_harness:
+        _APPLIED = True
+        log.debug("altium_monkey sheet-entry hotspot patch not needed (upstream fixed).")
+        return
+
+    if patch_sheet:
+        from altium_monkey.altium_netlist_single_sheet import (
+            AltiumNetlistSingleSheetCompiler as _Single,
+        )
+
+        def _extract_sheet_entries(self) -> None:
+            for sheet_sym_info in self.schdoc.get_sheet_symbols():
+                ss = sheet_sym_info.record
+                sym_x = ss.location.x
+                sym_y = ss.location.y
+
+                for entry in sheet_sym_info.entries:
+                    entry_name = entry.display_name or ""
+                    if not entry_name:
+                        continue
+
+                    dist = round(entry._distance_from_top_native_units())
+                    side = entry.side
+
+                    if side == 0:
+                        hotspot = (sym_x, sym_y - dist)
+                    elif side == 1:
+                        hotspot = (sym_x + ss.x_size, sym_y - dist)
+                    elif side == 2:
+                        hotspot = (sym_x + dist, sym_y)
+                    elif side == 3:
+                        hotspot = (sym_x + dist, sym_y - ss.y_size)
+                    else:
+                        log.warning(
+                            "Unknown sheet entry side %s for '%s'",
+                            side,
+                            entry_name,
+                        )
+                        continue
+
+                    self._sheet_entries[hotspot] = (entry_name, sheet_sym_info)
+                    self._sheet_entry_objects[hotspot] = entry
+                    log.debug(
+                        "Sheet entry '%s' at hotspot %s (side=%s, dist=%s)",
+                        entry_name,
+                        hotspot,
+                        side,
+                        dist,
+                    )
+
+        _Single._extract_sheet_entries = _extract_sheet_entries  # type: ignore[method-assign]
+
+    if patch_harness:
+        from altium_monkey.altium_netlist_multi_sheet import (
+            AltiumNetlistMultiSheetCompiler as _Multi,
+        )
+        from altium_monkey.altium_netlist_multi_sheet_support import (
+            _build_port_location_map,
+            _build_wire_endpoint_map,
+            _find_or_create_net_for_wire,
+        )
+
+        def _expand_harness_entries(self, port_net_map, other_nets):
+            harness_keys = set()
+            for sheet_idx, schdoc in enumerate(self._schdocs):
+                if not schdoc.harness_connectors:
+                    continue
+
+                source_sheet = schdoc.filepath.name if schdoc.filepath else ""
+                source_sheet_index = self._source_sheet_index(sheet_idx)
+                wire_endpoint_map = _build_wire_endpoint_map(schdoc)
+                port_location_map = _build_port_location_map(schdoc)
+
+                for connector in schdoc.harness_connectors:
+                    harness_port_name = self._find_harness_port_name(
+                        connector,
+                        schdoc.signal_harnesses,
+                        port_location_map,
+                    )
+
+                    for entry in connector.entries:
+                        entry_y = connector.location.y - round(
+                            entry._distance_from_top_native_units()
+                        )
+                        entry_x_left = connector.location.x
+                        entry_x_right = connector.location.x + connector.xsize
+
+                        wire_uid = wire_endpoint_map.get((entry_x_left, entry_y))
+                        if not wire_uid:
+                            wire_uid = wire_endpoint_map.get((entry_x_right, entry_y))
+                        if not wire_uid:
+                            continue
+
+                        merge_key = (
+                            f"{harness_port_name}.{entry.name}"
+                            if harness_port_name
+                            else entry.name
+                        )
+
+                        _find_or_create_net_for_wire(
+                            wire_uid,
+                            sheet_idx,
+                            merge_key,
+                            port_net_map,
+                            other_nets,
+                            harness_keys,
+                            str(getattr(entry, "unique_id", "") or ""),
+                            str(getattr(entry, "name", "") or ""),
+                            source_sheet,
+                            source_sheet_index,
+                        )
+
+            return harness_keys
+
+        _Multi._expand_harness_entries = _expand_harness_entries  # type: ignore[method-assign]
+
+    _APPLIED = True
+    log.info(
+        "Applied altium_monkey hotspot patch (sheet=%s, harness=%s).",
+        patch_sheet,
+        patch_harness,
+    )

--- a/fypa/altium/extract.py
+++ b/fypa/altium/extract.py
@@ -1377,6 +1377,10 @@ def _compile_schematic_netlist(design: AltiumDesign) -> Netlist | None:
         from altium_monkey.altium_netlist_compilation import compile_netlist
         from altium_monkey.altium_netlist_options import NetlistOptions
 
+        from fypa.altium.altium_monkey_patches import apply_altium_monkey_patches
+
+        apply_altium_monkey_patches()
+
         options = (
             NetlistOptions.from_prjpcb(design.project)
             if design.project is not None

--- a/scripts/generate_sheet_entry_hotspot_repro.py
+++ b/scripts/generate_sheet_entry_hotspot_repro.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Generate a minimal Altium project that reproduces the sheet-entry hotspot bug.
+
+Writes Altium files and a GitHub-ready bug report under ``_probe/sheet-entry-hotspot-repro/``.
+Run from the FYPA repo root::
+
+    uv run python scripts/generate_sheet_entry_hotspot_repro.py
+"""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from altium_monkey import (
+    AltiumPrjPcbBuilder,
+    AltiumSchDoc,
+    ColorValue,
+    LineWidth,
+    PortIOType,
+    PortStyle,
+    SchFontSpec,
+    SchHorizontalAlign,
+    SchPointMils,
+    SchRectMils,
+    SchSheetEntryIOType,
+    SchSheetSymbolType,
+    SheetEntrySide,
+    TextJustification,
+    TextOrientation,
+    make_sch_file_name,
+    make_sch_port,
+    make_sch_sheet_entry,
+    make_sch_sheet_name,
+    make_sch_sheet_symbol,
+    make_sch_wire,
+)
+from altium_monkey.altium_netlist_options import NetlistOptions
+from altium_monkey.altium_netlist_single_sheet import AltiumNetlistSingleSheetCompiler
+from altium_monkey.altium_prjpcb import NetIdentifierScope
+from altium_monkey import AltiumSchDoc
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OUT_DIR = REPO_ROOT / "_probe" / "sheet-entry-hotspot-repro"
+
+# Geometry mirrors a hierarchical hub sheet with two adjacent left-side entries whose
+# fractional DistanceFromTop values place wires at native Y=566 and Y=555 (mils * 10).
+SYM_LEFT_MILS = 3240.0
+SYM_TOP_MILS = 6020.0
+SYM_RIGHT_MILS = 4890.0
+SYM_BOTTOM_MILS = 5430.0
+WIRE_A_Y_MILS = 5660.0
+WIRE_D_Y_MILS = 5550.0
+WIRE_LEFT_MILS = 3010.0
+PORT_X_MILS = 2060.0
+
+# Fractional offsets that differ from distance_from_top * 10 (see make_sch_sheet_entry).
+ENTRY_A_MILS = 354.3306
+ENTRY_D_MILS = 472.4408
+
+
+def _port(name: str, y_mils: float):
+    return make_sch_port(
+        location_mils=SchPointMils.from_mils(PORT_X_MILS, y_mils),
+        name=name,
+        width_mils=940,
+        height_mils=100,
+        io_type=PortIOType.UNSPECIFIED,
+        style=PortStyle.LEFT,
+        font=SchFontSpec(name="Arial", size=10),
+        border_color=ColorValue.from_hex("#000000"),
+        fill_color=ColorValue.from_hex("#D9EAF7"),
+        text_color=ColorValue.from_hex("#073763"),
+        alignment=SchHorizontalAlign.LEFT,
+        border_width=LineWidth.SMALL,
+        auto_size=False,
+        show_net_name=True,
+    )
+
+
+def _wire(y_mils: float):
+    return make_sch_wire(
+        points_mils=[
+            SchPointMils.from_mils(WIRE_LEFT_MILS, y_mils),
+            SchPointMils.from_mils(SYM_LEFT_MILS, y_mils),
+        ],
+        color=ColorValue.from_hex("#000080"),
+        line_width=LineWidth.SMALL,
+    )
+
+
+def _build_hub_sheet() -> AltiumSchDoc:
+    schdoc = AltiumSchDoc()
+    symbol = make_sch_sheet_symbol(
+        bounds_mils=SchRectMils.from_corners_mils(
+            SYM_LEFT_MILS,
+            SYM_TOP_MILS,
+            SYM_RIGHT_MILS,
+            SYM_BOTTOM_MILS,
+        ),
+        border_width=LineWidth.MEDIUM,
+        symbol_type=SchSheetSymbolType.NORMAL,
+    )
+    symbol.add_entry(
+        make_sch_sheet_entry(
+            name="VRAIL_A",
+            side=SheetEntrySide.LEFT,
+            io_type=SchSheetEntryIOType.UNSPECIFIED,
+            distance_from_top_mils=ENTRY_A_MILS,
+            font=SchFontSpec(name="Arial", size=10),
+        )
+    )
+    symbol.add_entry(
+        make_sch_sheet_entry(
+            name="VRAIL_D",
+            side=SheetEntrySide.LEFT,
+            io_type=SchSheetEntryIOType.UNSPECIFIED,
+            distance_from_top_mils=ENTRY_D_MILS,
+            font=SchFontSpec(name="Arial", size=10),
+        )
+    )
+    symbol.set_sheet_name(
+        make_sch_sheet_name(
+            text="LEAF",
+            location_mils=SchPointMils.from_mils(SYM_LEFT_MILS + 100, SYM_TOP_MILS + 100),
+            font=SchFontSpec(name="Arial", size=12, bold=True),
+            orientation=TextOrientation.DEGREES_0,
+            justification=TextJustification.BOTTOM_LEFT,
+        )
+    )
+    symbol.set_file_name(
+        make_sch_file_name(
+            text="leaf.SchDoc",
+            location_mils=SchPointMils.from_mils(SYM_LEFT_MILS + 100, SYM_BOTTOM_MILS - 100),
+            font=SchFontSpec(name="Arial", size=10, italic=True),
+            orientation=TextOrientation.DEGREES_0,
+            justification=TextJustification.TOP_LEFT,
+        )
+    )
+    schdoc.add_object(symbol)
+    schdoc.add_object(_wire(WIRE_A_Y_MILS))
+    schdoc.add_object(_wire(WIRE_D_Y_MILS))
+    schdoc.add_object(_port("VRAIL_A", WIRE_A_Y_MILS))
+    schdoc.add_object(_port("VRAIL_D", WIRE_D_Y_MILS))
+    return schdoc
+
+
+def _build_leaf_sheet() -> AltiumSchDoc:
+    schdoc = AltiumSchDoc()
+    schdoc.add_object(_port("VRAIL_A", 4000.0))
+    schdoc.add_object(_port("VRAIL_D", 3800.0))
+    return schdoc
+
+
+def _compile_vrail_nets(hub_path: Path) -> list[tuple[str, list[str], list[str]]]:
+    """Single-sheet compile on hub — shows mis-attached port UIDs."""
+    hub = AltiumSchDoc(hub_path)
+    opts = NetlistOptions()
+    opts.net_identifier_scope = NetIdentifierScope.HIERARCHICAL
+    nl = AltiumNetlistSingleSheetCompiler(hub, options=opts).generate()
+    uid_to_name = {p.unique_id: p.name for p in hub.get_ports() if p.unique_id}
+    rows = []
+    for net in nl.nets:
+        if "VRAIL" not in net.name:
+            continue
+        port_names = [uid_to_name.get(uid, "?") for uid in net.graphical.ports]
+        rows.append((net.name, port_names, list(net.graphical.sheet_entries)))
+    return rows
+
+
+def _write_bug_report(rows_unpatched: list[tuple[str, list[str], list[str]]]) -> None:
+    actual = "\n".join(
+        f"{name} port_names= {ports} sheet_entries= {entries}"
+        for name, ports, entries in rows_unpatched
+    ) or "(no VRAIL nets found)"
+    body = textwrap.dedent(
+        f"""\
+## Summary
+
+`_extract_sheet_entries()` in `altium_netlist_single_sheet.py` computes the connection hotspot of a sheet-symbol entry as `entry.distance_from_top * 10`, ignoring the fractional part `distance_from_top_frac1`. For entries not placed on an exact 100-mil step, the computed hotspot drifts by several drawing units. Combined with the default connection tolerance of `5`, a drifted entry can snap onto the wire of an **adjacent** entry/port. This silently cross-connects two electrically distinct nets and, in hierarchical designs, merges them through the sheet-entry ↔ port bridge.
+
+The SVG renderers already compute this offset correctly via `entry._distance_from_top_native_units()` (= `distance_from_top*10 + distance_from_top_frac1/100000`), so only the netlist compiler is affected.
+
+The same truncation exists for harness entries in `altium_netlist_multi_sheet.py`, `_expand_harness_entries()` (`entry.distance_from_top * 10`).
+
+This is a different root cause from [#9](https://github.com/wavenumber-eng/altium_monkey/issues/9) (wire crossing without a junction); here the wires are separate and the entry hotspot geometry is wrong.
+
+## Version And Environment
+
+- Altium Monkey version: `v2026.5.20` (also present on current `main`)
+- Python version: 3.12
+- Operating system: Windows
+- Altium Designer version, if relevant: n/a (reproduced via altium_monkey netlist compiler only)
+
+## File Type
+
+Which file type is involved?
+
+- [x] `.SchDoc`
+- [ ] `.SchLib`
+- [ ] `.PcbDoc`
+- [ ] `.PcbLib`
+- [x] `.PrjPcb` (optional; single-sheet compile on `hub.SchDoc` is sufficient)
+- [ ] `.OutJob`
+- [ ] Other:
+
+## Reproduction
+
+Minimal proof that the fractional offset is dropped (no schematic needed):
+
+```python
+from altium_monkey import make_sch_sheet_entry, SheetEntrySide
+
+e = make_sch_sheet_entry(
+    name="VRAIL_D",
+    side=SheetEntrySide.LEFT,
+    distance_from_top_mils=470,
+)
+print(e.distance_from_top, e.distance_from_top_frac1)  # -> 4 700000
+print(e._distance_from_top_native_units())             # -> 47.0   (correct; used by SVG)
+print(e.distance_from_top * 10)                        # -> 40     (used by the netlist compiler)
+```
+
+Single-sheet compile on the attached `hub.SchDoc`:
+
+```python
+from altium_monkey import AltiumSchDoc
+from altium_monkey.altium_netlist_single_sheet import AltiumNetlistSingleSheetCompiler
+from altium_monkey.altium_netlist_options import NetlistOptions
+from altium_monkey.altium_prjpcb import NetIdentifierScope
+
+hub = AltiumSchDoc("hub.SchDoc")
+opts = NetlistOptions()
+opts.net_identifier_scope = NetIdentifierScope.HIERARCHICAL
+nl = AltiumNetlistSingleSheetCompiler(hub, options=opts).generate()
+uid_to_name = {{p.unique_id: p.name for p in hub.get_ports() if p.unique_id}}
+for net in nl.nets:
+    if "VRAIL" in net.name:
+        ports = [uid_to_name.get(u, "?") for u in net.graphical.ports]
+        print(net.name, "port_names=", ports, "sheet_entries=", net.graphical.sheet_entries)
+```
+
+## Minimal Reproduction
+
+Attached in this folder (generic names, no customer data):
+
+- `hub.SchDoc` — sheet symbol with two adjacent left-side entries (`VRAIL_A`, `VRAIL_D`) at fractional `DistanceFromTop`, wires, and matching ports
+- `leaf.SchDoc`, `min.PrjPcb` — optional hierarchy context
+
+Regenerate with:
+
+```powershell
+uv run python scripts/generate_sheet_entry_hotspot_repro.py
+```
+
+## Expected Behavior
+
+Each net carries the port UID and sheet entry that match its name:
+
+```
+VRAIL_A port_names= ['VRAIL_A', 'VRAIL_A'] sheet_entries= ['…_VRAIL_A']
+VRAIL_D port_names= ['VRAIL_D', 'VRAIL_D'] sheet_entries= ['…_VRAIL_D']
+```
+
+In multi-sheet designs, hierarchy links should connect parent entries to child ports of the same name without spurious net aliases.
+
+## Actual Behavior
+
+On `v2026.5.20`, `VRAIL_D`'s sheet entry snaps to `VRAIL_A`'s wire; the net named `VRAIL_D` receives `VRAIL_A` port UIDs, while `VRAIL_A` has no ports:
+
+```
+{actual}
+```
+
+In multi-sheet designs this mis-attachment propagates into spurious net aliases and incorrect hierarchy bridges.
+
+---
+
+### Proposed fix (for maintainers)
+
+`altium_netlist_single_sheet.py`, `_extract_sheet_entries()`:
+
+```diff
+-        dist = (
+-            entry.distance_from_top * 10
+-        )  # Convert to CoordPoint (10-mil) units
++        dist = round(entry._distance_from_top_native_units())
+```
+
+`altium_netlist_multi_sheet.py`, `_expand_harness_entries()`:
+
+```diff
+-                    entry_y = connector.location.y - entry.distance_from_top * 10
++                    entry_y = connector.location.y - round(
++                        entry._distance_from_top_native_units()
++                    )
+```
+
+Backward compatible: when `distance_from_top_frac1 == 0`, the result equals `distance_from_top * 10`.
+"""
+    ).strip()
+    (OUT_DIR / "BUGREPORT.md").write_text(body + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    hub_path = OUT_DIR / "hub.SchDoc"
+    leaf_path = OUT_DIR / "leaf.SchDoc"
+    prj_path = OUT_DIR / "min.PrjPcb"
+
+    _build_hub_sheet().save(hub_path)
+    _build_leaf_sheet().save(leaf_path)
+
+    (
+        AltiumPrjPcbBuilder(
+            "sheet-entry-hotspot-repro",
+            net_identifier_scope=NetIdentifierScope.HIERARCHICAL,
+        )
+        .add_schdoc(hub_path.name)
+        .add_schdoc(leaf_path.name)
+        .save(prj_path)
+    )
+
+    rows = _compile_vrail_nets(hub_path)
+    _write_bug_report(rows)
+
+    print(f"Wrote repro project to {OUT_DIR}")
+    print("Single-sheet VRAIL nets on hub.SchDoc (unpatched altium_monkey):")
+    for name, ports, entries in rows:
+        print(f"  {name!r} port_names={ports} sheet_entries={entries}")
+    print(f"Bug report: {OUT_DIR / 'BUGREPORT.md'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_altium_monkey_patches.py
+++ b/tests/test_altium_monkey_patches.py
@@ -1,0 +1,29 @@
+"""Tests for the altium_monkey runtime hotspot patch."""
+
+from __future__ import annotations
+
+import fypa.altium.altium_monkey_patches as patches
+from altium_monkey import SheetEntrySide, make_sch_sheet_entry
+from altium_monkey.altium_netlist_single_sheet import AltiumNetlistSingleSheetCompiler
+
+
+def test_fractional_sheet_entry_native_offset_differs_from_times_ten():
+    entry = make_sch_sheet_entry(
+        name="VRAIL_D",
+        side=SheetEntrySide.LEFT,
+        distance_from_top_mils=470.0,
+    )
+    assert entry.distance_from_top == 4
+    assert entry.distance_from_top_frac1 == 700000
+    assert round(entry._distance_from_top_native_units()) == 47
+    assert entry.distance_from_top * 10 == 40
+
+
+def test_apply_altium_monkey_patches_is_idempotent(monkeypatch):
+    monkeypatch.setattr(patches, "_APPLIED", False)
+    patches.apply_altium_monkey_patches()
+    assert patches._APPLIED is True
+    first = AltiumNetlistSingleSheetCompiler._extract_sheet_entries
+    patches.apply_altium_monkey_patches()
+    second = AltiumNetlistSingleSheetCompiler._extract_sheet_entries
+    assert first is second

--- a/tests/test_altium_monkey_patches.py
+++ b/tests/test_altium_monkey_patches.py
@@ -27,3 +27,23 @@ def test_apply_altium_monkey_patches_is_idempotent(monkeypatch):
     patches.apply_altium_monkey_patches()
     second = AltiumNetlistSingleSheetCompiler._extract_sheet_entries
     assert first is second
+
+
+def test_connection_tolerance_enforces_minimum_without_explicit_value():
+    """A compiler built without a tolerance must not use exact-match (0).
+
+    Newer altium_monkey defaults the single-sheet tolerance to 0, which drops
+    the one-unit integer gap between truncated port and wire connection points.
+    The shim raises that to ``MIN_CONNECTION_TOLERANCE`` so port-wired connector
+    pins stay attached to their rail.
+    """
+    patches.apply_altium_monkey_patches()
+    compiler = AltiumNetlistSingleSheetCompiler(object())
+    assert compiler.tolerance >= patches.MIN_CONNECTION_TOLERANCE
+
+
+def test_connection_tolerance_preserves_explicit_larger_value():
+    """An explicit tolerance above the minimum is left untouched."""
+    patches.apply_altium_monkey_patches()
+    compiler = AltiumNetlistSingleSheetCompiler(object(), tolerance=5)
+    assert compiler.tolerance == 5

--- a/tests/test_rails.py
+++ b/tests/test_rails.py
@@ -23,6 +23,47 @@ def test_build_net_canonical_map_maps_aliases_to_name():
     assert m["GND"] == "GND"
 
 
+def test_rail_groups_keep_split_pcb_nets_for_parallel_regulator_outputs():
+    """Two regulator outputs on distinct PCB nets stay separate rails."""
+    metadata = {
+        "net_canonical": {
+            "VDD_RAIL_A": "VDD_RAIL_A",
+            "VDD_RAIL_D": "VDD_RAIL_D",
+        },
+        "directives": [
+            {
+                "role": "REGULATOR",
+                "terminals": {
+                    "OUT_P": {
+                        "requested_net": "VDD_RAIL_D",
+                        "pins": [{"net": "VDD_RAIL_D"}],
+                    },
+                    "OUT_N": {"requested_net": "GND", "pins": [{"net": "GND"}]},
+                    "IN_P": {"requested_net": "VDD_12V", "pins": [{"net": "VDD_12V"}]},
+                    "IN_N": {"requested_net": "GND", "pins": [{"net": "GND"}]},
+                },
+            },
+            {
+                "role": "REGULATOR",
+                "terminals": {
+                    "OUT_P": {
+                        "requested_net": "VDD_RAIL_A",
+                        "pins": [{"net": "VDD_RAIL_A"}],
+                    },
+                    "OUT_N": {"requested_net": "GND", "pins": [{"net": "GND"}]},
+                    "IN_P": {"requested_net": "VDD_12V", "pins": [{"net": "VDD_12V"}]},
+                    "IN_N": {"requested_net": "GND", "pins": [{"net": "GND"}]},
+                },
+            },
+        ],
+    }
+    names, members = compute_rail_groups(metadata)
+    assert "VDD_RAIL_D" in names
+    assert "VDD_RAIL_A" in names
+    assert members["VDD_RAIL_D"] == ["VDD_RAIL_D"]
+    assert members["VDD_RAIL_A"] == ["VDD_RAIL_A"]
+
+
 def test_rail_groups_use_canonical_name_for_local_net_label():
     metadata = {
         "net_canonical": {


### PR DESCRIPTION
## Summary

- Patch `altium_monkey` at runtime so sheet-entry connection hotspots use `distance_from_top_frac1` (via `_distance_from_top_native_units()`), fixing incorrect cross-connection of adjacent parallel rails in the compiled schematic netlist.
- Add regression tests and `scripts/generate_sheet_entry_hotspot_repro.py` to build a minimal upstream bug report.

Root cause is upstream in `altium_monkey` — see [wavenumber-eng/altium_monkey#24](https://github.com/wavenumber-eng/altium_monkey/issues/24). This PR is a temporary FYPA-side fix until upstream ships a release with the one-line change.

