### PR TITLE
Infer SMPS Vin through SERIES chains and stabilize multi-regulator adaptive gain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ ExampleDesigns/Sandbox/*
 sanitize_sandbox.ps1
 wiring.json
 scripts/test-*.ps1
+FYPA.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,3 @@ ExampleDesigns/Sandbox/*
 sanitize_sandbox.ps1
 wiring.json
 scripts/test-*.ps1
-FYPA.code-workspace

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -1361,7 +1361,8 @@ def _has_single_net_params(params: dict[str, str],
 
 
 def _parse_source(comp, proj, enabled_layers, result, bridge_groups=None,
-                  net_remap=None, supply_map=None, only_indices=None):
+                  net_remap=None, supply_map=None, only_indices=None,
+                  series_upstream=None, ambiguous_downstream=None):
     # ``only_indices`` (from the per-channel role dispatcher) restricts this
     # parser to the channels whose effective role is SOURCE; when ``None`` the
     # whole part is SOURCE and channels are discovered here.
@@ -1438,7 +1439,8 @@ def _parse_source(comp, proj, enabled_layers, result, bridge_groups=None,
 
 
 def _parse_sink(comp, proj, enabled_layers, result, bridge_groups=None,
-                net_remap=None, supply_map=None, only_indices=None):
+                net_remap=None, supply_map=None, only_indices=None,
+                series_upstream=None, ambiguous_downstream=None):
     # ``only_indices`` restricts this parser to the part's SINK-role channels;
     # see _parse_source.
     if only_indices is not None:
@@ -1519,7 +1521,8 @@ def _parse_sink(comp, proj, enabled_layers, result, bridge_groups=None,
 
 
 def _parse_resistance(comp, proj, enabled_layers, result, bridge_groups=None,
-                      net_remap=None, supply_map=None, only_indices=None):
+                      net_remap=None, supply_map=None, only_indices=None,
+                      series_upstream=None, ambiguous_downstream=None):
     # This parser only ever handles SERIES-role channels (part-wide or a
     # PDN<n>_ROLE=SERIES override), so the role for diagnostics is always
     # SERIES regardless of the part-wide PDN_ROLE.
@@ -1672,22 +1675,120 @@ def _collect_supply_voltages_by_net(
     return out
 
 
+def _canonical_supply_net_name(
+    proj: ExtractedProject,
+    net_name: str,
+    net_remap: dict[int, int] | None = None,
+) -> str:
+    """Upper-case supply net label, optionally remapped to a merge canonical."""
+    key = net_name.strip().upper()
+    indices = _net_indices_by_name(proj, key)
+    if not indices:
+        return key
+    idx = indices[0]
+    if net_remap:
+        idx = net_remap.get(idx, idx)
+    return proj.nets[idx].name.upper()
+
+
+def _collect_series_upstream_map(
+    parameter_sources: list[PdnParameterSource],
+    proj: ExtractedProject,
+    net_remap: dict[int, int] | None = None,
+) -> tuple[dict[str, str], frozenset[str]]:
+    """Directed SERIES power-flow edges for nominal Vin lookup.
+
+    Each SERIES channel contributes one edge ``downstream N_NET → upstream
+    P_NET``. Unlike :func:`_collect_bridge_groups`, this graph is directed
+    only — sense paths that undirectedly bridge unrelated rails via GND must
+    not collapse Vin inference.
+
+    Returns ``(upstream_map, ambiguous_downstream)``. A downstream net is
+    *ambiguous* when two SERIES channels name different upstream nets for the
+    same ``N_NET``.
+    """
+    upstream: dict[str, str] = {}
+    ambiguous: set[str] = set()
+
+    def _register_edge(downstream: str, upstream_net: str) -> None:
+        dn = _canonical_supply_net_name(proj, downstream, net_remap)
+        up = _canonical_supply_net_name(proj, upstream_net, net_remap)
+        if dn in ambiguous:
+            return
+        prev = upstream.get(dn)
+        if prev is not None:
+            if prev != up:
+                ambiguous.add(dn)
+                upstream.pop(dn, None)
+            return
+        upstream[dn] = up
+
+    for comp in parameter_sources:
+        part_role_raw = _ci_get(comp.parameters, ROLE_KEY)
+        if part_role_raw is None:
+            continue
+        part_role = part_role_raw.strip().upper()
+        indices = [
+            idx for idx in _discover_channel_indices(comp.parameters, "R")
+            if _effective_role(comp.parameters, idx, part_role)
+            in _RESISTOR_LIKE_ROLES
+        ]
+        if not indices:
+            continue
+        for idx in indices:
+            p_net = _ci_get(comp.parameters, _channel_key("P_NET", idx))
+            n_net = _ci_get(comp.parameters, _channel_key("N_NET", idx))
+            if p_net is None and n_net is None and \
+                    _ci_get(comp.parameters, _channel_key("P_PINS", idx)) is None and \
+                    _ci_get(comp.parameters, _channel_key("N_PINS", idx)) is None:
+                if len(indices) == 1:
+                    for pcb_idx in _pcb_indices_for_source(comp, proj):
+                        inferred = _autoinfer_2pin_nets(proj, pcb_idx)
+                        if inferred is not None:
+                            _register_edge(inferred[1], inferred[0])
+            if p_net and n_net:
+                _register_edge(n_net, p_net)
+
+    return upstream, frozenset(ambiguous)
+
+
 def _lookup_inferred_vin(
     in_p_net: str | None,
     supply_map: dict[str, float],
-) -> float | None:
-    """Nominal Vin from an upstream SOURCE / REGULATOR on ``in_p_net``.
+    series_upstream: dict[str, str] | None = None,
+    ambiguous_downstream: frozenset[str] | None = None,
+) -> tuple[float | None, str | None]:
+    """Nominal Vin from an upstream SOURCE / REGULATOR reachable from ``in_p_net``.
 
-    Uses an exact net-name match only — SERIES bridge equivalence must not
-    expand Vin lookup, because sense paths through GND can join unrelated
-    rails (e.g. 48 V input and 12 V output) into one class.
+    ``supply_map`` lists voltages on SOURCE ``P_NET`` and REGULATOR ``OUT_P_NET``
+    only. When ``series_upstream`` is provided, walk directed SERIES edges
+    (downstream ``N_NET`` → upstream ``P_NET``) until a mapped voltage is found.
+
+    Returns ``(vin, failure)`` where ``failure`` is ``'ambiguous'`` when
+    ``in_p_net`` is an ambiguous SERIES downstream, ``'cycle'`` when the walk
+    loops, or ``None`` on success / no match.
+
+    Undirected :func:`_collect_bridge_groups` equivalence must not be used here:
+    sense paths through GND can join unrelated rails into one class.
     """
     if in_p_net is None or not str(in_p_net).strip():
-        return None
-    v = supply_map.get(in_p_net.strip().upper())
-    if v is not None and v > 0:
-        return v
-    return None
+        return None, None
+    net = in_p_net.strip().upper()
+    if ambiguous_downstream and net in ambiguous_downstream:
+        return None, "ambiguous"
+    visited: set[str] = set()
+    while net not in visited:
+        v = supply_map.get(net)
+        if v is not None and v > 0:
+            return v, None
+        visited.add(net)
+        if not series_upstream:
+            return None, None
+        parent = series_upstream.get(net)
+        if parent is None:
+            return None, None
+        net = parent
+    return None, "cycle"
 
 
 def _resolve_regulator_gain(
@@ -1698,6 +1799,8 @@ def _resolve_regulator_gain(
     supply_map: dict[str, float],
     role_diag: str,
     result: AnnotationResult,
+    series_upstream: dict[str, str] | None = None,
+    ambiguous_downstream: frozenset[str] | None = None,
 ) -> tuple[float, str | None, float, bool] | None:
     """Return ``(gain, regulator_type, efficiency, adaptive_gain_eligible)``."""
     gain_key = _channel_key("GAIN", idx)
@@ -1765,14 +1868,29 @@ def _resolve_regulator_gain(
         )
         return None
 
-    vin = _lookup_inferred_vin(in_p_net, supply_map)
+    vin, vin_failure = _lookup_inferred_vin(
+        in_p_net, supply_map,
+        series_upstream=series_upstream,
+        ambiguous_downstream=ambiguous_downstream,
+    )
     if vin is None or vin <= 0:
         in_key = _channel_key("IN_P_NET", idx)
-        result.errors.append(
-            f"{role_diag}: cannot infer input voltage for SMPS gain — "
-            f"no unique upstream SOURCE/REGULATOR voltage found for "
-            f"{in_key}={in_p_net!r}"
-        )
+        if vin_failure == "ambiguous":
+            result.errors.append(
+                f"{role_diag}: cannot infer input voltage for SMPS gain — "
+                f"ambiguous SERIES upstream for {in_key}={in_p_net!r}"
+            )
+        elif vin_failure == "cycle":
+            result.errors.append(
+                f"{role_diag}: cannot infer input voltage for SMPS gain — "
+                f"cyclic SERIES upstream path for {in_key}={in_p_net!r}"
+            )
+        else:
+            result.errors.append(
+                f"{role_diag}: cannot infer input voltage for SMPS gain — "
+                f"no unique upstream SOURCE/REGULATOR voltage found for "
+                f"{in_key}={in_p_net!r}"
+            )
         return None
 
     gain = v_out / (vin * eff)
@@ -1780,7 +1898,8 @@ def _resolve_regulator_gain(
 
 
 def _parse_regulator(comp, proj, enabled_layers, result, bridge_groups=None,
-                     net_remap=None, supply_map=None, only_indices=None):
+                     net_remap=None, supply_map=None, only_indices=None,
+                     series_upstream=None, ambiguous_downstream=None):
     role_diag_base = f"REGULATOR on {comp.designator}"
     if _has_single_net_params(comp.parameters, only_indices):
         result.errors.append(
@@ -1827,6 +1946,8 @@ def _parse_regulator(comp, proj, enabled_layers, result, bridge_groups=None,
         resolved = _resolve_regulator_gain(
             comp.parameters, idx, v, in_p_net,
             supply_map, role_diag, result,
+            series_upstream=series_upstream,
+            ambiguous_downstream=ambiguous_downstream,
         ) if v is not None else None
         if v is None or resolved is None:
             continue
@@ -2190,6 +2311,9 @@ def parse_annotations(proj: ExtractedProject,
     # SERIES bridge equivalence for cross-directive validation and the solver.
     bridge_groups = _collect_bridge_groups(parameter_sources, proj)
     supply_map = _collect_supply_voltages_by_net(parameter_sources)
+    series_upstream, series_ambiguous = _collect_series_upstream_map(
+        parameter_sources, proj, net_remap=net_remap,
+    )
 
     for comp in parameter_sources:
         if comp.designator.upper() in skip_set:
@@ -2234,7 +2358,9 @@ def parse_annotations(proj: ExtractedProject,
             specs = _PARSER_BY_ROLE[role](comp, proj, enabled_layers, result,
                                           bridge_groups=bridge_groups,
                                           net_remap=net_remap,
-                                          supply_map=supply_map)
+                                          supply_map=supply_map,
+                                          series_upstream=series_upstream,
+                                          ambiguous_downstream=series_ambiguous)
             result.directives.extend(specs)
         else:
             for chan_role, idxs in channel_roles.items():
@@ -2242,6 +2368,8 @@ def parse_annotations(proj: ExtractedProject,
                     comp, proj, enabled_layers, result,
                     bridge_groups=bridge_groups, net_remap=net_remap,
                     supply_map=supply_map, only_indices=idxs,
+                    series_upstream=series_upstream,
+                    ambiguous_downstream=series_ambiguous,
                 )
                 # Every parser returns a list — empty if the directive failed
                 # to resolve, one element per resolved channel otherwise.

--- a/fypa/altium/loader.py
+++ b/fypa/altium/loader.py
@@ -1591,22 +1591,48 @@ def _gil_yield(i: int, every: int = 4096) -> None:
         time.sleep(0.001)
 
 
-def build_net_canonical_map(netlist) -> dict[str, str]:
+def build_net_canonical_map(
+    netlist,
+    *,
+    pcb_net_names: set[str] | frozenset[str] | None = None,
+) -> dict[str, str]:
     """Map every schematic net label (``Net.name`` or alias) to ``Net.name``.
 
     Altium's compiled netlist stores the top-level / flattened name in
     ``Net.name`` and local or cross-sheet labels in ``aliases``. The viewer
     uses this map so rail lists show the canonical name rather than a local
     sheet label from ``PDN_*_NET``.
+
+    An alias is **not** mapped when another netlist entry (or, when provided,
+    a distinct PCB net) already owns that label as its primary name. The
+    schematic netlist compiler can emit spurious aliases in multi-sheet
+    designs — e.g. two regulator outputs that only meet again at a multi-rail
+    sink may appear as ``Net(name='VDD_1V25A', aliases=['VDD_1V25D'])`` while
+    ``Net(name='VDD_1V25D')`` also exists. Folding that alias would hide one
+    rail and mis-attribute copper even though the nets were never merged.
     """
     if netlist is None:
         return {}
+    nets = list(getattr(netlist, "nets", ()) or ())
+    primary_upper = {
+        net.name.upper()
+        for net in nets
+        if getattr(net, "name", None)
+    }
+    pcb_upper = {n.upper() for n in (pcb_net_names or ()) if n}
     out: dict[str, str] = {}
-    for net in getattr(netlist, "nets", ()) or ():
+    for net in nets:
         canonical = net.name
+        canon_upper = canonical.upper()
         for label in (canonical, *getattr(net, "aliases", ())):
-            if label:
-                out[label.upper()] = canonical
+            if not label:
+                continue
+            key = label.upper()
+            if key != canon_upper and (
+                key in primary_upper or key in pcb_upper
+            ):
+                continue
+            out[key] = canonical
     return out
 
 
@@ -2461,7 +2487,10 @@ def build_solve_metadata(
             ),
         },
         "directives": directives,
-        "net_canonical": build_net_canonical_map(proj.compiled_netlist),
+        "net_canonical": build_net_canonical_map(
+            proj.compiled_netlist,
+            pcb_net_names={n.name for n in proj.nets},
+        ),
         "active_nets": active_nets,
         "vias": vias,
         "pths": pths,

--- a/fypa/altium/loader.py
+++ b/fypa/altium/loader.py
@@ -1594,9 +1594,12 @@ def build_net_canonical_map(netlist) -> dict[str, str]:
 
 # --- adaptive SMPS regulator gain (optional fixed-point iteration) ------------
 
-_ADAPTIVE_GAIN_MAX_ITERATIONS: int = 8
+_ADAPTIVE_GAIN_MAX_ITERATIONS: int = 12
 _ADAPTIVE_GAIN_REL_TOL: float = 1e-3
 _ADAPTIVE_GAIN_VIN_FLOOR_V: float = 0.1
+# Blend toward the measured-Vin target gain each iteration (1 = full step).
+# Values < 1 stabilise coupled SMPS rails that share a SERIES upstream path.
+_ADAPTIVE_GAIN_BLEND: float = 0.65
 
 
 def has_adaptive_smps_regulators(loaded: LoadedProject) -> bool:
@@ -1727,6 +1730,11 @@ def solve_problem_adaptive(
         bool(adaptive_regulator_gain)
         and has_adaptive_smps_regulators(loaded)
     )
+    n_adaptive = sum(
+        1 for d in loaded.annotations.directives
+        if isinstance(d, RegulatorSpec) and d.adaptive_gain_eligible
+    )
+    gain_blend = _ADAPTIVE_GAIN_BLEND if n_adaptive > 1 else 1.0
 
     problem, via_segment_records, stub_pieces_by_pair, per_net_layers = (
         build_problem(loaded)
@@ -1788,7 +1796,8 @@ def solve_problem_adaptive(
                 new_gain = d.gain
             else:
                 any_vin_sampled = True
-                new_gain = d.voltage / (vin * d.efficiency)
+                target_gain = d.voltage / (vin * d.efficiency)
+                new_gain = (1.0 - gain_blend) * d.gain + gain_blend * target_gain
             if d.gain != 0.0:
                 max_rel_change = max(
                     max_rel_change,

--- a/tests/test_adaptive_regulator_gain.py
+++ b/tests/test_adaptive_regulator_gain.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 from fypa.altium.annotations import AnnotationResult, RegulatorSpec, TerminalSpec
 from fypa.altium.loader import (
     _ADAPTIVE_GAIN_MAX_ITERATIONS,
+    _ADAPTIVE_GAIN_REL_TOL,
     solve_problem_adaptive,
 )
 
@@ -96,6 +97,33 @@ def test_adaptive_gain_converges_to_fixed_point():
     assert abs(reported - expected) < 1e-9
     # Metadata (read off ``loaded``) must agree with the reported gain.
     assert abs(loaded.annotations.directives[0].gain - expected) < 1e-9
+
+
+def test_adaptive_gain_damped_when_multiple_smps_share_upstream():
+    """Several adaptive SMPS use blended gain steps (slower but stable)."""
+    term = TerminalSpec(pins=())
+    regs = [
+        RegulatorSpec(
+            designator=f"U{i}", schdoc_name="Pwr.SchDoc",
+            voltage=vout, gain=0.2, out_p=term, out_n=term,
+            in_p=term, in_n=term, regulator_type="SMPS",
+            efficiency=0.8, adaptive_gain_eligible=True,
+        )
+        for i, vout in enumerate((12.0, 3.3, 5.0), start=5)
+    ]
+    loaded = SimpleNamespace(
+        extracted=SimpleNamespace(),
+        annotations=AnnotationResult(directives=regs),
+    )
+    adaptive_info = _run_adaptive(loaded, lambda *a: 48.0)
+    assert adaptive_info["enabled"]
+    assert adaptive_info["converged"] is True
+    # Damped updates need more passes than a single-regulator design.
+    assert adaptive_info["iterations"] > 2
+    for d in loaded.annotations.directives:
+        assert isinstance(d, RegulatorSpec)
+        expected = d.voltage / (48.0 * d.efficiency)
+        assert abs(d.gain - expected) / expected < _ADAPTIVE_GAIN_REL_TOL
 
 
 def test_adaptive_gain_reports_gains_used_by_returned_solution():

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1076,11 +1076,209 @@ def test_regulator_explicit_gain_overrides_type():
     assert any("overrides" in w for w in result.warnings)
 
 
-def test_lookup_inferred_vin_ignores_series_bridge_groups():
-    """Sense paths through GND must not make Vin ambiguous (project_a / PDN5_R)."""
+def test_lookup_inferred_vin_exact_match_without_series_walk():
+    """Without series_upstream, only direct supply_map hits resolve."""
     supply_map = {"VDD_48V": 48.0, "VDD_12V": 12.0}
-    assert _lookup_inferred_vin("VDD_48V", supply_map) == 48.0
-    assert _lookup_inferred_vin("VDD_12V", supply_map) == 12.0
+    assert _lookup_inferred_vin("VDD_48V", supply_map) == (48.0, None)
+    assert _lookup_inferred_vin("VDD_12V", supply_map) == (12.0, None)
+    assert _lookup_inferred_vin("VDD_48V_RP", supply_map) == (None, None)
+
+
+def test_lookup_inferred_vin_walks_series_upstream():
+    supply_map = {"VDD_48V_IN": 48.0}
+    upstream = {"VDD_48V_RP": "VDD_48V", "VDD_48V": "VDD_48V_IN"}
+    assert _lookup_inferred_vin(
+        "VDD_48V_RP", supply_map, series_upstream=upstream,
+    ) == (48.0, None)
+
+
+def test_lookup_inferred_vin_series_ambiguous_and_cycle():
+    supply_map = {"VDD_48V_IN": 48.0}
+    assert _lookup_inferred_vin(
+        "VDD_48V_RP", supply_map, ambiguous_downstream=frozenset({"VDD_48V_RP"}),
+    ) == (None, "ambiguous")
+    assert _lookup_inferred_vin(
+        "VDD_48V_RP", supply_map,
+        series_upstream={"VDD_48V_RP": "VDD_48V", "VDD_48V": "VDD_48V_RP"},
+    ) == (None, "cycle")
+
+
+def test_regulator_smps_vin_through_series_chain():
+    """VIP-style: SOURCE -> SERIES -> SERIES -> SMPS on downstream net."""
+    proj = _minimal_proj(
+        nets=(
+            RawNet("GND"), RawNet("VDD_48V_IN"), RawNet("VDD_48V"),
+            RawNet("VDD_48V_RP"), RawNet("VDD_12V"),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="J7", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SOURCE",
+                    "PDN_V": "48",
+                    "PDN_P_NET": "VDD_48V_IN",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="J8", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN_R": "50m",
+                    "PDN_P_NET": "VDD_48V_IN",
+                    "PDN_N_NET": "VDD_48V",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="Q3", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN_R": "300m",
+                    "PDN_P_NET": "VDD_48V",
+                    "PDN_N_NET": "VDD_48V_RP",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="U5", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_REGULATOR_TYPE": "SMPS",
+                    "PDN_REGULATOR_EFFICIENCY": "0.8",
+                    "PDN_V": "12",
+                    "PDN_OUT_P_NET": "VDD_12V",
+                    "PDN_OUT_N_NET": "GND",
+                    "PDN_IN_P_NET": "VDD_48V_RP",
+                    "PDN_IN_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J7", center=Pt2D(-15, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="CONN", source_designator="J7",
+            ),
+            RawPcbComponent(
+                designator="J8", center=Pt2D(-10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="FUSE", source_designator="J8",
+            ),
+            RawPcbComponent(
+                designator="Q3", center=Pt2D(-5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOT", source_designator="Q3",
+            ),
+            RawPcbComponent(
+                designator="U5", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOT", source_designator="U5",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1, -15), _pad(0, "2", 0, -14),
+            _pad(1, "1", 1, -10), _pad(1, "2", 2, -9),
+            _pad(2, "1", 2, -5), _pad(2, "2", 3, -4),
+            _pad(3, "1", 4, 0), _pad(3, "2", 0, 1),
+            _pad(3, "3", 3, 2), _pad(3, "4", 0, 3),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    reg = next(d for d in result.directives if d.designator == "U5")
+    assert isinstance(reg, RegulatorSpec)
+    assert reg.regulator_type == "SMPS"
+    assert abs(reg.gain - (12.0 / (48.0 * 0.8))) < 1e-6
+    assert not any("cannot infer input voltage" in e for e in result.errors)
+
+
+def test_regulator_smps_vin_series_ambiguous_fork():
+    proj = _minimal_proj(
+        nets=(
+            RawNet("GND"), RawNet("VDD_48V_IN"), RawNet("VDD_48V"),
+            RawNet("VDD_48V_RP"), RawNet("VDD_12V"), RawNet("ALT_48V"),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="J7", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SOURCE", "PDN_V": "48",
+                    "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="J8", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES", "PDN_R": "50m",
+                    "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="Q3a", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES", "PDN_R": "100m",
+                    "PDN_P_NET": "VDD_48V", "PDN_N_NET": "VDD_48V_RP",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="Q3b", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES", "PDN_R": "200m",
+                    "PDN_P_NET": "ALT_48V", "PDN_N_NET": "VDD_48V_RP",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="U5", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_REGULATOR_TYPE": "SMPS",
+                    "PDN_REGULATOR_EFFICIENCY": "0.8",
+                    "PDN_V": "12",
+                    "PDN_OUT_P_NET": "VDD_12V",
+                    "PDN_OUT_N_NET": "GND",
+                    "PDN_IN_P_NET": "VDD_48V_RP",
+                    "PDN_IN_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J7", center=Pt2D(-15, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="CONN", source_designator="J7",
+            ),
+            RawPcbComponent(
+                designator="J8", center=Pt2D(-10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="FUSE", source_designator="J8",
+            ),
+            RawPcbComponent(
+                designator="Q3a", center=Pt2D(-5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOT", source_designator="Q3a",
+            ),
+            RawPcbComponent(
+                designator="Q3b", center=Pt2D(-4, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOT", source_designator="Q3b",
+            ),
+            RawPcbComponent(
+                designator="U5", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOT", source_designator="U5",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1, -15), _pad(0, "2", 0, -14),
+            _pad(1, "1", 1, -10), _pad(1, "2", 2, -9),
+            _pad(2, "1", 2, -5), _pad(2, "2", 3, -4),
+            _pad(3, "1", 5, -4), _pad(3, "2", 3, -3),
+            _pad(4, "1", 4, 0), _pad(4, "2", 0, 1),
+            _pad(4, "3", 3, 2), _pad(4, "4", 0, 3),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert not result.ok
+    assert any("ambiguous SERIES upstream" in e for e in result.errors)
 
 
 def test_regulator_smps_vin_not_ambiguous_through_sense_bridges():

--- a/tests/test_rails.py
+++ b/tests/test_rails.py
@@ -4,6 +4,87 @@ from fypa.altium.loader import build_net_canonical_map
 from fypa.rail_groups import compute_rail_groups
 
 
+def test_build_net_canonical_map_skips_alias_when_netlist_has_distinct_entry():
+    """Spurious compiler alias must not fold a net that owns its own entry."""
+    class _Net:
+        def __init__(self, name, aliases=()):
+            self.name = name
+            self.aliases = list(aliases)
+
+    class _Netlist:
+        nets = [
+            _Net("VDD_1V25D"),
+            _Net("VDD_1V25A", aliases=["VDD_1V25D"]),
+            _Net("VDD_1V25A"),
+        ]
+
+    m = build_net_canonical_map(_Netlist())
+    assert m["VDD_1V25A"] == "VDD_1V25A"
+    assert m["VDD_1V25D"] == "VDD_1V25D"
+
+
+def test_build_net_canonical_map_skips_alias_when_pcb_has_distinct_net():
+    """Schematic alias must not fold a PCB net that still exists by that name."""
+    class _Net:
+        def __init__(self, name, aliases=()):
+            self.name = name
+            self.aliases = list(aliases)
+
+    class _Netlist:
+        nets = [
+            _Net("VDD_1V25D"),
+            _Net("VDD_1V25A", aliases=["VDD_1V25D"]),
+        ]
+
+    m = build_net_canonical_map(
+        _Netlist(),
+        pcb_net_names={"VDD_1V25A", "VDD_1V25D"},
+    )
+    assert m["VDD_1V25A"] == "VDD_1V25A"
+    assert m["VDD_1V25D"] == "VDD_1V25D"
+
+
+def test_rail_groups_keep_split_pcb_nets_when_schematic_aliases_overlap():
+    """Two regulator outputs on distinct PCB nets stay separate rails."""
+    metadata = {
+        "net_canonical": {
+            "VDD_1V25A": "VDD_1V25A",
+            "VDD_1V25D": "VDD_1V25D",
+        },
+        "directives": [
+            {
+                "role": "REGULATOR",
+                "terminals": {
+                    "OUT_P": {
+                        "requested_net": "VDD_1V25D",
+                        "pins": [{"net": "VDD_1V25D"}],
+                    },
+                    "OUT_N": {"requested_net": "GND", "pins": [{"net": "GND"}]},
+                    "IN_P": {"requested_net": "VDD_12V", "pins": [{"net": "VDD_12V"}]},
+                    "IN_N": {"requested_net": "GND", "pins": [{"net": "GND"}]},
+                },
+            },
+            {
+                "role": "REGULATOR",
+                "terminals": {
+                    "OUT_P": {
+                        "requested_net": "VDD_1V25A",
+                        "pins": [{"net": "VDD_1V25A"}],
+                    },
+                    "OUT_N": {"requested_net": "GND", "pins": [{"net": "GND"}]},
+                    "IN_P": {"requested_net": "VDD_12V", "pins": [{"net": "VDD_12V"}]},
+                    "IN_N": {"requested_net": "GND", "pins": [{"net": "GND"}]},
+                },
+            },
+        ],
+    }
+    names, members = compute_rail_groups(metadata)
+    assert "VDD_1V25D" in names
+    assert "VDD_1V25A" in names
+    assert members["VDD_1V25D"] == ["VDD_1V25D"]
+    assert members["VDD_1V25A"] == ["VDD_1V25A"]
+
+
 def test_build_net_canonical_map_maps_aliases_to_name():
     class _Net:
         def __init__(self, name, aliases=()):


### PR DESCRIPTION
## Summary

SMPS regulators placed downstream of `SERIES` elements (e-fuses, filters, sense resistors, etc.) often sit on a net that is not the upstream supply rail itself. Without an explicit `PDN_GAIN`, FYPA could not infer a nominal input voltage and rejected or mis-configured those regulators.

This PR closes that gap and makes coupled multi-converter designs more stable:

- **Directed SERIES Vin inference** — walk upstream along `SERIES` edges (`N_NET` → `P_NET`) from `PDN_IN_P_NET` until a `SOURCE` or upstream `REGULATOR` output voltage is found, then derive nominal SMPS gain as `Vout / (Vin · η)`.
- **Safe failure modes** — ambiguous SERIES forks and cycles produce explicit annotation errors instead of guessing.
- **Damped adaptive gain** — when several adaptive SMPS regulators share an upstream path, gain updates are blended so the fixed-point iteration converges reliably.
- **Rail canonicalization guard** — skip spurious schematic netlist aliases when another net (or distinct PCB net) already owns that name, so parallel regulator outputs stay separate in rail grouping.

Explicit `PDN_GAIN` still wins; LDO behaviour is unchanged.

## Motivation

Typical power trees are `SOURCE → SERIES → SERIES → SMPS`. Designers should not have to duplicate upstream voltages in every converter annotation, and multi-SMPS boards should not oscillate during adaptive gain refinement.

## Test plan

- [x] `pytest tests/test_annotations.py -k "inferred_vin or series"`
- [x] `pytest tests/test_adaptive_regulator_gain.py`
- [x] `pytest tests/test_rails.py`
- [ ] Load a real hierarchical design with SERIES-filtered inputs and confirm SMPS gain is inferred without `PDN_GAIN`
- [ ] Run adaptive gain on a board with multiple SMPS fed from a common upstream path and confirm stable convergence