### PR TITLE
Fix/nested local net resolution

### DIFF
--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -721,6 +721,17 @@ class InstanceLocalNetResolver:
         ]
         if len(sch_matches) == 1:
             return sch_matches[0]
+        # Channel-qualified PCB designators (``R1.3``) without SourceDesignator
+        # still need the child sheet for local-net fallback; match the base
+        # schematic designator on sch_components.
+        base_des = _base_sch_designator(lookup_des)
+        if base_des.upper() != lookup_des.upper():
+            base_matches = [
+                c.schdoc_name for c in self.proj.sch_components
+                if c.designator.upper() == base_des.upper()
+            ]
+            if len(base_matches) == 1:
+                return base_matches[0]
         return ""
 
     def expand_net_names(
@@ -739,15 +750,16 @@ class InstanceLocalNetResolver:
 
         names = {local_name.upper()}
 
-        if self.proj.compiled_netlist is not None:
-            pads_by = self.pads_index()
-            pcb = self.proj.pcb_components[pcb_index]
-            lookup_des = pcb.source_designator or pcb.designator
-            schdoc = self.infer_schdoc(
-                pcb_index, lookup_des, pads_by_component=pads_by,
-            )
-            routed = pads_by.get(pcb_index, {})
-            if routed:
+        pads_by = self.pads_index()
+        pcb = self.proj.pcb_components[pcb_index]
+        lookup_des = pcb.source_designator or pcb.designator
+        schdoc = self.infer_schdoc(
+            pcb_index, lookup_des, pads_by_component=pads_by,
+        )
+        routed = pads_by.get(pcb_index, {})
+        if routed:
+            local_pins: list[str] = []
+            if self.proj.compiled_netlist is not None:
                 local_pins = _resolve_local_net_pins(
                     self.proj.compiled_netlist,
                     lookup_des,
@@ -756,10 +768,18 @@ class InstanceLocalNetResolver:
                     routed_pin_keys=set(routed),
                     pcb_designator=pcb.designator,
                 )
-                wanted = {p.upper() for p in local_pins}
-                for pin_key, pad in routed.items():
-                    if pin_key in wanted and pad.net_index != NO_NET:
-                        names.add(self.proj.nets[pad.net_index].name.upper())
+            if not local_pins and schdoc:
+                local_pins = _resolve_local_net_pins_child_sheet(
+                    self.proj,
+                    lookup_des,
+                    schdoc,
+                    local_name,
+                    routed_pin_keys=set(routed),
+                )
+            wanted = {p.upper() for p in local_pins}
+            for pin_key, pad in routed.items():
+                if pin_key in wanted and pad.net_index != NO_NET:
+                    names.add(self.proj.nets[pad.net_index].name.upper())
 
         result = tuple(sorted(names))
         self._expanded_cache[cache_key] = result
@@ -767,6 +787,13 @@ class InstanceLocalNetResolver:
 
 
 _resolver_cache: dict[int, tuple[ExtractedProject, InstanceLocalNetResolver]] = {}
+_netlist_options_cache: dict[str, object] = {}
+
+
+def clear_annotation_caches() -> None:
+    """Drop memoized resolvers / netlist options. Call on project (re)load."""
+    _resolver_cache.clear()
+    _netlist_options_cache.clear()
 
 
 def _instance_resolver(proj: ExtractedProject) -> InstanceLocalNetResolver:
@@ -847,9 +874,192 @@ def _sheet_name_matches(schdoc_name: str, source_sheets: list[str]) -> bool:
         s = sheet.replace("\\", "/").lower()
         if s == target_full:
             return True
-        if not has_dir and Path(sheet).name.lower() == target_base:
+        sheet_base = Path(sheet).name.lower()
+        if sheet_base != target_base:
+            continue
+        # Basename-only annotation: accept any path-qualified provenance.
+        if not has_dir:
+            return True
+        # Path-qualified annotation + basename-only netlist sheet (common from
+        # altium_monkey): same basename is enough; path-vs-path mismatches
+        # already failed the equality check above.
+        if "/" not in s:
             return True
     return False
+
+
+def _base_sch_designator(designator: str) -> str:
+    """Strip a numeric channel suffix (``R1.3`` → ``R1``) for child-sheet lookup.
+
+    Child-sheet netlists use the schematic base designator. Non-numeric tails
+    (``J3_SL8M7``) are left unchanged — those sheets key terminals flattened.
+    """
+    if "." not in designator:
+        return designator
+    base, suffix = designator.rsplit(".", 1)
+    return base if suffix.isdigit() and base else designator
+
+
+def _schdoc_path_key(proj: ExtractedProject, schdoc_name: str) -> str | None:
+    """Resolve ``schdoc_name`` to a key in :attr:`ExtractedProject.schdoc_paths`.
+
+    Returns ``None`` when the basename is ambiguous and ``schdoc_name`` carries
+    no path hint — callers must not guess a sheet (wrong pin→net mapping).
+    """
+    paths = getattr(proj, "schdoc_paths", None) or {}
+    if not paths:
+        return None
+    full = schdoc_name.replace("\\", "/").lower()
+    base = Path(schdoc_name).name.lower()
+    if full in paths:
+        return full
+    if base in paths:
+        return base
+    matches = sorted(k for k in paths if Path(k).name.lower() == base)
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        # Basename-only names are never a path hint (``"child.schdoc" in
+        # "mod_a/child.schdoc"`` would false-positive every match).
+        if "/" in full:
+            for k in matches:
+                if k == full or k.endswith("/" + full) or full.endswith("/" + k):
+                    return k
+        log.warning(
+            "Ambiguous SchDoc basename %r matches %s; refusing child-sheet "
+            "fallback without a path hint",
+            base, matches,
+        )
+        return None
+    return None
+
+
+def _basename_sheet_cache_ok(paths: dict[str, str], base: str) -> bool:
+    """True when a basename-only ``sheet_netlists`` entry is unambiguous."""
+    if not paths:
+        return True  # tests / legacy extracts without schdoc_paths
+    if base in paths:
+        return True
+    return sum(1 for k in paths if Path(k).name.lower() == base) <= 1
+
+
+def _netlist_options_for_project(proj: ExtractedProject):
+    """Project netlist options (same source as the full-project compile)."""
+    from altium_monkey.altium_netlist_options import NetlistOptions
+
+    prj = getattr(proj, "prjpcb_path", None)
+    if prj is None:
+        return NetlistOptions()
+    cache_key = str(Path(prj).resolve())
+    cached = _netlist_options_cache.get(cache_key)
+    if cached is not None:
+        return cached
+    try:
+        from altium_monkey.altium_prjpcb import AltiumPrjPcb
+
+        opts = NetlistOptions.from_prjpcb(AltiumPrjPcb(prj))
+    except Exception as exc:
+        log.debug(
+            "Could not load NetlistOptions from %s (%s); using defaults",
+            prj, exc,
+        )
+        # Do not cache failures — a transient PrjPcb read must be retryable.
+        return NetlistOptions()
+    _netlist_options_cache[cache_key] = opts
+    return opts
+
+
+def _compile_sheet_netlist_at_path(path: str, proj: ExtractedProject | None = None):
+    """Compile an isolated netlist for one SchDoc file. Returns None on failure."""
+    try:
+        from altium_monkey.altium_netlist_compilation import compile_netlist
+        from altium_monkey.altium_netlist_options import NetlistOptions
+        from altium_monkey.altium_schdoc import AltiumSchDoc
+
+        options = (
+            _netlist_options_for_project(proj)
+            if proj is not None
+            else NetlistOptions()
+        )
+        sch = AltiumSchDoc(path)
+        return compile_netlist([sch], None, options)
+    except Exception as exc:
+        log.warning("Could not compile child-sheet netlist for %s: %s", path, exc)
+        return None
+
+
+def _get_child_sheet_netlist(proj: ExtractedProject, schdoc_name: str):
+    """Return (and lazily compile) an isolated netlist for one child sheet.
+
+    Deeply nested REPEAT hierarchies sometimes omit flattened channel instances
+    from the project-wide netlist (e.g. ``R1.3`` missing while ``R1.1`` is
+    present). Pin→local-net wiring on the child sheet is identical for every
+    channel instance, so a single-sheet compile is sufficient.
+    """
+    if not schdoc_name:
+        return None
+    key = _schdoc_path_key(proj, schdoc_name)
+    sheets = getattr(proj, "sheet_netlists", None)
+    if sheets is None:
+        return None
+    if key is not None and key in sheets:
+        return sheets[key]
+
+    paths = getattr(proj, "schdoc_paths", None) or {}
+    base = Path(schdoc_name).name.lower()
+    # Tests / legacy: pre-populated basename entries, only if unambiguous.
+    if base in sheets and _basename_sheet_cache_ok(paths, base):
+        return sheets[base]
+
+    path = paths.get(key) if key else None
+    if not path:
+        return None
+    nl = _compile_sheet_netlist_at_path(path, proj)
+    if nl is None:
+        # Do not memoize failures — a transient I/O error must be retryable.
+        return None
+    sheets[key] = nl
+    if base in paths and paths[base] == path:
+        sheets[base] = nl
+    return nl
+
+
+def _resolve_local_net_pins_child_sheet(
+    proj: ExtractedProject,
+    sch_designator: str,
+    schdoc_name: str,
+    local_net_name: str,
+    *,
+    routed_pin_keys: set[str] | None = None,
+) -> list[str]:
+    """Resolve pins via a child-sheet-only netlist (base schematic designator)."""
+    netlist = _get_child_sheet_netlist(proj, schdoc_name)
+    if netlist is None:
+        return []
+    # Child-sheet terminals use the base schematic designator (``R1``), not
+    # the flattened PCB form (``R1.3``).
+    base_des = _base_sch_designator(sch_designator).upper()
+    des_candidates = {base_des}
+    pins: list[str] = []
+    seen: set[str] = set()
+    for net in netlist.nets:
+        names = [net.name, *getattr(net, "aliases", ())]
+        if not any(
+            _local_net_label_matches(n, local_net_name, des_candidates)
+            for n in names
+        ):
+            continue
+        for term in net.terminals:
+            if term.designator.upper() != base_des:
+                continue
+            pin = str(term.pin)
+            key = pin.upper()
+            if routed_pin_keys is not None and key not in routed_pin_keys:
+                continue
+            if key not in seen:
+                seen.add(key)
+                pins.append(pin)
+    return pins
 
 
 def _resolve_local_net_pins(
@@ -1046,6 +1256,16 @@ def _resolve_terminal(
                 routed_pin_keys=routed_pin_keys or None,
                 pcb_designator=designator,
             )
+            child_sheet_pins = False
+            if not local_pins and schdoc_name:
+                local_pins = _resolve_local_net_pins_child_sheet(
+                    proj,
+                    sch_lookup_designator,
+                    schdoc_name,
+                    net_name,
+                    routed_pin_keys=routed_pin_keys or None,
+                )
+                child_sheet_pins = bool(local_pins)
             if local_pins:
                 wanted_pins = {pin.upper() for pin in local_pins}
                 matched = [
@@ -1062,9 +1282,14 @@ def _resolve_terminal(
                             if p.net_index != NO_NET
                         })
                         nets_text = ", ".join(pcb_net_names) if pcb_net_names else "?"
+                        via = (
+                            "child-sheet schematic pins"
+                            if child_sheet_pins
+                            else "schematic pins"
+                        )
                         warnings.append(
                             f"{role_diagnostic}: resolved local net "
-                            f"{net_name!r} via schematic pins "
+                            f"{net_name!r} via {via} "
                             f"{sorted(local_pins)} → PCB net(s) {nets_text}"
                         )
 

--- a/fypa/altium/extract.py
+++ b/fypa/altium/extract.py
@@ -398,7 +398,10 @@ class RawStackupLayer:
 @dataclass(frozen=True, slots=True)
 class RawSchComponent:
     designator: str
-    schdoc_name: str          # filename only, e.g. 'Power.SchDoc'
+    # Project-relative SchDoc path (forward slashes, original casing preserved
+    # for diagnostics), e.g. ``Power.SchDoc`` or ``mod/Child.SchDoc``. Absolute
+    # path string when the file sits outside the ``.PrjPcb`` tree.
+    schdoc_name: str
     parameters: dict[str, str]  # name -> text (case-preserved keys)
     pin_designators: tuple[str, ...]
 
@@ -421,6 +424,15 @@ class ExtractedProject:
     # Compiled schematic netlist (multi-sheet aware). Used to translate local
     # sheet net names in PDN_*_NET parameters to per-instance PCB connectivity.
     compiled_netlist: Any | None = None
+    # Absolute SchDoc paths keyed by project-relative lowercase path (forward
+    # slashes). When a basename is unique in the project it is also registered
+    # as an alias key (``"child.schdoc"``) so callers that only know the
+    # filename still resolve. Used for lazy per-sheet netlist compiles.
+    schdoc_paths: dict[str, str] = field(default_factory=dict)
+    # Lazily filled single-sheet netlists, keyed like :attr:`schdoc_paths`.
+    # Empty until a child-sheet local-net fallback needs a sheet; keeps the
+    # design-info pickle small.
+    sheet_netlists: dict[str, Any] = field(default_factory=dict)
     # User-defined Altium origin (Board6/ORIGINX,ORIGINY), in mm. Every
     # Pt2D produced above has already had this subtracted, so coordinates
     # match what Altium displays when the user has set a custom origin.
@@ -1337,10 +1349,37 @@ def _extract_sch_component(comp, schdoc_name: str) -> RawSchComponent | None:
     )
 
 
-def _extract_sch_components(design) -> tuple[RawSchComponent, ...]:
+def _schdoc_storage_key(abs_path: Path, project_root: Path) -> str:
+    """Stable lowercase dict key for one SchDoc path.
+
+    Prefer a path relative to the ``.PrjPcb`` directory (lowercase, ``/``).
+    Files outside that tree use the absolute path so two external sheets with
+    the same basename do not collide.
+    """
+    return _schdoc_display_path(abs_path, project_root).lower()
+
+
+def _schdoc_display_path(abs_path: Path, project_root: Path) -> str:
+    """Case-preserving relative (or absolute) SchDoc path for annotations/UI."""
+    abs_path = abs_path.resolve()
+    root = project_root.resolve()
+    try:
+        return str(abs_path.relative_to(root)).replace("\\", "/")
+    except ValueError:
+        return str(abs_path).replace("\\", "/")
+
+
+def _extract_sch_components(
+    design,
+    prjpcb_path: Path,
+) -> tuple[RawSchComponent, ...]:
     out: list[RawSchComponent] = []
+    root = prjpcb_path.parent
     for sd in design.schdocs:
-        schdoc_name = sd.filepath.name
+        if not getattr(sd, "filepath", None):
+            continue
+        # Preserve casing for diagnostics; lookups lower-case on compare.
+        schdoc_name = _schdoc_display_path(Path(sd.filepath), root)
         for comp in sd.components:
             rec = _extract_sch_component(comp, schdoc_name)
             if rec is not None:
@@ -1388,6 +1427,36 @@ def _compile_schematic_netlist(design: AltiumDesign) -> Netlist | None:
         return None
 
 
+def _collect_schdoc_paths(
+    design: AltiumDesign,
+    prjpcb_path: Path,
+) -> dict[str, str]:
+    """Map unique SchDoc keys → absolute path strings for lazy sheet compiles.
+
+    Primary key is :func:`_schdoc_storage_key` (project-relative, or absolute
+    when outside the tree). When a basename is unique across the project it is
+    also registered so callers that only know ``Child.SchDoc`` still resolve.
+    """
+    root = prjpcb_path.parent
+    entries: list[tuple[str, str, str]] = []
+    basename_counts: dict[str, int] = {}
+    for sch in design.schdocs:
+        if not getattr(sch, "filepath", None):
+            continue
+        abs_path = Path(sch.filepath).resolve()
+        key = _schdoc_storage_key(abs_path, root)
+        base = abs_path.name.lower()
+        entries.append((key, str(abs_path), base))
+        basename_counts[base] = basename_counts.get(base, 0) + 1
+
+    out: dict[str, str] = {}
+    for key, abs_s, base in entries:
+        out[key] = abs_s
+        if basename_counts.get(base, 0) == 1:
+            out[base] = abs_s
+    return out
+
+
 def extract_project(prjpcb_path: str | Path,
                     pcbdoc_selector: str | Path | None = None,
                     ) -> ExtractedProject:
@@ -1407,6 +1476,11 @@ def extract_project(prjpcb_path: str | Path,
         raise FileNotFoundError(f"PrjPcb not found: {prjpcb_path}")
 
     log.info("Loading Altium project: %s", prjpcb_path)
+    # Drop annotation memoization from any previous project so a reload of the
+    # same path cannot reuse stale child-sheet / resolver state.
+    from fypa.altium.annotations import clear_annotation_caches
+    clear_annotation_caches()
+
     design = AltiumDesign.from_prjpcb(str(prjpcb_path))
     pcb = design.load_pcbdoc(selector=pcbdoc_selector)
     if pcb is None:
@@ -1426,6 +1500,7 @@ def extract_project(prjpcb_path: str | Path,
     oy_mm = mils_to_mm(origin_y_mils)
 
     compiled_netlist = _compile_schematic_netlist(design)
+    schdoc_paths = _collect_schdoc_paths(design, prjpcb_path)
 
     return ExtractedProject(
         prjpcb_path=prjpcb_path,
@@ -1441,8 +1516,10 @@ def extract_project(prjpcb_path: str | Path,
         pcb_components=_extract_pcb_components(pcb, ox_mm, oy_mm),
         nets=_extract_nets(pcb),
         stackup=_extract_stackup(pcb),
-        sch_components=_extract_sch_components(design),
+        sch_components=_extract_sch_components(design, prjpcb_path),
         compiled_netlist=compiled_netlist,
+        schdoc_paths=schdoc_paths,
+        sheet_netlists={},
         board_origin_mm=Pt2D(ox_mm, oy_mm),
         board_outline=_extract_board_outline(pcb, ox_mm, oy_mm),
         **_plane_rule_kwargs(pcb),

--- a/fypa/cli.py
+++ b/fypa/cli.py
@@ -1044,6 +1044,10 @@ def _try_load_cached_design_info(
         log.info("Design-info cache: fingerprint mismatch — re-extracting.")
         return None
     log.info("Design-info cache hit — reusing the design extract.")
+    # Same as extract_project: drop resolvers memoized against a prior
+    # ExtractedProject identity so a cache hit cannot reuse stale state.
+    from fypa.altium.annotations import clear_annotation_caches
+    clear_annotation_caches()
     return blob.get("loaded")
 
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -878,6 +878,81 @@ def test_sheet_name_matches_full_path_not_basename_collision():
         "Power.SchDoc",
         ["SubB/Power.SchDoc"],
     )
+    # Path-qualified annotation vs basename-only netlist provenance.
+    assert _sheet_name_matches(
+        "mod/Child.SchDoc",
+        ["Child.SchDoc"],
+    )
+    assert _sheet_name_matches(
+        "mod/Child.SchDoc",
+        ["child.schdoc"],
+    )
+
+
+def test_resolve_local_net_relative_schdoc_with_basename_source_sheets():
+    """Nested relative schdoc_name must still hit project-netlist pins."""
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="RAIL",
+            aliases=["VIN_LOCAL"],
+            source_sheets=["Child.SchDoc"],  # basename only
+            terminals=[_FakeTerminal("R1", "1")],
+        ),
+    ])
+    proj = _minimal_proj(
+        nets=(RawNet("VIN_GROUP"),),
+        pcb_components=(
+            RawPcbComponent(
+                designator="R1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1005R", source_designator="R1",
+            ),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="R1", schdoc_name="mod/Child.SchDoc",
+                parameters={}, pin_designators=("1", "2"),
+            ),
+        ),
+        pads=(_pad(0, "1", 0),),
+        compiled_netlist=netlist,
+        schdoc_paths={"mod/child.schdoc": r"C:\proj\mod\Child.SchDoc"},
+        sheet_netlists={},
+    )
+    # Must resolve via project netlist (not require child-sheet compile).
+    with patch(
+        "fypa.altium.annotations._compile_sheet_netlist_at_path",
+    ) as compile_mock:
+        spec, err = _resolve_terminal(
+            proj, 0, "VIN_LOCAL", None, [1], "SERIES P",
+            sch_lookup_designator="R1", schdoc_name="mod/Child.SchDoc",
+        )
+    assert not err and spec is not None
+    assert spec.pins[0].net_index == 0
+    compile_mock.assert_not_called()
+
+
+def test_netlist_options_for_project_does_not_cache_load_failure():
+    from fypa.altium.annotations import (
+        _netlist_options_for_project,
+        clear_annotation_caches,
+    )
+
+    clear_annotation_caches()
+    proj = _minimal_proj(prjpcb_path=Path("C:/proj/board.PrjPcb"))
+    sentinel = object()
+    with patch(
+        "altium_monkey.altium_prjpcb.AltiumPrjPcb",
+        side_effect=[RuntimeError("locked"), object()],
+    ):
+        with patch(
+            "altium_monkey.altium_netlist_options.NetlistOptions.from_prjpcb",
+            return_value=sentinel,
+        ) as from_prj:
+            first = _netlist_options_for_project(proj)
+            second = _netlist_options_for_project(proj)
+    assert first is not sentinel  # defaults after failure
+    assert second is sentinel
+    assert from_prj.call_count == 1
 
 
 def test_pcb_sourced_local_net_scoped_per_instance():
@@ -1054,6 +1129,358 @@ def test_resolve_local_net_pins_dot_channel_alias_scoped():
         pcb_designator="J3.4",
     )
     assert pins == []
