### PR TITLE
Fix impedance numeric fields under German locale.

### DIFF
--- a/fypa/altium_viewer.py
+++ b/fypa/altium_viewer.py
@@ -7110,6 +7110,15 @@ class _SettingsTabMixin:
         # %g picks fixed or scientific automatically; clamp to 6 sig figs.
         return f"{f:.6g}"
 
+    @staticmethod
+    def _parse_settings_value(text: str) -> float:
+        """Parse a numeric QLineEdit value independent of the system locale.
+
+        Impedance and Settings fields always use dot decimals in the
+        validator; tolerate a comma decimal from pasted locale-formatted
+        input (e.g. ``5,00E-01``)."""
+        return float(text.strip().replace(",", "."))
+
     def _on_settings_reset(self) -> None:
         """Restore every Settings-tab field to its built-in default. The
         user still has to press Re-run Solver to commit."""
@@ -26289,7 +26298,9 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
             "capacitors no longer helps.")
         for e in (self.imp_ripple_edit, self.imp_itran_edit,
                   self.imp_fmax_edit):
-            e.setValidator(QDoubleValidator(0.0, 1e12, 6, self))
+            validator = QDoubleValidator(0.0, 1e12, 6, self)
+            validator.setNotation(QDoubleValidator.StandardNotation)
+            e.setValidator(validator)
             e.setMaximumWidth(120)
         mask_form.addRow("Ripple (%)", self.imp_ripple_edit)
         mask_form.addRow("Transient current (A)", self.imp_itran_edit)
@@ -26312,7 +26323,9 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
             "Output inductance of the regulator including its path to the "
             "plane. It makes the VRM branch give up above its bandwidth.")
         for e in (self.imp_vrm_r_edit, self.imp_vrm_l_edit):
-            e.setValidator(QDoubleValidator(0.0, 1e12, 6, self))
+            validator = QDoubleValidator(0.0, 1e12, 6, self)
+            validator.setNotation(QDoubleValidator.StandardNotation)
+            e.setValidator(validator)
             e.setMaximumWidth(120)
         vrm_form.addRow("R (mΩ)", self.imp_vrm_r_edit)
         vrm_form.addRow("L (nH)", self.imp_vrm_l_edit)
@@ -26618,11 +26631,16 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
 
     def _load_impedance_rail_config(self, rail: str) -> None:
         cfg = self._caploop_rail_config(rail)
-        self.imp_ripple_edit.setText(f"{cfg['ripple_pct']:g}")
-        self.imp_itran_edit.setText(f"{cfg['transient_current_a']:g}")
-        self.imp_fmax_edit.setText(f"{cfg['f_max_hz'] / 1e6:g}")
-        self.imp_vrm_r_edit.setText(f"{cfg['vrm_r_ohm'] * 1e3:g}")
-        self.imp_vrm_l_edit.setText(f"{cfg['vrm_l_h'] * 1e9:g}")
+        self.imp_ripple_edit.setText(
+            self._fmt_settings_value(cfg["ripple_pct"]))
+        self.imp_itran_edit.setText(
+            self._fmt_settings_value(cfg["transient_current_a"]))
+        self.imp_fmax_edit.setText(
+            self._fmt_settings_value(cfg["f_max_hz"] / 1e6))
+        self.imp_vrm_r_edit.setText(
+            self._fmt_settings_value(cfg["vrm_r_ohm"] * 1e3))
+        self.imp_vrm_l_edit.setText(
+            self._fmt_settings_value(cfg["vrm_l_h"] * 1e9))
 
     def _on_impedance_rail_changed(self, rail: str) -> None:
         if not rail:
@@ -26639,7 +26657,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         def _f(edit, name, scale=1.0):
             text = edit.text().strip()
             try:
-                value = float(text)
+                value = self._parse_settings_value(text)
             except ValueError:
                 raise ValueError(f"{name}: {text!r} is not a number")
             if value < 0.0:

--- a/tests/test_caploop_impedance_tab.py
+++ b/tests/test_caploop_impedance_tab.py
@@ -140,6 +140,32 @@ def test_invalid_mask_input_is_rejected_without_persisting(viewer, monkeypatch):
     assert "caploop_rails" not in viewer._project.viewer_settings
 
 
+def test_transient_current_loads_with_dot_decimal_notation(viewer):
+    viewer._set_caploop_rail_config("+3V3", {
+        **viewer._caploop_rail_config("+3V3"),
+        "transient_current_a": 0.5,
+    })
+    viewer._load_impedance_rail_config("+3V3")
+    assert viewer.imp_itran_edit.text() == "0.5"
+
+
+def test_transient_current_accepts_comma_decimal_on_apply(viewer):
+    viewer.imp_itran_edit.setText("5,00E-01")
+    viewer._on_impedance_apply()
+    assert viewer._caploop_rail_config("+3V3")["transient_current_a"] == 0.5
+
+
+def test_impedance_mask_edits_use_standard_notation_validator(viewer):
+    from PySide6.QtGui import QDoubleValidator
+
+    for edit in (viewer.imp_ripple_edit, viewer.imp_itran_edit,
+                 viewer.imp_fmax_edit, viewer.imp_vrm_r_edit,
+                 viewer.imp_vrm_l_edit):
+        validator = edit.validator()
+        assert isinstance(validator, QDoubleValidator)
+        assert validator.notation() == QDoubleValidator.StandardNotation
+
+
 def test_vrm_resistance_sets_the_dc_floor(viewer):
     viewer._set_caploop_rail_config("+3V3", {
         **viewer._caploop_rail_config("+3V3"), "vrm_r_ohm": 4e-3})


### PR DESCRIPTION
## Summary

- Use `QDoubleValidator.StandardNotation` on Impedance tab numeric fields so Qt does not reformat values with locale-specific decimals (e.g. `0.5` → `5,00E-01`).
- Format loaded values with `_fmt_settings_value()` and parse with a locale-tolerant `_parse_settings_value()` (comma → dot).
- Fixes transient current (and the other mask/VRM inputs) being rejected on Apply under German Windows locale.

## Test plan

- [ ] `pytest tests/test_caploop_impedance_tab.py`
- [ ] Impedance tab → enter `0.5` for transient current → Apply succeeds
- [ ] Reload rail config → field shows `0.5`, not locale-formatted scientific notation