### PR TITLE
Shift-click eye icons to isolate layer/rail visibility

### DIFF
--- a/fypa/altium_viewer.py
+++ b/fypa/altium_viewer.py
@@ -1394,6 +1394,11 @@ class EyeButton(QToolButton):
     """Altium-style eye-icon toggle for layer visibility."""
 
     toggled_visible = Signal(bool)
+    shift_clicked = Signal()
+
+    _SHIFT_TIP = (
+        "\nShift+Click: show only this item; again to invert (hide this, show others)"
+    )
 
     def __init__(self, parent=None, *, visible: bool = True,
                  icon_size: int = 16,
@@ -1405,7 +1410,11 @@ class EyeButton(QToolButton):
         self._icon_size = icon_size
         self._tip_show = tip_show
         self._tip_hide = tip_hide
-        self._tip_partial = "Some subnet nets visible — click to show all"
+        self._tip_partial = (
+            "Some subnet nets visible — click to show all"
+            + self._SHIFT_TIP
+        )
+        self._press_mods: Qt.KeyboardModifiers = Qt.NoModifier
         self.setAutoRaise(True)
         self.setCursor(Qt.PointingHandCursor)
         self.setIconSize(QSize(icon_size, icon_size))
@@ -1440,9 +1449,21 @@ class EyeButton(QToolButton):
         if self._partial:
             self.setToolTip(self._tip_partial)
         else:
-            self.setToolTip(self._tip_hide if self._visible else self._tip_show)
+            base = self._tip_hide if self._visible else self._tip_show
+            self.setToolTip(base + self._SHIFT_TIP)
+
+    def mousePressEvent(self, event) -> None:
+        # Capture modifiers at press time — clicked fires on release and
+        # QApplication.keyboardModifiers() may already be cleared.
+        self._press_mods = event.modifiers()
+        super().mousePressEvent(event)
 
     def _on_clicked(self) -> None:
+        mods = self._press_mods
+        self._press_mods = Qt.NoModifier
+        if mods & Qt.ShiftModifier:
+            self.shift_clicked.emit()
+            return
         if self._partial:
             self.setVisibleState(True, partial=False)
         else:
@@ -8770,12 +8791,18 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
                 tip_hide="Hide this layer's analysed rails (rail copper only)",
             )
             eye.toggled_visible.connect(self._on_layer_eye_toggled)
+            eye.shift_clicked.connect(
+                lambda p=phys: self._on_layer_eye_shift_clicked(p),
+            )
             eye2 = EyeButton(
                 visible=False,
                 tip_show="Show all copper on this layer",
                 tip_hide="Hide all copper on this layer",
             )
             eye2.toggled_visible.connect(self._on_layer_eye2_toggled)
+            eye2.shift_clicked.connect(
+                lambda p=phys: self._on_layer_eye2_shift_clicked(p),
+            )
             fill = FillToggleButton(solid=True)
             fill.toggled_fill.connect(self._on_layer_fill_toggled)
             transp = TransparencyButton(step=0)
@@ -9199,12 +9226,18 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
                 tip_hide="Hide this layer's analysed rails (rail copper only)",
             )
             eye.toggled_visible.connect(self._on_layer_eye_toggled)
+            eye.shift_clicked.connect(
+                lambda p=phys: self._on_layer_eye_shift_clicked(p),
+            )
             eye2 = EyeButton(
                 visible=False,
                 tip_show="Show all copper on this layer",
                 tip_hide="Hide all copper on this layer",
             )
             eye2.toggled_visible.connect(self._on_layer_eye2_toggled)
+            eye2.shift_clicked.connect(
+                lambda p=phys: self._on_layer_eye2_shift_clicked(p),
+            )
             fill = FillToggleButton(solid=True)
             fill.toggled_fill.connect(self._on_layer_fill_toggled)
             transp = TransparencyButton(step=0)
@@ -9991,6 +10024,9 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
             eye.toggled_visible.connect(
                 lambda on, r=rail: self._on_rail_eye_toggled(r, on),
             )