+
+
+def test_resolve_terminal_child_sheet_fallback_when_project_netlist_incomplete():
+    """Nested REPEAT: project netlist may omit R1.3 while R1.1 exists."""
+    full_netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="RAIL_A",
+            aliases=["VIN_LOCAL.1"],
+            source_sheets=["Child.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "1")],
+        ),
+        _FakeNet(
+            name="RAIL_B",
+            aliases=["VOUT.1"],
+            source_sheets=["Child.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "2")],
+        ),
+    ])
+    child_netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="VIN_LOCAL",
+            source_sheets=["Child.SchDoc"],
+            terminals=[_FakeTerminal("R1", "1")],
+        ),
+        _FakeNet(
+            name="VOUT",
+            source_sheets=["Child.SchDoc"],
+            terminals=[_FakeTerminal("R1", "2")],
+        ),
+    ])
+    proj = _minimal_proj(
+        nets=(RawNet("VIN_GROUP.2"), RawNet("VOUT.3")),
+        pcb_components=(
+            RawPcbComponent(
+                designator="R1.3", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1005R", source_designator="R1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 0),
+            _pad(0, "2", 1),
+        ),
+        compiled_netlist=full_netlist,
+        sheet_netlists={"child.schdoc": child_netlist},
+    )
+    p_spec, p_err = _resolve_terminal(
+        proj, 0, "VIN_LOCAL", None, [1], "SERIES P",
+        sch_lookup_designator="R1", schdoc_name="Child.SchDoc",
+    )
+    n_spec, n_err = _resolve_terminal(
+        proj, 0, "VOUT", None, [1], "SERIES N",
+        sch_lookup_designator="R1", schdoc_name="Child.SchDoc",
+    )
+    assert not p_err and not n_err
+    assert p_spec is not None and n_spec is not None
+    assert p_spec.pins[0].net_index == 0
+    assert n_spec.pins[0].net_index == 1
+
+
+def test_expand_net_names_child_sheet_fallback():
+    """expand_net_names must use sheet_netlists when project netlist omits the instance."""
+    full_netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="RAIL_A",
+            aliases=["VIN_LOCAL.1"],
+            source_sheets=["Child.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "1")],
+        ),
+    ])
+    child_netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="VIN_LOCAL",
+            source_sheets=["Child.SchDoc"],
+            terminals=[_FakeTerminal("R1", "1")],
+        ),
+    ])
+    proj = _minimal_proj(
+        nets=(RawNet("VIN_GROUP.2"),),
+        pcb_components=(
+            RawPcbComponent(
+                designator="R1.3", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1005R", source_designator="R1",
+            ),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="R1", schdoc_name="Child.SchDoc",
+                parameters={}, pin_designators=("1", "2"),
+            ),
+        ),
+        pads=(_pad(0, "1", 0),),
+        compiled_netlist=full_netlist,
+        sheet_netlists={"child.schdoc": child_netlist},
+    )
+    names = _instance_resolver(proj).expand_net_names("VIN_LOCAL", 0)
+    assert "VIN_GROUP.2" in names
+    assert "VIN_LOCAL" in names
+
+
+def test_resolve_local_net_pins_child_sheet_direct():
+    child_netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="VIN_LOCAL",
+            terminals=[_FakeTerminal("R1", "1")],
+        ),
+    ])
+    proj = _minimal_proj(sheet_netlists={"child.schdoc": child_netlist})
+    from fypa.altium.annotations import _resolve_local_net_pins_child_sheet
+    pins = _resolve_local_net_pins_child_sheet(
+        proj, "R1", "Child.SchDoc", "VIN_LOCAL",
+        routed_pin_keys={"1"},
+    )
+    assert pins == ["1"]
+    assert _resolve_local_net_pins_child_sheet(
+        proj, "R1", "Child.SchDoc", "VIN_LOCAL",
+        routed_pin_keys={"2"},
+    ) == []
+
+
+def test_base_sch_designator_strips_numeric_channel():
+    from fypa.altium.annotations import _base_sch_designator
+    assert _base_sch_designator("R1.3") == "R1"
+    assert _base_sch_designator("R1") == "R1"
+    assert _base_sch_designator("J3_SL8M7") == "J3_SL8M7"
+    assert _base_sch_designator("U1.A") == "U1.A"
+
+
+def test_child_sheet_resolves_channel_designator_without_source_designator():
+    """PCB designator R1.3 with no source_designator still matches child R1."""
+    full_netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="RAIL_A",
+            aliases=["VIN_LOCAL.1"],
+            source_sheets=["Child.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "1")],
+        ),
+    ])
+    child_netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="VIN_LOCAL",
+            source_sheets=["Child.SchDoc"],
+            terminals=[_FakeTerminal("R1", "1")],
+        ),
+    ])
+    proj = _minimal_proj(
+        nets=(RawNet("VIN_GROUP.2"),),
+        pcb_components=(
+            RawPcbComponent(
+                designator="R1.3", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1005R",
+                source_designator="",  # missing — lookup falls back to R1.3
+            ),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="R1", schdoc_name="Child.SchDoc",
+                parameters={}, pin_designators=("1", "2"),
+            ),
+        ),
+        pads=(_pad(0, "1", 0),),
+        compiled_netlist=full_netlist,
+        sheet_netlists={"child.schdoc": child_netlist},
+    )
+    spec, err = _resolve_terminal(
+        proj, 0, "VIN_LOCAL", None, [1], "SERIES P",
+        sch_lookup_designator="R1.3", schdoc_name="Child.SchDoc",
+    )
+    assert not err and spec is not None
+    assert spec.pins[0].net_index == 0
+    names = _instance_resolver(proj).expand_net_names("VIN_LOCAL", 0)
+    assert "VIN_GROUP.2" in names
+
+
+def test_schdoc_path_key_prefers_relative_path_on_basename_collision():
+    from fypa.altium.annotations import _get_child_sheet_netlist, _schdoc_path_key
+
+    nl_a = _FakeNetlist(nets=[
+        _FakeNet(name="VIN", terminals=[_FakeTerminal("R1", "1")]),
+    ])
+    nl_b = _FakeNetlist(nets=[
+        _FakeNet(name="VOUT", terminals=[_FakeTerminal("R1", "1")]),
+    ])
+    # Collision: same basename, no basename alias — only relative keys.
+    proj = _minimal_proj(
+        schdoc_paths={
+            "mod_a/child.schdoc": r"C:\proj\mod_a\Child.SchDoc",
+            "mod_b/child.schdoc": r"C:\proj\mod_b\Child.SchDoc",
+        },
+        sheet_netlists={
+            "mod_a/child.schdoc": nl_a,
+            "mod_b/child.schdoc": nl_b,
+        },
+    )
+    assert _schdoc_path_key(proj, "mod_a/Child.SchDoc") == "mod_a/child.schdoc"
+    assert _schdoc_path_key(proj, "mod_b/Child.SchDoc") == "mod_b/child.schdoc"
+    assert _get_child_sheet_netlist(proj, "mod_a/Child.SchDoc") is nl_a
+    assert _get_child_sheet_netlist(proj, "mod_b/Child.SchDoc") is nl_b
+
+
+def test_schdoc_path_key_refuses_ambiguous_basename_only():
+    """Basename-only lookup must not guess when two sheets share the name."""
+    from fypa.altium.annotations import _get_child_sheet_netlist, _schdoc_path_key
+
+    nl_a = _FakeNetlist(nets=[
+        _FakeNet(name="VIN", terminals=[_FakeTerminal("R1", "1")]),
+    ])
+    proj = _minimal_proj(
+        schdoc_paths={
+            "mod_a/child.schdoc": r"C:\proj\mod_a\Child.SchDoc",
+            "mod_b/child.schdoc": r"C:\proj\mod_b\Child.SchDoc",
+        },
+        sheet_netlists={
+            "mod_a/child.schdoc": nl_a,
+            "child.schdoc": nl_a,  # must not be used under ambiguity
+        },
+    )
+    assert _schdoc_path_key(proj, "Child.SchDoc") is None
+    assert _get_child_sheet_netlist(proj, "Child.SchDoc") is None
+
+
+def test_get_child_sheet_netlist_lazy_compile_memoizes():
+    from fypa.altium.annotations import _get_child_sheet_netlist
+
+    child_nl = _FakeNetlist(nets=[
+        _FakeNet(name="VIN", terminals=[_FakeTerminal("R1", "1")]),
+    ])
+    proj = _minimal_proj(
+        schdoc_paths={"child.schdoc": r"C:\proj\Child.SchDoc"},
+        sheet_netlists={},
+    )
+    with patch(
+        "fypa.altium.annotations._compile_sheet_netlist_at_path",
+        return_value=child_nl,
+    ) as compile_mock:
+        first = _get_child_sheet_netlist(proj, "Child.SchDoc")
+        second = _get_child_sheet_netlist(proj, "Child.SchDoc")
+    assert first is child_nl
+    assert second is child_nl
+    assert compile_mock.call_count == 1
+    assert proj.sheet_netlists.get("child.schdoc") is child_nl
+
+
+def test_get_child_sheet_netlist_does_not_cache_failed_compile():
+    from fypa.altium.annotations import _get_child_sheet_netlist
+
+    child_nl = _FakeNetlist(nets=[
+        _FakeNet(name="VIN", terminals=[_FakeTerminal("R1", "1")]),
+    ])
+    proj = _minimal_proj(
+        schdoc_paths={"child.schdoc": r"C:\proj\Child.SchDoc"},
+        sheet_netlists={},
+    )
+    with patch(
+        "fypa.altium.annotations._compile_sheet_netlist_at_path",
+        side_effect=[None, child_nl],
+    ) as compile_mock:
+        assert _get_child_sheet_netlist(proj, "Child.SchDoc") is None
+        assert "child.schdoc" not in proj.sheet_netlists
+        assert _get_child_sheet_netlist(proj, "Child.SchDoc") is child_nl
+    assert compile_mock.call_count == 2
+
+
+def test_compile_sheet_netlist_uses_project_netlist_options():
+    from fypa.altium.annotations import (
+        _compile_sheet_netlist_at_path,
+        clear_annotation_caches,
+    )
+
+    clear_annotation_caches()
+    proj = _minimal_proj(prjpcb_path=Path("C:/proj/board.PrjPcb"))
+    sentinel = object()
+    with (
+        patch(
+            "fypa.altium.annotations._netlist_options_for_project",
+            return_value=sentinel,
+        ) as opts_mock,
+        patch("altium_monkey.altium_schdoc.AltiumSchDoc") as sch_cls,
+        patch(
+            "altium_monkey.altium_netlist_compilation.compile_netlist",
+            return_value="NL",
+        ) as compile_mock,
+    ):
+        sch_cls.return_value = object()
+        assert _compile_sheet_netlist_at_path(r"C:\proj\Child.SchDoc", proj) == "NL"
+    opts_mock.assert_called_once_with(proj)
+    assert compile_mock.call_args.args[2] is sentinel
+
+
+def test_collect_schdoc_paths_unique_basename_alias_only():
+    from fypa.altium.extract import _collect_schdoc_paths
+
+    @dataclass
+    class _Sch:
+        filepath: str
+
+    @dataclass
+    class _Design:
+        schdocs: list
+
+    root = Path("C:/proj")
+    design = _Design(schdocs=[
+        _Sch(filepath=str(root / "Power.SchDoc")),
+        _Sch(filepath=str(root / "mod_a" / "Child.SchDoc")),
+        _Sch(filepath=str(root / "mod_b" / "Child.SchDoc")),
+    ])
+    paths = _collect_schdoc_paths(design, root / "board.PrjPcb")
+    assert paths["power.schdoc"].lower().endswith("power.schdoc")
+    assert "child.schdoc" not in paths  # basename collision — no alias
+    assert "mod_a/child.schdoc" in paths
+    assert "mod_b/child.schdoc" in paths
+
+
+def test_collect_schdoc_paths_outside_root_uses_absolute_key():
+    from fypa.altium.extract import (
+        _collect_schdoc_paths,
+        _schdoc_display_path,
+        _schdoc_storage_key,
+    )
+
+    @dataclass
+    class _Sch:
+        filepath: str
+
+    @dataclass
+    class _Design:
+        schdocs: list
+
+    root = Path("C:/proj")
+    outside_a = Path("D:/libs/Shared.SchDoc")
+    outside_b = Path("E:/other/Shared.SchDoc")
+    design = _Design(schdocs=[
+        _Sch(filepath=str(outside_a)),
+        _Sch(filepath=str(outside_b)),
+    ])
+    paths = _collect_schdoc_paths(design, root / "board.PrjPcb")
+    key_a = _schdoc_storage_key(outside_a, root)
+    key_b = _schdoc_storage_key(outside_b, root)
+    assert key_a != key_b
+    assert key_a == _schdoc_display_path(outside_a, root).lower()
+    assert "shared.schdoc" not in paths  # colliding basenames — no alias
+    assert paths[key_a].lower().endswith("shared.schdoc")
+    assert paths[key_b].lower().endswith("shared.schdoc")
+
+
+def test_schdoc_display_path_preserves_casing():
+    from fypa.altium.extract import _schdoc_display_path, _schdoc_storage_key
+
+    root = Path("C:/proj")
+    abs_path = root / "mod" / "Child.SchDoc"
+    display = _schdoc_display_path(abs_path, root)
+    assert display == "mod/Child.SchDoc"
+    assert _schdoc_storage_key(abs_path, root) == "mod/child.schdoc"
 
 
 def test_schdoc_inference_pin_centric_without_net_name_match():


### PR DESCRIPTION
## Summary
- Fix local-net PDN resolution when the project-wide schematic netlist omits some channel instances of a repeated/nested child sheet (PCB has all flattened designators; netlist only has a subset).
- Lazily compile per-child-sheet netlists on demand (relative SchDoc keys, project `NetlistOptions`, cache clear on extract / design-info hit).
- Harden path/designator lookup: refuse ambiguous basename-only sheets, strip numeric channel suffixes when `SourceDesignator` is missing, match path-qualified annotations to basename-only netlist provenance.

## Root cause (not an Altium design error)
Nested multi-placement of the same child sheet (outer sheet symbols × inner leaf placements) is valid Altium hierarchy; PCB annotation is correct. The gap is in **altium_monkey** hierarchical netlist compilation, which under-expands outer sheet instantiations — tracked upstream as [wavenumber-eng/altium_monkey#26](https://github.com/wavenumber-eng/altium_monkey/issues/26). FYPA’s child-sheet fallback is a deliberate workaround: pin→local-net wiring on the leaf sheet is identical for every channel. A proper fix belongs in altium_monkey’s hierarchy flatten.

## Test plan
- [ ] `pytest tests/test_annotations.py`
- [ ] Re-extract a nested multi-placement board; previously missing channel instances resolve with 0 annotation errors
- [ ] Confirm design-info cache hit clears resolver state (no stale pins across reloads)