+            eye.shift_clicked.connect(
+                lambda r=rail: self._on_rail_eye_shift_clicked(r),
+            )
 
             expand_btn = None
             expanded = bool(self._rail_expanded.get(rail, False))
@@ -10038,6 +10074,11 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
                     subnet_eye.toggled_visible.connect(
                         lambda on, r=rail, n=net: self._on_subnet_eye_toggled(
                             r, n, on,
+                        ),
+                    )
+                    subnet_eye.shift_clicked.connect(
+                        lambda r=rail, n=net: self._on_subnet_eye_shift_clicked(
+                            r, n,
                         ),
                     )
                     self._subnet_eye_buttons[rail][net] = subnet_eye
@@ -10161,6 +10202,111 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         self._sync_all_rails_eye()
         self._sync_rail_only_visibility()
         self._render_with_busy_popup()
+
+    def _apply_eye_isolate_or_invert(
+        self,
+        items: list[tuple[str, EyeButton]],
+        target: str,
+    ) -> None:
+        """Show only *target*, or invert when it is already the sole visible item."""
+        alive = [
+            (name, eye) for name, eye in items
+            if _qt_widget_alive(eye)
+        ]
+        if not alive:
+            return
+        visible = [name for name, eye in alive if eye.isVisibleState()]
+        isolated = len(visible) == 1 and visible[0] == target
+        for name, eye in alive:
+            if isolated:
+                eye.setVisibleState(name != target, partial=False, emit=False)
+            else:
+                eye.setVisibleState(name == target, partial=False, emit=False)
+
+    def _iter_rail_visibility_entries(
+        self,
+    ) -> list[tuple[str, str | None, EyeButton]]:
+        """Return (rail, net_or_none, eye) for every isolatable rail/subnet eye."""
+        entries: list[tuple[str, str | None, EyeButton]] = []
+        for rail, eye in self._rail_eye_buttons:
+            if not _qt_widget_alive(eye):
+                continue
+            subnets = self._subnet_eye_buttons.get(rail, {})
+            if subnets:
+                for net, seye in subnets.items():
+                    if _qt_widget_alive(seye):
+                        entries.append((rail, net, seye))
+            else:
+                entries.append((rail, None, eye))
+        return entries
+
+    def _is_rail_group_isolated(self, rail: str) -> bool:
+        """True when only nets belonging to *rail* are visible."""
+        any_target = False
+        for r, _net, eye in self._iter_rail_visibility_entries():
+            if not eye.isVisibleState():
+                continue
+            if r != rail:
+                return False
+            any_target = True
+        return any_target
+
+    def _apply_rail_group_isolate_or_invert(self, rail: str) -> None:
+        """Isolate a rail (all its subnets) or invert when already sole group."""
+        if self._is_rail_group_isolated(rail):
+            for r, _net, eye in self._iter_rail_visibility_entries():
+                eye.setVisibleState(r != rail, partial=False, emit=False)
+        else:
+            for r, _net, eye in self._iter_rail_visibility_entries():
+                eye.setVisibleState(r == rail, partial=False, emit=False)
+        for r in self._subnet_eye_buttons:
+            self._sync_rail_eye_from_subnets(r)
+        self._sync_all_rails_eye()
+        self._sync_rail_only_visibility()
+        self._render_with_busy_popup()
+
+    def _apply_rail_entry_isolate_or_invert(
+        self, rail: str, net: str | None,
+    ) -> None:
+        """Isolate one rail or subnet entry, or invert when already sole visible."""
+        entries = self._iter_rail_visibility_entries()
+        visible = [
+            (r, n) for r, n, eye in entries if eye.isVisibleState()
+        ]
+        isolated = len(visible) == 1 and visible[0] == (rail, net)
+        for r, n, eye in entries:
+            if isolated:
+                on = (r, n) != (rail, net)
+            else:
+                on = (r, n) == (rail, net)
+            eye.setVisibleState(on, partial=False, emit=False)
+        for r in self._subnet_eye_buttons:
+            self._sync_rail_eye_from_subnets(r)
+        self._sync_all_rails_eye()
+        self._sync_rail_only_visibility()
+        self._render_with_busy_popup()
+
+    def _on_layer_eye_shift_clicked(self, phys: str) -> None:
+        self._apply_eye_isolate_or_invert(self._layer_eye_buttons, phys)
+        self._sync_all_layers_eye()
+        self._on_layer_visibility_changed()
+
+    def _on_layer_eye2_shift_clicked(self, phys: str) -> None:
+        self._apply_eye_isolate_or_invert(self._layer_eye2_buttons, phys)
+        self._sync_all_layers_eye2()
+        rails = self._visible_rails()
+        self._run_with_busy_popup(
+            lambda: self._refresh_after_copper_eye(rails))
+
+    def _on_rail_eye_shift_clicked(self, rail: str) -> None:
+        members = self._rail_to_members.get(rail, [rail])
+        if len(members) > 1:
+            self._apply_rail_group_isolate_or_invert(rail)
+        else:
+            self._apply_rail_entry_isolate_or_invert(rail, None)
+
+    def _on_subnet_eye_shift_clicked(self, rail: str, net: str) -> None:
+        self._apply_rail_entry_isolate_or_invert(rail, net)
 
     def _on_layer_eye_toggled(self, _on: bool) -> None:
         """An individual layer's eye was clicked."""

--- a/tests/test_eye_isolate.py
+++ b/tests/test_eye_isolate.py
@@ -1,0 +1,152 @@
+"""Shift-click eye isolation for layer and rail visibility lists."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtCore import Qt  # noqa: E402
+from PySide6.QtGui import QMouseEvent  # noqa: E402
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+from fypa.altium_viewer import EyeButton, PdnViewer  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+class _IsolateViewerStub:
+    _apply_eye_isolate_or_invert = PdnViewer._apply_eye_isolate_or_invert
+    _iter_rail_visibility_entries = PdnViewer._iter_rail_visibility_entries
+    _is_rail_group_isolated = PdnViewer._is_rail_group_isolated
+    _apply_rail_group_isolate_or_invert = PdnViewer._apply_rail_group_isolate_or_invert
+    _apply_rail_entry_isolate_or_invert = PdnViewer._apply_rail_entry_isolate_or_invert
+    _sync_rail_eye_from_subnets = PdnViewer._sync_rail_eye_from_subnets
+    _sync_all_rails_eye = PdnViewer._sync_all_rails_eye
+    _sync_rail_only_visibility = PdnViewer._sync_rail_only_visibility
+
+    def __init__(self) -> None:
+        self._layer_eye_buttons: list[tuple[str, EyeButton]] = []
+        self._rail_eye_buttons: list[tuple[str, EyeButton]] = []
+        self._subnet_eye_buttons: dict[str, dict[str, EyeButton]] = {}
+        self._rail_to_members: dict[str, list[str]] = {}
+        self._all_rails_eye = EyeButton(visible=False)
+        self.render_calls = 0
+
+    def _render_with_busy_popup(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+        self.render_calls += 1
+
+
+def _shift_click(eye: EyeButton) -> None:
+    pos = eye.rect().center()
+    press = QMouseEvent(
+        QMouseEvent.Type.MouseButtonPress,
+        pos,
+        eye.mapToGlobal(pos),
+        Qt.LeftButton,
+        Qt.LeftButton,
+        Qt.ShiftModifier,
+    )
+    release = QMouseEvent(
+        QMouseEvent.Type.MouseButtonRelease,
+        pos,
+        eye.mapToGlobal(pos),
+        Qt.LeftButton,
+        Qt.NoButton,
+        Qt.ShiftModifier,
+    )
+    eye.mousePressEvent(press)
+    eye.mouseReleaseEvent(release)
+
+
+def test_eye_button_shift_click_emits_without_toggle(qapp) -> None:
+    eye = EyeButton(visible=True)
+    shifts: list[object] = []
+    eye.shift_clicked.connect(lambda: shifts.append(True))
+    toggles: list[bool] = []
+    eye.toggled_visible.connect(toggles.append)
+    _shift_click(eye)
+    assert shifts == [True]
+    assert toggles == []
+    assert eye.isVisibleState() is True
+
+
+def test_apply_eye_isolate_or_invert_solo_then_invert(qapp) -> None:
+    viewer = _IsolateViewerStub()
+    a = EyeButton(visible=True)
+    b = EyeButton(visible=True)
+    c = EyeButton(visible=False)
+
+    viewer._layer_eye_buttons = [("L1", a), ("L2", b), ("L3", c)]
+
+    viewer._apply_eye_isolate_or_invert(viewer._layer_eye_buttons, "L2")
+    assert a.isVisibleState() is False
+    assert b.isVisibleState() is True
+    assert c.isVisibleState() is False
+
+    viewer._apply_eye_isolate_or_invert(viewer._layer_eye_buttons, "L2")
+    assert a.isVisibleState() is True
+    assert b.isVisibleState() is False
+    assert c.isVisibleState() is True
+
+
+def test_rail_subnet_isolate_and_invert(qapp) -> None:
+    viewer = _IsolateViewerStub()
+    rail_a = EyeButton(visible=False)
+    rail_b = EyeButton(visible=False)
+    net_a1 = EyeButton(visible=True)
+    net_a2 = EyeButton(visible=True)
+    net_b1 = EyeButton(visible=False)
+
+    viewer._rail_eye_buttons = [("VCC", rail_a), ("GND", rail_b)]
+    viewer._subnet_eye_buttons = {
+        "VCC": {"VCC_3V3": net_a1, "VCC_5V": net_a2},
+        "GND": {"GND": net_b1},
+    }
+    viewer._rail_to_members = {
+        "VCC": ["VCC_3V3", "VCC_5V"],
+        "GND": ["GND"],
+    }
+
+    viewer._apply_rail_entry_isolate_or_invert("VCC", "VCC_3V3")
+    assert net_a1.isVisibleState() is True
+    assert net_a2.isVisibleState() is False
+    assert net_b1.isVisibleState() is False
+
+    viewer._apply_rail_entry_isolate_or_invert("VCC", "VCC_3V3")
+    assert net_a1.isVisibleState() is False
+    assert net_a2.isVisibleState() is True
+    assert net_b1.isVisibleState() is True
+
+
+def test_rail_group_isolate_and_invert(qapp) -> None:
+    viewer = _IsolateViewerStub()
+    rail_a = EyeButton(visible=False)
+    rail_b = EyeButton(visible=False)
+    net_a1 = EyeButton(visible=True)
+    net_a2 = EyeButton(visible=False)
+    net_b1 = EyeButton(visible=True)
+
+    viewer._rail_eye_buttons = [("VCC", rail_a), ("GND", rail_b)]
+    viewer._subnet_eye_buttons = {
+        "VCC": {"VCC_3V3": net_a1, "VCC_5V": net_a2},
+        "GND": {"GND": net_b1},
+    }
+
+    viewer._apply_rail_group_isolate_or_invert("VCC")
+    assert net_a1.isVisibleState() is True
+    assert net_a2.isVisibleState() is True
+    assert net_b1.isVisibleState() is False
+
+    viewer._apply_rail_group_isolate_or_invert("VCC")
+    assert net_a1.isVisibleState() is False
+    assert net_a2.isVisibleState() is False
+    assert net_b1.isVisibleState() is True


### PR DESCRIPTION
## Summary

- Shift+click on a layer or rail **eye** shows only that item (all others of the same list are hidden).
- Shift+click again when it is already the sole visible item **inverts** the selection (hide it, show all others).
- Works for layer heatmap eyes, layer all-copper eyes, rail eyes, and subnet eyes; rail parent eyes isolate the whole rail group (all subnets).

## Test plan

- [ ] Shift+click a layer eye → only that layer visible; repeat → inverted
- [ ] Shift+click a layer all-copper eye → same behaviour, independent of heatmap eyes
- [ ] Shift+click a rail eye (with/without subnets) → solo rail or solo subnet as expected
- [ ] Plain click still toggles a single eye as before
- [ ] `pytest tests/test_eye_isolate.py`