### PR TITLE
Add area-weighted pin coupling and SchLib-friendly pin selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,9 @@ dependency — including `altium_monkey`, which uv pulls from
 [upstream](https://github.com/wavenumber-eng/altium_monkey) at the tag pinned
 in `pyproject.toml`'s `[tool.uv.sources]`.
 
-> **Python version: 3.11 or 3.12 only.** The `altium_monkey` upstream pins
-> `requires-python = ">=3.11,<3.13"`, and its `numpy==2.2.3` dependency
-> does not yet ship wheels for 3.13/3.14. `.python-version` pins 3.12, which
-> uv fetches automatically; to use 3.11 instead, edit that file before
-> running `uv sync`.
+> **Python version: 3.12 only.** Both FYPA and `altium_monkey` pin
+> `requires-python = ">=3.12,<3.13"`. `.python-version` selects 3.12, which
+> uv fetches automatically.
 
 Day-to-day commands:
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ Add `PDN_ROLE` on the component (e.g. `PDN_ROLE=SOURCE`) and the required parame
 For 2-pin parts the tool can auto-infer `PDN_P_NET` /
 `PDN_N_NET` from connectivity; for ICs you'll need to set them explicitly.
 
+Pads on a rail net are collected automatically. To keep enable/signal ties
+off the terminal — especially on multi-rail ICs in a SchLib — set part-wide
+`PDN_PINS_ONLY` (optional `PDN_EXTRA_PINS` adds to that list on the instance;
+EXTRA alone is the full allowlist). Per-terminal `PDN_P_PINS` / `PDN_N_PINS`
+still override one terminal; `PDN_IGNORE` / `PDN_IGNORE_PINS` fine-tune
+exclusions. See
+[Restricting which pins may join](docs/user-guide/01-sources-and-sinks.md#restricting-which-pins-may-join-allowlist)
+in the user guide.
+
 ### `SINK` — minimum-voltage check (`PDN_MIN_V`)
 
 A `SINK` can carry an optional `PDN_MIN_V` parameter giving the **minimum

--- a/docs/user-guide/01-sources-and-sinks.md
+++ b/docs/user-guide/01-sources-and-sinks.md
@@ -173,6 +173,36 @@ To override the inferred pad set (e.g. to exclude a thermal pad), use
 the `PDN_P_PINS` / `PDN_N_PINS` parameters documented in the
 [main README](../../README.md).
 
+### Excluding non-current pins
+
+Enable pins hard-tied to the supply, or signal pins pulled to GND, sit on
+the same net as the power pads but do not carry load current. Listing
+every *included* pin in `PDN_P_PINS` gets long on a BGA. Prefer an
+**exclude** instead:
+
+1. **Pin parameter (preferred)** — on the schematic pin (Pin Properties →
+   Parameters), add `PDN_IGNORE` = `1` (also `TRUE` / `YES` / `IGNORE`).
+   Alias: name `PDN`, value `IGNORE`. Works in the library symbol so every
+   placement inherits it.
+2. **Component list** — `PDN_IGNORE_PINS` (or `PDNn_IGNORE_PINS` for one
+   channel) with a short comma-separated list of pin designators.
+
+Ignored pins are removed after net or include matching, so they never
+join the SOURCE/SINK terminal — including on GND/return.
+
+### Area-weighted multi-pin coupling
+
+By default each pin of a multi-pin terminal couples through the same
+star resistance. For parts with differently sized power pads (or a large
+QFN thermal pad on GND), open **Settings** and enable **Weight multi-pin
+coupling by pad area**. Coupling resistance then scales as
+`R ∝ 1/A`, so larger pads take a larger share of current when copper
+access is similar. Off by default.
+
+Marker hover text uses the same area weights as a quick estimate
+(`I · A_i / ΣA`). The FEM can still shift current when copper access to
+the pads differs — the hover value is not a guaranteed pin current.
+
 ### Several rails on one part (multi-channel)
 
 An IC that draws from more than one supply rail is a single part with

--- a/docs/user-guide/01-sources-and-sinks.md
+++ b/docs/user-guide/01-sources-and-sinks.md
@@ -341,6 +341,12 @@ placing them on every symbol:
 4. Launch FYPA — it reads the `PDN_*` values from the **PCB component
    parameters** (not from the blanket graphic itself).
 
+A SchLib symbol may already carry part-wide pin filters such as
+`PDN_PINS_ONLY` without a `PDN_ROLE`. That is normal: after ECO the role
+and values live on the PCB instance, and FYPA does not warn about the
+symbol-side pin filter alone. If the PCB still has no role (ECO not
+applied), FYPA logs an informational note so the missing sync is visible.
+
 ### Local net names (hierarchical / reused sheets)
 
 `PDN_P_NET`, `PDN_N_NET`, and `PDN_NET` may use the **local net name

--- a/docs/user-guide/01-sources-and-sinks.md
+++ b/docs/user-guide/01-sources-and-sinks.md
@@ -169,26 +169,52 @@ directive bridges those nets elsewhere on the board. Name the net that
 the pad actually sits on in the PCB netlist (see 1.8 if the pin is on
 a switching node or pre-inductor net).
 
-To override the inferred pad set (e.g. to exclude a thermal pad), use
-the `PDN_P_PINS` / `PDN_N_PINS` parameters documented in the
-[main README](../../README.md).
+To override the inferred pad set for one terminal (e.g. a single rail on
+a simple part), use `PDN_P_PINS` / `PDN_N_PINS` as documented in the
+[main README](../../README.md). For multi-rail ICs those lists are awkward
+in a SchLib because channel indices (`PDN` / `PDN1` / …) are board-specific.
 
-### Excluding non-current pins
+### Restricting which pins may join (allowlist)
 
-Enable pins hard-tied to the supply, or signal pins pulled to GND, sit on
-the same net as the power pads but do not carry load current. Listing
-every *included* pin in `PDN_P_PINS` gets long on a BGA. Prefer an
-**exclude** instead:
+Enable pins hard-tied to a supply, or signal pins pulled to GND, sit on
+the same net as the power pads but should not carry load current. Prefer a
+**part-wide allowlist** in the library — independent of channel indices —
+then let net matching partition pins across rails:
 
-1. **Pin parameter (preferred)** — on the schematic pin (Pin Properties →
-   Parameters), add `PDN_IGNORE` = `1` (also `TRUE` / `YES` / `IGNORE`).
-   Alias: name `PDN`, value `IGNORE`. Works in the library symbol so every
-   placement inherits it.
-2. **Component list** — `PDN_IGNORE_PINS` (or `PDNn_IGNORE_PINS` for one
-   channel) with a short comma-separated list of pin designators.
+1. **`PDN_PINS_ONLY`** (preferred in the SchLib) — comma/whitespace list of
+   pin designators that may join any SOURCE/SINK/SERIES/REGULATOR terminal.
+   Pads not on the list are never considered, even when they sit on
+   `PDN_P_NET` / `PDN_N_NET`.
+2. **`PDN_EXTRA_PINS`** — always **unioned** into the allowlist. Typical use:
+   library sets `PDN_PINS_ONLY`, the schematic instance adds one forgotten
+   pin via `PDN_EXTRA_PINS` without retyping the list. If **only**
+   `PDN_EXTRA_PINS` is set (no `PDN_PINS_ONLY`), that list **is** the full
+   allowlist — it does *not* mean “all pads plus these”.
+3. **Per-terminal override** — `PDN[_n]_P_PINS` / `PDN[_n]_N_PINS` (or
+   single-net `PDN[_n]_PINS`) bypasses the allowlist for that terminal.
+4. **Exclude (fine-tuning)** — pin parameter `PDN_IGNORE` = `1` (also
+   `TRUE` / `YES` / `IGNORE`; alias name `PDN` value `IGNORE`), or
+   component `PDN_IGNORE_PINS` / `PDNn_IGNORE_PINS`, removes pins after
+   matching (including from an explicit include list). Prefer
+   `PDN_IGNORE_PINS` on the part when pin-owned parameters are not visible
+   to FYPA (unusual SchLib hierarchy); the pin-level form needs the
+   parameter's OwnerIndex to point at the pin record.
 
-Ignored pins are removed after net or include matching, so they never
-join the SOURCE/SINK terminal — including on GND/return.
+`PDN_PINS_ONLY` / `PDN_EXTRA_PINS` are **unindexed** (part-wide). Indexed
+forms such as `PDN1_PINS_ONLY` are ignored with a warning.
+
+Example — multi-rail IC in the SchLib with power pins `1`–`4` and `EP`,
+enable pin `EN` hard-tied to `+3V3` on the board:
+
+| Name | Value |
+|------|-------|
+| `PDN_PINS_ONLY` | `1,2,3,4,EP` |
+| `PDN_ROLE` | `SINK` |
+| `PDN_I` | `500mA` | `PDN_P_NET` = `+3V3`, `PDN_N_NET` = `GND` |
+| `PDN1_I` | `250mA` | `PDN1_P_NET` = `+1V8`, `PDN1_N_NET` = `GND` |
+
+`EN` never joins the `+3V3` terminal. On one board, add a forgotten sense
+pin with `PDN_EXTRA_PINS=SNS` on the placed part.
 
 ### Area-weighted multi-pin coupling
 
@@ -200,8 +226,10 @@ coupling by pad area**. Coupling resistance then scales as
 access is similar. Off by default.
 
 Marker hover text uses the same area weights as a quick estimate
-(`I · A_i / ΣA`). The FEM can still shift current when copper access to
-the pads differs — the hover value is not a guaranteed pin current.
+(`I · A_i / ΣA`). Areas come from each pin's pad outline polygon on its
+terminal layer (not a multi-layer copper volume). The FEM can still shift
+current when copper access to the pads differs — the hover value is not a
+guaranteed pin current.
 
 ### Several rails on one part (multi-channel)
 

--- a/docs/via_resistance_model.md
+++ b/docs/via_resistance_model.md
@@ -319,6 +319,7 @@ does not trigger an immediate re-solve; press **Re-run Solver** to apply.
 | Fallback via resistance                | 1.0 mΩ           | Per-hop R substituted when geometry is missing                        |
 | Conductive fill resistivity            | 5×10⁻³ Ω·mm      | `ρ_fill` for the parallel rod inside conductively-filled vias        |
 | Multi-pin coupling resistance          | 100 mΩ           | Star-couples pins within one terminal; not part of the barrel model  |
+| Weight multi-pin coupling by pad area  | off              | When on, each star R scales as `R ∝ 1/A` (supply and GND terminals) |
 
 Solver-side constants (`PLATING_THICKNESS_MM`, `COPPER_RESISTIVITY_OHM_MM`,
 `FALLBACK_VIA_RESISTANCE_OHM`) are patched in

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -722,6 +722,17 @@ class InstanceLocalNetResolver:
         ]
         if len(sch_matches) == 1:
             return sch_matches[0]
+        # Channel-qualified PCB designators (``R1.3``) without SourceDesignator
+        # still need the child sheet for local-net fallback; match the base
+        # schematic designator on sch_components.
+        base_des = _base_sch_designator(lookup_des)
+        if base_des.upper() != lookup_des.upper():
+            base_matches = [
+                c.schdoc_name for c in self.proj.sch_components
+                if c.designator.upper() == base_des.upper()
+            ]
+            if len(base_matches) == 1:
+                return base_matches[0]
         return ""
 
     def expand_net_names(
@@ -740,15 +751,16 @@ class InstanceLocalNetResolver:
 
         names = {local_name.upper()}
 
-        if self.proj.compiled_netlist is not None:
-            pads_by = self.pads_index()
-            pcb = self.proj.pcb_components[pcb_index]
-            lookup_des = pcb.source_designator or pcb.designator
-            schdoc = self.infer_schdoc(
-                pcb_index, lookup_des, pads_by_component=pads_by,
-            )
-            routed = pads_by.get(pcb_index, {})
-            if routed:
+        pads_by = self.pads_index()
+        pcb = self.proj.pcb_components[pcb_index]
+        lookup_des = pcb.source_designator or pcb.designator
+        schdoc = self.infer_schdoc(
+            pcb_index, lookup_des, pads_by_component=pads_by,
+        )
+        routed = pads_by.get(pcb_index, {})
+        if routed:
+            local_pins: list[str] = []
+            if self.proj.compiled_netlist is not None:
                 local_pins = _resolve_local_net_pins(
                     self.proj.compiled_netlist,
                     lookup_des,
@@ -758,10 +770,18 @@ class InstanceLocalNetResolver:
                     pcb_designator=pcb.designator,
                     proj=self.proj,
                 )
-                wanted = {p.upper() for p in local_pins}
-                for pin_key, pad in routed.items():
-                    if pin_key in wanted and pad.net_index != NO_NET:
-                        names.add(self.proj.nets[pad.net_index].name.upper())
+            if not local_pins and schdoc:
+                local_pins = _resolve_local_net_pins_child_sheet(
+                    self.proj,
+                    lookup_des,
+                    schdoc,
+                    local_name,
+                    routed_pin_keys=set(routed),
+                )
+            wanted = {p.upper() for p in local_pins}
+            for pin_key, pad in routed.items():
+                if pin_key in wanted and pad.net_index != NO_NET:
+                    names.add(self.proj.nets[pad.net_index].name.upper())
 
         result = tuple(sorted(names))
         self._expanded_cache[cache_key] = result
@@ -769,6 +789,13 @@ class InstanceLocalNetResolver:
 
 
 _resolver_cache: dict[int, tuple[ExtractedProject, InstanceLocalNetResolver]] = {}
+_netlist_options_cache: dict[str, object] = {}
+
+
+def clear_annotation_caches() -> None:
+    """Drop memoized resolvers / netlist options. Call on project (re)load."""
+    _resolver_cache.clear()
+    _netlist_options_cache.clear()
 
 
 def _instance_resolver(proj: ExtractedProject) -> InstanceLocalNetResolver:
@@ -889,9 +916,192 @@ def _sheet_name_matches(
         s = resolved.replace("\\", "/").lower()
         if s == target_full:
             return True
-        if not has_dir and Path(resolved).name.lower() == target_base:
+        sheet_base = Path(resolved).name.lower()
+        if sheet_base != target_base:
+            continue
+        # Basename-only annotation: accept any path-qualified provenance.
+        if not has_dir:
+            return True
+        # Path-qualified annotation + basename-only netlist sheet (common from
+        # altium_monkey): same basename is enough; path-vs-path mismatches
+        # already failed the equality check above.
+        if "/" not in s:
             return True
     return False
+
+
+def _base_sch_designator(designator: str) -> str:
+    """Strip a numeric channel suffix (``R1.3`` → ``R1``) for child-sheet lookup.
+
+    Child-sheet netlists use the schematic base designator. Non-numeric tails
+    (``J3_SL8M7``) are left unchanged — those sheets key terminals flattened.
+    """
+    if "." not in designator:
+        return designator
+    base, suffix = designator.rsplit(".", 1)
+    return base if suffix.isdigit() and base else designator
+
+
+def _schdoc_path_key(proj: ExtractedProject, schdoc_name: str) -> str | None:
+    """Resolve ``schdoc_name`` to a key in :attr:`ExtractedProject.schdoc_paths`.
+
+    Returns ``None`` when the basename is ambiguous and ``schdoc_name`` carries
+    no path hint — callers must not guess a sheet (wrong pin→net mapping).
+    """
+    paths = getattr(proj, "schdoc_paths", None) or {}
+    if not paths:
+        return None
+    full = schdoc_name.replace("\\", "/").lower()
+    base = Path(schdoc_name).name.lower()
+    if full in paths:
+        return full
+    if base in paths:
+        return base
+    matches = sorted(k for k in paths if Path(k).name.lower() == base)
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        # Basename-only names are never a path hint (``"child.schdoc" in
+        # "mod_a/child.schdoc"`` would false-positive every match).
+        if "/" in full:
+            for k in matches:
+                if k == full or k.endswith("/" + full) or full.endswith("/" + k):
+                    return k
+        log.warning(
+            "Ambiguous SchDoc basename %r matches %s; refusing child-sheet "
+            "fallback without a path hint",
+            base, matches,
+        )
+        return None
+    return None
+
+
+def _basename_sheet_cache_ok(paths: dict[str, str], base: str) -> bool:
+    """True when a basename-only ``sheet_netlists`` entry is unambiguous."""
+    if not paths:
+        return True  # tests / legacy extracts without schdoc_paths
+    if base in paths:
+        return True
+    return sum(1 for k in paths if Path(k).name.lower() == base) <= 1
+
+
+def _netlist_options_for_project(proj: ExtractedProject):
+    """Project netlist options (same source as the full-project compile)."""
+    from altium_monkey.altium_netlist_options import NetlistOptions
+
+    prj = getattr(proj, "prjpcb_path", None)
+    if prj is None:
+        return NetlistOptions()
+    cache_key = str(Path(prj).resolve())
+    cached = _netlist_options_cache.get(cache_key)
+    if cached is not None:
+        return cached
+    try:
+        from altium_monkey.altium_prjpcb import AltiumPrjPcb
+
+        opts = NetlistOptions.from_prjpcb(AltiumPrjPcb(prj))
+    except Exception as exc:
+        log.debug(
+            "Could not load NetlistOptions from %s (%s); using defaults",
+            prj, exc,
+        )
+        # Do not cache failures — a transient PrjPcb read must be retryable.
+        return NetlistOptions()
+    _netlist_options_cache[cache_key] = opts
+    return opts
+
+
+def _compile_sheet_netlist_at_path(path: str, proj: ExtractedProject | None = None):
+    """Compile an isolated netlist for one SchDoc file. Returns None on failure."""
+    try:
+        from altium_monkey.altium_netlist_compilation import compile_netlist
+        from altium_monkey.altium_netlist_options import NetlistOptions
+        from altium_monkey.altium_schdoc import AltiumSchDoc
+
+        options = (
+            _netlist_options_for_project(proj)
+            if proj is not None
+            else NetlistOptions()
+        )
+        sch = AltiumSchDoc(path)
+        return compile_netlist([sch], None, options)
+    except Exception as exc:
+        log.warning("Could not compile child-sheet netlist for %s: %s", path, exc)
+        return None
+
+
+def _get_child_sheet_netlist(proj: ExtractedProject, schdoc_name: str):
+    """Return (and lazily compile) an isolated netlist for one child sheet.
+
+    Deeply nested REPEAT hierarchies sometimes omit flattened channel instances
+    from the project-wide netlist (e.g. ``R1.3`` missing while ``R1.1`` is
+    present). Pin→local-net wiring on the child sheet is identical for every
+    channel instance, so a single-sheet compile is sufficient.
+    """
+    if not schdoc_name:
+        return None
+    key = _schdoc_path_key(proj, schdoc_name)
+    sheets = getattr(proj, "sheet_netlists", None)
+    if sheets is None:
+        return None
+    if key is not None and key in sheets:
+        return sheets[key]
+
+    paths = getattr(proj, "schdoc_paths", None) or {}
+    base = Path(schdoc_name).name.lower()
+    # Tests / legacy: pre-populated basename entries, only if unambiguous.
+    if base in sheets and _basename_sheet_cache_ok(paths, base):
+        return sheets[base]
+
+    path = paths.get(key) if key else None
+    if not path:
+        return None
+    nl = _compile_sheet_netlist_at_path(path, proj)
+    if nl is None:
+        # Do not memoize failures — a transient I/O error must be retryable.
+        return None
+    sheets[key] = nl
+    if base in paths and paths[base] == path:
+        sheets[base] = nl
+    return nl
+
+
+def _resolve_local_net_pins_child_sheet(
+    proj: ExtractedProject,
+    sch_designator: str,
+    schdoc_name: str,
+    local_net_name: str,
+    *,
+    routed_pin_keys: set[str] | None = None,
+) -> list[str]:
+    """Resolve pins via a child-sheet-only netlist (base schematic designator)."""
+    netlist = _get_child_sheet_netlist(proj, schdoc_name)
+    if netlist is None:
+        return []
+    # Child-sheet terminals use the base schematic designator (``R1``), not
+    # the flattened PCB form (``R1.3``).
+    base_des = _base_sch_designator(sch_designator).upper()
+    des_candidates = {base_des}
+    pins: list[str] = []
+    seen: set[str] = set()
+    for net in netlist.nets:
+        names = [net.name, *getattr(net, "aliases", ())]
+        if not any(
+            _local_net_label_matches(n, local_net_name, des_candidates)
+            for n in names
+        ):
+            continue
+        for term in net.terminals:
+            if term.designator.upper() != base_des:
+                continue
+            pin = str(term.pin)
+            key = pin.upper()
+            if routed_pin_keys is not None and key not in routed_pin_keys:
+                continue
+            if key not in seen:
+                seen.add(key)
+                pins.append(pin)
+    return pins
 
 
 def _resolve_local_net_pins(
@@ -1090,6 +1300,16 @@ def _resolve_terminal(
                 pcb_designator=designator,
                 proj=proj,
             )
+            child_sheet_pins = False
+            if not local_pins and schdoc_name:
+                local_pins = _resolve_local_net_pins_child_sheet(
+                    proj,
+                    sch_lookup_designator,
+                    schdoc_name,
+                    net_name,
+                    routed_pin_keys=routed_pin_keys or None,
+                )
+                child_sheet_pins = bool(local_pins)
             if local_pins:
                 wanted_pins = {pin.upper() for pin in local_pins}
                 matched = [
@@ -1106,9 +1326,14 @@ def _resolve_terminal(
                             if p.net_index != NO_NET
                         })
                         nets_text = ", ".join(pcb_net_names) if pcb_net_names else "?"
+                        via = (
+                            "child-sheet schematic pins"
+                            if child_sheet_pins
+                            else "schematic pins"
+                        )
                         warnings.append(
                             f"{role_diagnostic}: resolved local net "
-                            f"{net_name!r} via schematic pins "
+                            f"{net_name!r} via {via} "
                             f"{sorted(local_pins)} → PCB net(s) {nets_text}"
                         )
 

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -11,7 +11,8 @@ Every directive lives on a single Altium component as a set of parameters whose
 names begin with ``PDN_``. ``PDN_ROLE`` selects the role; the other parameters
 supply the value and the rail/return nets. Pin sets are auto-resolved by
 finding the named component's pads that sit on the named net; explicit pin
-overrides are honoured if supplied.
+overrides are honoured if supplied. Pins can be excluded with a pin-level
+``PDN_IGNORE`` parameter or a component ``PDN_IGNORE_PINS`` list.
 
 ============   =============================   ==================================================
 Role           Value params                    Net / pin params
@@ -177,7 +178,7 @@ _RESISTOR_LIKE_ROLES: frozenset[str] = frozenset({"SERIES"})
 VALID_ROLES: frozenset[str] = frozenset({"SOURCE", "SINK", "REGULATOR"}) | _RESISTOR_LIKE_ROLES
 
 _COMMON_TERMINAL_SUFFIXES: frozenset[str] = frozenset({
-    "NET", "PINS", "P_NET", "N_NET", "P_PINS", "N_PINS",
+    "NET", "PINS", "P_NET", "N_NET", "P_PINS", "N_PINS", "IGNORE_PINS",
 })
 _KNOWN_SUFFIXES_BY_ROLE: dict[str, frozenset[str]] = {
     "SOURCE": _COMMON_TERMINAL_SUFFIXES | frozenset({"V"}),
@@ -186,8 +187,9 @@ _KNOWN_SUFFIXES_BY_ROLE: dict[str, frozenset[str]] = {
         "V", "GAIN", "REGULATOR_TYPE", "REGULATOR_EFFICIENCY", "QUIESCENT",
         "OUT_P_NET", "OUT_N_NET", "OUT_P_PINS", "OUT_N_PINS",
         "IN_P_NET", "IN_N_NET", "IN_P_PINS", "IN_N_PINS",
+        "IGNORE_PINS",
     }),
-    "SERIES": frozenset({"R", "P_NET", "N_NET", "P_PINS", "N_PINS"}),
+    "SERIES": frozenset({"R", "P_NET", "N_NET", "P_PINS", "N_PINS", "IGNORE_PINS"}),
 }
 
 
@@ -358,6 +360,87 @@ def _split_pin_list(s: str | None) -> list[str] | None:
         return None
     items = [t.strip() for t in re.split(r"[,\s]+", s) if t.strip()]
     return items or None
+
+
+def _sch_ignored_pins(
+    proj: ExtractedProject,
+    lookup_designator: str,
+    schdoc_name: str | None = None,
+) -> frozenset[str]:
+    """Pin designators marked ``PDN_IGNORE`` on matching schematic components.
+
+    Sheet selection:
+
+    * Non-empty ``schdoc_name`` that matches one or more rows → union ignores
+      from those rows only (empty ignore set stays empty; no cross-sheet leak).
+    * Non-empty ``schdoc_name`` that matches nothing, or blank/``None`` sheet →
+      use a same-designator row only when it is **unique** in the project.
+      Multiple placements with the same designator are ambiguous; return empty
+      rather than unioning ignores across sheets.
+    """
+    if not lookup_designator:
+        return frozenset()
+    lu = lookup_designator.upper()
+    sheet = (schdoc_name or "").strip()
+    target_base = Path(sheet).name.lower() if sheet else None
+
+    def _matching_rows(sheet_base: str | None) -> list:
+        rows = []
+        for sch in proj.sch_components:
+            if sch.designator.upper() != lu:
+                continue
+            if sheet_base is not None:
+                if Path(sch.schdoc_name).name.lower() != sheet_base:
+                    continue
+            rows.append(sch)
+        return rows
+
+    def _union_ignores(rows) -> frozenset[str]:
+        out: set[str] = set()
+        for sch in rows:
+            out |= {p.upper() for p in sch.ignored_pins}
+        return frozenset(out)
+
+    if target_base is not None:
+        rows = _matching_rows(target_base)
+        if rows:
+            return _union_ignores(rows)
+        # Sheet hint missed — only fall back when the designator is unique.
+        global_rows = _matching_rows(None)
+        if len(global_rows) == 1:
+            return _union_ignores(global_rows)
+        return frozenset()
+
+    # No usable sheet name: unique placement only.
+    global_rows = _matching_rows(None)
+    if len(global_rows) == 1:
+        return _union_ignores(global_rows)
+    return frozenset()
+
+
+def _ignore_pins_for_channel(
+    params: dict[str, str],
+    idx: int | None,
+    sch_ignored: frozenset[str],
+) -> frozenset[str]:
+    """Union of schematic pin ignores and ``PDN[_n]_IGNORE_PINS`` lists.
+
+    Part-wide ``PDN_IGNORE_PINS`` always applies; ``PDNn_IGNORE_PINS`` applies
+    only when resolving channel ``n``.
+    """
+    ignored: set[str] = set(sch_ignored)
+    part_wide = _split_pin_list(
+        _ci_get(params, _channel_key("IGNORE_PINS", None)),
+    )
+    if part_wide:
+        ignored.update(p.upper() for p in part_wide)
+    if idx is not None:
+        ch = _split_pin_list(
+            _ci_get(params, _channel_key("IGNORE_PINS", idx)),
+        )
+        if ch:
+            ignored.update(p.upper() for p in ch)
+    return frozenset(ignored)
 
 
 def _channel_key(suffix: str, index: int | None) -> str:
@@ -1227,6 +1310,7 @@ def _resolve_terminal(
     net_remap: dict[int, int] | None = None,
     sch_lookup_designator: str | None = None,
     schdoc_name: str | None = None,
+    ignore_pins: frozenset[str] | None = None,
 ) -> tuple[TerminalSpec | None, list[str]]:
     """Resolve a terminal to its participating pads.
 
@@ -1239,6 +1323,10 @@ def _resolve_terminal(
     local-net fallback) matches the named net directly. SERIES bridge
     equivalence classes are *not* consulted here — those belong to the
     solver's net graph, not terminal pin selection.
+
+    ``ignore_pins`` (upper-cased designators) are removed after matching —
+    including when an include override listed them — so enable / signal ties
+    on the rail net do not join the lumped terminal.
 
     Returns ``(spec, errors)``. If ``errors`` is non-empty, ``spec`` is ``None``.
     """
@@ -1424,6 +1512,28 @@ def _resolve_terminal(
                 f"{role_diagnostic}: component {designator} has no pad on net "
                 f"{net_name!r}. {designator}'s pads connect to: {pads_listing}"
                 f" (could be due a series part not setup with PDN_ROLE: SERIES)"
+            )
+            return None, errors
+
+    if ignore_pins:
+        kept = [
+            p for p in matched
+            if p.designator.upper() not in ignore_pins
+        ]
+        dropped = sorted({
+            p.designator for p in matched
+            if p.designator.upper() in ignore_pins
+        })
+        if dropped and warnings is not None:
+            warnings.append(
+                f"{role_diagnostic}: ignoring pin(s) {dropped} "
+                f"(PDN_IGNORE / PDN_IGNORE_PINS)"
+            )
+        matched = kept
+        if not matched:
+            errors.append(
+                f"{role_diagnostic}: all matched pads on {designator} were "
+                f"excluded by PDN_IGNORE / PDN_IGNORE_PINS"
             )
             return None, errors
 
@@ -1810,6 +1920,7 @@ def _resolve_two_terminal(
     net_remap: dict[int, int] | None = None,
     sch_lookup_designator: str | None = None,
     schdoc_name: str | None = None,
+    ignore_pins: frozenset[str] | None = None,
 ) -> tuple[TerminalSpec, TerminalSpec] | None:
     p_net = _ci_get(params, p_net_key)
     n_net = _ci_get(params, n_net_key)
@@ -1830,6 +1941,7 @@ def _resolve_two_terminal(
         net_remap=net_remap,
         sch_lookup_designator=sch_lookup_designator,
         schdoc_name=schdoc_name,
+        ignore_pins=ignore_pins,
     )
     n_spec, n_err = _resolve_terminal(
         proj, pcb_index, n_net, n_pins, enabled_layers,
@@ -1838,6 +1950,7 @@ def _resolve_two_terminal(
         net_remap=net_remap,
         sch_lookup_designator=sch_lookup_designator,
         schdoc_name=schdoc_name,
+        ignore_pins=ignore_pins,
     )
     result.errors.extend(p_err)
     result.errors.extend(n_err)
@@ -1909,6 +2022,7 @@ def _resolve_single_terminal(
     net_remap: dict[int, int] | None = None,
     sch_lookup_designator: str | None = None,
     schdoc_name: str | None = None,
+    ignore_pins: frozenset[str] | None = None,
 ) -> TerminalSpec | None:
     """Resolve the single PCB terminal of a single-net SOURCE/SINK directive.
 
@@ -1924,6 +2038,7 @@ def _resolve_single_terminal(
         f"{role_diag} terminal", warnings=result.warnings, net_remap=net_remap,
         sch_lookup_designator=sch_lookup_designator,
         schdoc_name=schdoc_name,
+        ignore_pins=ignore_pins,
     )
     result.errors.extend(errs)
     return spec
@@ -1988,6 +2103,10 @@ def _parse_source(comp, proj, enabled_layers, result,
         mode = _terminal_mode(comp.parameters, idx, role_diag, result)
         if mode is None:
             continue
+        ignore_pins = _ignore_pins_for_channel(
+            comp.parameters, idx,
+            _sch_ignored_pins(proj, comp.lookup_designator, comp.schdoc_name),
+        )
         for pcb_idx in pcb_indices:
             pcb_des = proj.pcb_components[pcb_idx].designator
             inst_diag = (
@@ -2002,6 +2121,7 @@ def _parse_source(comp, proj, enabled_layers, result,
                     net_remap=net_remap,
                     sch_lookup_designator=comp.lookup_designator,
                     schdoc_name=comp.schdoc_name,
+                    ignore_pins=ignore_pins,
                 )
                 if p is None:
                     continue
@@ -2018,6 +2138,7 @@ def _parse_source(comp, proj, enabled_layers, result,
                 net_remap=net_remap,
                 sch_lookup_designator=comp.lookup_designator,
                 schdoc_name=comp.schdoc_name,
+                ignore_pins=ignore_pins,
             )
             if pair is None:
                 continue
@@ -2067,6 +2188,10 @@ def _parse_sink(comp, proj, enabled_layers, result,
         min_v = _optional_value(
             comp.parameters, _channel_key("MIN_V", idx), role_diag, result,
         )
+        ignore_pins = _ignore_pins_for_channel(
+            comp.parameters, idx,
+            _sch_ignored_pins(proj, comp.lookup_designator, comp.schdoc_name),
+        )
         for pcb_idx in pcb_indices:
             pcb_des = proj.pcb_components[pcb_idx].designator
             inst_diag = (
@@ -2081,6 +2206,7 @@ def _parse_sink(comp, proj, enabled_layers, result,
                     net_remap=net_remap,
                     sch_lookup_designator=comp.lookup_designator,
                     schdoc_name=comp.schdoc_name,
+                    ignore_pins=ignore_pins,
                 )
                 if p is None:
                     continue
@@ -2098,6 +2224,7 @@ def _parse_sink(comp, proj, enabled_layers, result,
                 net_remap=net_remap,
                 sch_lookup_designator=comp.lookup_designator,
                 schdoc_name=comp.schdoc_name,
+                ignore_pins=ignore_pins,
             )
             if pair is None:
                 continue
@@ -2160,6 +2287,10 @@ def _parse_resistance(comp, proj, enabled_layers, result,
                 f"{role_diag}: {_channel_key('R', idx)} must be positive, got {r}"
             )
             continue
+        ignore_pins = _ignore_pins_for_channel(
+            comp.parameters, idx,
+            _sch_ignored_pins(proj, comp.lookup_designator, comp.schdoc_name),
+        )
         for pcb_idx in pcb_indices:
             pcb_des = proj.pcb_components[pcb_idx].designator
             inst_diag = (
@@ -2208,6 +2339,7 @@ def _parse_resistance(comp, proj, enabled_layers, result,
                 net_remap=net_remap,
                 sch_lookup_designator=comp.lookup_designator,
                 schdoc_name=comp.schdoc_name,
+                ignore_pins=ignore_pins,
             )
             if pair is None:
                 continue
@@ -2432,6 +2564,10 @@ def _parse_regulator(comp, proj, enabled_layers, result,
                 result.errors.append(f"{role_diag}: {q_key} must be >= 0")
                 continue
             quiescent = iq_raw
+        ignore_pins = _ignore_pins_for_channel(
+            comp.parameters, idx,
+            _sch_ignored_pins(proj, comp.lookup_designator, comp.schdoc_name),
+        )
         for pcb_idx in pcb_indices:
             pcb_des = proj.pcb_components[pcb_idx].designator
             inst_diag = (
@@ -2446,6 +2582,7 @@ def _parse_regulator(comp, proj, enabled_layers, result,
                 net_remap=net_remap,
                 sch_lookup_designator=comp.lookup_designator,
                 schdoc_name=comp.schdoc_name,
+                ignore_pins=ignore_pins,
             )
             in_ = _resolve_two_terminal(
                 proj, pcb_idx, comp.parameters,
@@ -2455,6 +2592,7 @@ def _parse_regulator(comp, proj, enabled_layers, result,
                 net_remap=net_remap,
                 sch_lookup_designator=comp.lookup_designator,
                 schdoc_name=comp.schdoc_name,
+                ignore_pins=ignore_pins,
             )
             if out is None or in_ is None:
                 continue

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -11,8 +11,11 @@ Every directive lives on a single Altium component as a set of parameters whose
 names begin with ``PDN_``. ``PDN_ROLE`` selects the role; the other parameters
 supply the value and the rail/return nets. Pin sets are auto-resolved by
 finding the named component's pads that sit on the named net; explicit pin
-overrides are honoured if supplied. Pins can be excluded with a pin-level
-``PDN_IGNORE`` parameter or a component ``PDN_IGNORE_PINS`` list.
+overrides are honoured if supplied. A part-wide ``PDN_PINS_ONLY`` allowlist
+(optional ``PDN_EXTRA_PINS`` union) restricts which pads may join any
+rail before net matching — preferred in the SchLib for multi-rail parts.
+Pins can still be excluded with a pin-level ``PDN_IGNORE`` or
+``PDN_IGNORE_PINS`` (fine-tuning after the allowlist).
 
 ============   =============================   ==================================================
 Role           Value params                    Net / pin params
@@ -177,9 +180,14 @@ _RESISTOR_LIKE_ROLES: frozenset[str] = frozenset({"SERIES"})
 
 VALID_ROLES: frozenset[str] = frozenset({"SOURCE", "SINK", "REGULATOR"}) | _RESISTOR_LIKE_ROLES
 
+# Part-wide only (unindexed): restrict which pads may enter net matching.
+# Channel indices belong to nets / per-terminal overrides, not this list.
+_PART_WIDE_PIN_FILTER_SUFFIXES: frozenset[str] = frozenset({
+    "PINS_ONLY", "EXTRA_PINS",
+})
 _COMMON_TERMINAL_SUFFIXES: frozenset[str] = frozenset({
     "NET", "PINS", "P_NET", "N_NET", "P_PINS", "N_PINS", "IGNORE_PINS",
-})
+}) | _PART_WIDE_PIN_FILTER_SUFFIXES
 _KNOWN_SUFFIXES_BY_ROLE: dict[str, frozenset[str]] = {
     "SOURCE": _COMMON_TERMINAL_SUFFIXES | frozenset({"V"}),
     "SINK": _COMMON_TERMINAL_SUFFIXES | frozenset({"I", "MIN_V"}),
@@ -188,8 +196,10 @@ _KNOWN_SUFFIXES_BY_ROLE: dict[str, frozenset[str]] = {
         "OUT_P_NET", "OUT_N_NET", "OUT_P_PINS", "OUT_N_PINS",
         "IN_P_NET", "IN_N_NET", "IN_P_PINS", "IN_N_PINS",
         "IGNORE_PINS",
-    }),
-    "SERIES": frozenset({"R", "P_NET", "N_NET", "P_PINS", "N_PINS", "IGNORE_PINS"}),
+    }) | _PART_WIDE_PIN_FILTER_SUFFIXES,
+    "SERIES": frozenset({
+        "R", "P_NET", "N_NET", "P_PINS", "N_PINS", "IGNORE_PINS",
+    }) | _PART_WIDE_PIN_FILTER_SUFFIXES,
 }
 
 
@@ -441,6 +451,31 @@ def _ignore_pins_for_channel(
         if ch:
             ignored.update(p.upper() for p in ch)
     return frozenset(ignored)
+
+
+def _allow_pins_for_part(params: dict[str, str]) -> frozenset[str] | None:
+    """Part-wide pin allowlist from ``PDN_PINS_ONLY`` ∪ ``PDN_EXTRA_PINS``.
+
+    Returns ``None`` when neither parameter is set (unrestricted — every pad
+    on the named net may join). ``PDN_EXTRA_PINS`` is always unioned in; when
+    it is set without ``PDN_PINS_ONLY``, it alone forms the allowlist (not
+    “all pads plus EXTRA”). Indexed ``PDNn_PINS_ONLY`` / ``PDNn_EXTRA_PINS``
+    are not read here (see :func:`_warn_unknown_pdn_params`).
+    """
+    only = _split_pin_list(
+        _ci_get(params, _channel_key("PINS_ONLY", None)),
+    )
+    extra = _split_pin_list(
+        _ci_get(params, _channel_key("EXTRA_PINS", None)),
+    )
+    if only is None and extra is None:
+        return None
+    out: set[str] = set()
+    if only:
+        out.update(p.upper() for p in only)
+    if extra:
+        out.update(p.upper() for p in extra)
+    return frozenset(out)
 
 
 def _channel_key(suffix: str, index: int | None) -> str:
@@ -1311,6 +1346,7 @@ def _resolve_terminal(
     sch_lookup_designator: str | None = None,
     schdoc_name: str | None = None,
     ignore_pins: frozenset[str] | None = None,
+    allow_pins: frozenset[str] | None = None,
 ) -> tuple[TerminalSpec | None, list[str]]:
     """Resolve a terminal to its participating pads.
 
@@ -1323,6 +1359,10 @@ def _resolve_terminal(
     local-net fallback) matches the named net directly. SERIES bridge
     equivalence classes are *not* consulted here — those belong to the
     solver's net graph, not terminal pin selection.
+
+    When ``allow_pins`` is set and ``override_pins`` is not, only pads in that
+    allowlist (``PDN_PINS_ONLY`` ∪ ``PDN_EXTRA_PINS``) are candidates for net
+    matching. Explicit ``*_PINS`` overrides bypass the allowlist.
 
     ``ignore_pins`` (upper-cased designators) are removed after matching —
     including when an include override listed them — so enable / signal ties
@@ -1352,6 +1392,33 @@ def _resolve_terminal(
         if not matched:
             return None, errors
     else:
+        pool = component_pads
+        if allow_pins is not None:
+            pool = [
+                p for p in component_pads
+                if p.designator.upper() in allow_pins
+            ]
+            missing_pcb = allow_pins - {
+                p.designator.upper() for p in component_pads
+            }
+            # One warning per designator (not per P/N/IN/OUT terminal).
+            if missing_pcb and warnings is not None:
+                miss_msg = (
+                    f"{designator}: PDN_PINS_ONLY / PDN_EXTRA_PINS "
+                    f"name pin(s) not on the PCB: {sorted(missing_pcb)}"
+                )
+                if miss_msg not in warnings:
+                    warnings.append(miss_msg)
+            if not pool:
+                # Designator-stable text so P/N/IN/OUT do not each append a
+                # duplicate when the allowlist matches nothing on the PCB.
+                empty_msg = (
+                    f"{designator}: no pads match "
+                    f"PDN_PINS_ONLY / PDN_EXTRA_PINS"
+                )
+                if empty_msg not in errors:
+                    errors.append(empty_msg)
+                return None, errors
         if not net_name:
             errors.append(
                 f"{role_diagnostic}: neither a net nor pin overrides supplied"
@@ -1359,6 +1426,7 @@ def _resolve_terminal(
             return None, errors
         net_indices = _net_indices_by_name(proj, net_name)
         matched: list[RawPad] = []
+        wanted_nets: set[int] | None = None
         if net_indices:
             # Apply the loader's net-merge remap so user annotations naming
             # EITHER side of an absorbed SERIES bridge (e.g. both "0V" and
@@ -1371,12 +1439,12 @@ def _resolve_terminal(
             # component sits in exactly one channel, so matching its own pads
             # against the whole name-class still selects only its channel's net.
             wanted_nets = set(net_indices)
-            matched = [p for p in component_pads if p.net_index in wanted_nets]
+            matched = [p for p in pool if p.net_index in wanted_nets]
 
         if not matched and sch_lookup_designator:
             routed_pin_keys = {
                 p.designator.upper()
-                for p in component_pads
+                for p in pool
                 if p.net_index != NO_NET
             }
             local_pins = _resolve_local_net_pins(
@@ -1401,7 +1469,7 @@ def _resolve_terminal(
             if local_pins:
                 wanted_pins = {pin.upper() for pin in local_pins}
                 matched = [
-                    p for p in component_pads
+                    p for p in pool
                     if p.designator.upper() in wanted_pins
                     and p.net_index != NO_NET
                 ]
@@ -1432,7 +1500,7 @@ def _resolve_terminal(
         ):
             alias_matched = _resolve_alias_fallback_pads(
                 proj,
-                component_pads,
+                pool,
                 net_name,
                 sch_lookup_designator,
                 schdoc_name or "",
@@ -1464,7 +1532,7 @@ def _resolve_terminal(
                         net_remap.get(ix, ix) for ix in candidate_indices
                     ]
                 wanted_nets = set(candidate_indices)
-                matched = [p for p in component_pads if p.net_index in wanted_nets]
+                matched = [p for p in pool if p.net_index in wanted_nets]
                 if matched:
                     if warnings is not None:
                         warnings.append(
@@ -1502,6 +1570,22 @@ def _resolve_terminal(
             # user can either correct PDN_*_NET or realise the directive is on
             # the wrong component. Buck regulator outputs commonly trip this
             # (pin sits on switching node, rail appears after the inductor).
+            # When an allowlist is active, pads on the named net may exist but
+            # be excluded — call that out so it is not mistaken for a net typo.
+            if allow_pins is not None and wanted_nets is not None:
+                excluded_on_net = sorted({
+                    p.designator for p in component_pads
+                    if p.net_index in wanted_nets
+                    and p.designator.upper() not in allow_pins
+                })
+                if excluded_on_net:
+                    errors.append(
+                        f"{role_diagnostic}: no allowlisted pad on net "
+                        f"{net_name!r} (PDN_PINS_ONLY / PDN_EXTRA_PINS). "
+                        f"Pads on that net outside the allowlist: "
+                        f"{excluded_on_net}"
+                    )
+                    return None, errors
             pad_nets = sorted({
                 proj.nets[p.net_index].name
                 for p in component_pads
@@ -1921,6 +2005,7 @@ def _resolve_two_terminal(
     sch_lookup_designator: str | None = None,
     schdoc_name: str | None = None,
     ignore_pins: frozenset[str] | None = None,
+    allow_pins: frozenset[str] | None = None,
 ) -> tuple[TerminalSpec, TerminalSpec] | None:
     p_net = _ci_get(params, p_net_key)
     n_net = _ci_get(params, n_net_key)
@@ -1942,6 +2027,7 @@ def _resolve_two_terminal(
         sch_lookup_designator=sch_lookup_designator,
         schdoc_name=schdoc_name,
         ignore_pins=ignore_pins,
+        allow_pins=allow_pins,
     )
     n_spec, n_err = _resolve_terminal(
         proj, pcb_index, n_net, n_pins, enabled_layers,
@@ -1951,9 +2037,9 @@ def _resolve_two_terminal(
         sch_lookup_designator=sch_lookup_designator,
         schdoc_name=schdoc_name,
         ignore_pins=ignore_pins,
+        allow_pins=allow_pins,
     )
-    result.errors.extend(p_err)
-    result.errors.extend(n_err)
+    result.errors.extend(e for e in (*p_err, *n_err) if e not in result.errors)
     if p_spec is None or n_spec is None:
         return None
     return p_spec, n_spec
@@ -2023,6 +2109,7 @@ def _resolve_single_terminal(
     sch_lookup_designator: str | None = None,
     schdoc_name: str | None = None,
     ignore_pins: frozenset[str] | None = None,
+    allow_pins: frozenset[str] | None = None,
 ) -> TerminalSpec | None:
     """Resolve the single PCB terminal of a single-net SOURCE/SINK directive.
 
@@ -2039,8 +2126,9 @@ def _resolve_single_terminal(
         sch_lookup_designator=sch_lookup_designator,
         schdoc_name=schdoc_name,
         ignore_pins=ignore_pins,
+        allow_pins=allow_pins,
     )
-    result.errors.extend(errs)
+    result.errors.extend(e for e in errs if e not in result.errors)
     return spec
 
 
@@ -2107,6 +2195,7 @@ def _parse_source(comp, proj, enabled_layers, result,
             comp.parameters, idx,
             _sch_ignored_pins(proj, comp.lookup_designator, comp.schdoc_name),
         )
+        allow_pins = _allow_pins_for_part(comp.parameters)
         for pcb_idx in pcb_indices:
             pcb_des = proj.pcb_components[pcb_idx].designator
             inst_diag = (
@@ -2122,6 +2211,7 @@ def _parse_source(comp, proj, enabled_layers, result,
                     sch_lookup_designator=comp.lookup_designator,
                     schdoc_name=comp.schdoc_name,
                     ignore_pins=ignore_pins,
+                    allow_pins=allow_pins,
                 )
                 if p is None:
                     continue
@@ -2139,6 +2229,7 @@ def _parse_source(comp, proj, enabled_layers, result,
                 sch_lookup_designator=comp.lookup_designator,
                 schdoc_name=comp.schdoc_name,
                 ignore_pins=ignore_pins,
+                allow_pins=allow_pins,
             )
             if pair is None:
                 continue
@@ -2192,6 +2283,7 @@ def _parse_sink(comp, proj, enabled_layers, result,
             comp.parameters, idx,
             _sch_ignored_pins(proj, comp.lookup_designator, comp.schdoc_name),
         )
+        allow_pins = _allow_pins_for_part(comp.parameters)
         for pcb_idx in pcb_indices:
             pcb_des = proj.pcb_components[pcb_idx].designator
             inst_diag = (
@@ -2207,6 +2299,7 @@ def _parse_sink(comp, proj, enabled_layers, result,
                     sch_lookup_designator=comp.lookup_designator,
                     schdoc_name=comp.schdoc_name,
                     ignore_pins=ignore_pins,
+                    allow_pins=allow_pins,
                 )
                 if p is None:
                     continue
@@ -2225,6 +2318,7 @@ def _parse_sink(comp, proj, enabled_layers, result,
                 sch_lookup_designator=comp.lookup_designator,
                 schdoc_name=comp.schdoc_name,
                 ignore_pins=ignore_pins,
+                allow_pins=allow_pins,
             )
             if pair is None:
                 continue
@@ -2291,6 +2385,7 @@ def _parse_resistance(comp, proj, enabled_layers, result,
             comp.parameters, idx,
             _sch_ignored_pins(proj, comp.lookup_designator, comp.schdoc_name),
         )
+        allow_pins = _allow_pins_for_part(comp.parameters)
         for pcb_idx in pcb_indices:
             pcb_des = proj.pcb_components[pcb_idx].designator
             inst_diag = (
@@ -2340,6 +2435,7 @@ def _parse_resistance(comp, proj, enabled_layers, result,
                 sch_lookup_designator=comp.lookup_designator,
                 schdoc_name=comp.schdoc_name,
                 ignore_pins=ignore_pins,
+                allow_pins=allow_pins,
             )
             if pair is None:
                 continue
@@ -2568,6 +2664,7 @@ def _parse_regulator(comp, proj, enabled_layers, result,
             comp.parameters, idx,
             _sch_ignored_pins(proj, comp.lookup_designator, comp.schdoc_name),
         )
+        allow_pins = _allow_pins_for_part(comp.parameters)
         for pcb_idx in pcb_indices:
             pcb_des = proj.pcb_components[pcb_idx].designator
             inst_diag = (
@@ -2583,6 +2680,7 @@ def _parse_regulator(comp, proj, enabled_layers, result,
                 sch_lookup_designator=comp.lookup_designator,
                 schdoc_name=comp.schdoc_name,
                 ignore_pins=ignore_pins,
+                allow_pins=allow_pins,
             )
             in_ = _resolve_two_terminal(
                 proj, pcb_idx, comp.parameters,
@@ -2593,6 +2691,7 @@ def _parse_regulator(comp, proj, enabled_layers, result,
                 sch_lookup_designator=comp.lookup_designator,
                 schdoc_name=comp.schdoc_name,
                 ignore_pins=ignore_pins,
+                allow_pins=allow_pins,
             )
             if out is None or in_ is None:
                 continue
@@ -2771,9 +2870,15 @@ def _warn_unknown_pdn_params(
             # errors on it; don't pile on per-parameter "unknown" noise.
             continue
         allowed = _KNOWN_SUFFIXES_BY_ROLE.get(eff_role, frozenset())
+        ch = f"#{idx}" if idx is not None else ""
+        if suffix_u in _PART_WIDE_PIN_FILTER_SUFFIXES and idx is not None:
+            result.warnings.append(
+                f"{diag}{ch}: {key!r} is ignored — pin allowlists are "
+                f"part-wide; use PDN_{suffix_u} (no channel index)"
+            )
+            continue
         if suffix_u in allowed:
             continue
-        ch = f"#{idx}" if idx is not None else ""
         if suffix_u == "PIN":
             suggest = _channel_key("P_PINS", idx)
             result.warnings.append(

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -185,6 +185,12 @@ VALID_ROLES: frozenset[str] = frozenset({"SOURCE", "SINK", "REGULATOR"}) | _RESI
 _PART_WIDE_PIN_FILTER_SUFFIXES: frozenset[str] = frozenset({
     "PINS_ONLY", "EXTRA_PINS",
 })
+# Pin-filter modifiers that may legitimately hang on a symbol / instance
+# without a PDN_ROLE (SchLib allowlist, EXTRA_PINS / IGNORE_PINS fine-tuning).
+# Alone they are not a directive attempt — see parse_annotations stray check.
+_PIN_FILTER_MODIFIER_SUFFIXES: frozenset[str] = (
+    _PART_WIDE_PIN_FILTER_SUFFIXES | frozenset({"IGNORE_PINS"})
+)
 _COMMON_TERMINAL_SUFFIXES: frozenset[str] = frozenset({
     "NET", "PINS", "P_NET", "N_NET", "P_PINS", "N_PINS", "IGNORE_PINS",
 }) | _PART_WIDE_PIN_FILTER_SUFFIXES
@@ -560,6 +566,73 @@ def _is_pdn_annotated(params: dict[str, str]) -> bool:
     if _ci_get(params, ROLE_KEY) is not None:
         return True
     return _has_indexed_role_params(params)
+
+
+def _stray_pdn_suffixes(params: dict[str, str]) -> list[tuple[str, str]]:
+    """Return ``(key, uppercased_suffix)`` for every ``PDN[_n]_*`` parameter.
+
+    Keys that do not match :data:`_INDEXED_KEY_RE` (malformed ``PDN_*`` names)
+    keep the upper-cased key as the ``suffix`` so they still count as non-
+    modifier strays.
+    """
+    out: list[tuple[str, str]] = []
+    for k in params:
+        if not k.upper().startswith(PARAM_PREFIX):
+            continue
+        m = _INDEXED_KEY_RE.match(k.strip())
+        if m is None:
+            out.append((k, k.upper()))
+        else:
+            out.append((k, m.group(2).upper()))
+    return out
+
+
+def _record_unannotated_pdn_params(
+    result: AnnotationResult,
+    *,
+    where: str,
+    params: dict[str, str],
+    suppress_info: bool = False,
+    info_dedupe_key: tuple[str, str] | None = None,
+    seen_info_keys: set[tuple[str, str]] | None = None,
+) -> None:
+    """Classify PDN_* params without a role as INFO or WARNING.
+
+    Pin-filter modifiers alone (``PINS_ONLY`` / ``EXTRA_PINS`` /
+    ``IGNORE_PINS``) are informational when no role exists anywhere —
+    they often live on a SchLib symbol while ``PDN_ROLE`` and values sit
+    on the PCB after Blanket/ECO sync. Pass ``suppress_info=True`` when
+    that PCB (or another) source already carries a role for the same
+    designator so the expected workflow stays quiet. Multipart symbols
+    share one INFO via ``info_dedupe_key`` / ``seen_info_keys``.
+
+    Any other ``PDN_*`` key without a role is treated as a forgotten
+    directive (WARNING).
+    """
+    strays = _stray_pdn_suffixes(params)
+    if not strays or _is_pdn_annotated(params):
+        return
+    names = ", ".join(k for k, _ in strays)
+    modifiers_only = all(
+        sfx in _PIN_FILTER_MODIFIER_SUFFIXES for _, sfx in strays
+    )
+    if modifiers_only:
+        if suppress_info:
+            return
+        if info_dedupe_key is not None and seen_info_keys is not None:
+            if info_dedupe_key in seen_info_keys:
+                return
+            seen_info_keys.add(info_dedupe_key)
+        result.infos.append(
+            f"{where}: carries only PDN_* pin-filter parameter(s) ({names}) "
+            f"and no PDN_ROLE or PDN<n>_ROLE — no directive from this source "
+            f"(role/values expected elsewhere, e.g. the PCB instance)"
+        )
+    else:
+        result.warnings.append(
+            f"{where}: has {len(strays)} PDN_* parameter(s) but no "
+            f"PDN_ROLE or PDN<n>_ROLE — directive ignored (add PDN_ROLE)"
+        )
 
 
 def _part_role_default(params: dict[str, str]) -> str:
@@ -1924,6 +1997,10 @@ class AnnotationResult:
     directives: list[DirectiveSpec] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
+    # Non-actionable notes (e.g. symbol-only PDN_PINS_ONLY without a role —
+    # role/values are expected on the PCB instance). Logged at INFO, not
+    # treated as a problem for solveability / GUI warning dialogs.
+    infos: list[str] = field(default_factory=list)
     # Per-rail "won't be solved" notices for single-type rails (only sources
     # or only sinks). A subset of ``warnings`` (also shown in the Setup tab),
     # kept separately so the GUI can pop them as an active dialog on load /
@@ -1950,6 +2027,10 @@ class AnnotationResult:
         lines = [f"Annotation result: {len(self.directives)} directive(s)"]
         for kind, designators in sorted(by_kind.items()):
             lines.append(f"  {kind:<14} {len(designators):>3}  on: {', '.join(designators)}")
+        if self.infos:
+            lines.append(f"  infos: {len(self.infos)}")
+            for i in self.infos:
+                lines.append(f"    - {i}")
         if self.warnings:
             lines.append(f"  warnings: {len(self.warnings)}")
             for w in self.warnings:
@@ -3003,23 +3084,33 @@ def parse_annotations(proj: ExtractedProject,
     seen_designators: set[str] = set()
     skip_set: set[str] = {d.upper() for d in (skip_designators or set())}
 
+    # Designators that already carry a role on the PCB (Blanket/ECO path).
+    # SchLib pin-filter-only symbols for those parts are the expected
+    # workflow — do not INFO about a "missing" sch-side directive.
+    pcb_annotated_designators: set[str] = {
+        (pcb.source_designator or pcb.designator).upper()
+        for pcb in proj.pcb_components
+        if _is_pdn_annotated(pcb.parameters)
+    }
+    seen_info_keys: set[tuple[str, str]] = set()
+
     for comp in proj.sch_components:
-        stray = [k for k in comp.parameters if k.upper().startswith(PARAM_PREFIX)]
-        if stray and not _is_pdn_annotated(comp.parameters):
-            result.warnings.append(
-                f"{comp.designator} ({comp.schdoc_name}): has {len(stray)} "
-                f"PDN_* parameter(s) but no PDN_ROLE or PDN<n>_ROLE — "
-                f"directive ignored"
-            )
+        des_u = comp.designator.upper()
+        _record_unannotated_pdn_params(
+            result,
+            where=f"{comp.designator} ({comp.schdoc_name})",
+            params=comp.parameters,
+            suppress_info=des_u in pcb_annotated_designators,
+            info_dedupe_key=(des_u, Path(comp.schdoc_name).name.lower()),
+            seen_info_keys=seen_info_keys,
+        )
     for pcb in proj.pcb_components:
-        stray = [k for k in pcb.parameters if k.upper().startswith(PARAM_PREFIX)]
-        if stray and not _is_pdn_annotated(pcb.parameters):
-            lookup = pcb.source_designator or pcb.designator
-            result.warnings.append(
-                f"{pcb.designator} (PCB, from {lookup}): has {len(stray)} "
-                f"PDN_* parameter(s) but no PDN_ROLE or PDN<n>_ROLE — "
-                f"directive ignored"
-            )
+        lookup = pcb.source_designator or pcb.designator
+        _record_unannotated_pdn_params(
+            result,
+            where=f"{pcb.designator} (PCB, from {lookup})",
+            params=pcb.parameters,
+        )
 
     parameter_sources = _iter_pdn_parameter_sources(proj)
 

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -713,7 +713,8 @@ class InstanceLocalNetResolver:
                     sorted(k for k, v in sheet_votes.items() if v == top),
                     sheet_paths[best],
                 )
-            return sheet_paths[best]
+            raw = sheet_paths[best]
+            return _logical_schdoc_name(raw, _physical_sheet_file_map(self.proj))
 
         sch_matches = [
             c.schdoc_name for c in self.proj.sch_components
@@ -755,6 +756,7 @@ class InstanceLocalNetResolver:
                     local_name,
                     routed_pin_keys=set(routed),
                     pcb_designator=pcb.designator,
+                    proj=self.proj,
                 )
                 wanted = {p.upper() for p in local_pins}
                 for pin_key, pad in routed.items():
@@ -831,7 +833,44 @@ def _pcb_indices_for_source(comp: PdnParameterSource,
     return _find_pcb_instances(proj, comp.designator)
 
 
-def _sheet_name_matches(schdoc_name: str, source_sheets: list[str]) -> bool:
+def _physical_sheet_file_map(proj: ExtractedProject | None) -> dict[str, str]:
+    """physical page id (lower) → logical ``*.SchDoc`` file name."""
+    if proj is None:
+        return {}
+    return {
+        pid.replace("\\", "/").lower(): fn
+        for pid, fn in getattr(proj, "physical_sheet_names", ()) or ()
+        if pid and fn
+    }
+
+
+def _logical_schdoc_name(name: str, sheet_map: dict[str, str]) -> str:
+    """Map a physical page id to its logical ``*.SchDoc`` name when known.
+
+    Relative paths with directories are preserved so SubA/Power.SchDoc and
+    SubB/Power.SchDoc stay distinct. Bare file names and physical page ids
+    (``physical:0:logical:0:Power.SchDoc:…``) resolve to the SchDoc leaf.
+    """
+    if not name:
+        return ""
+    key = name.replace("\\", "/").lower()
+    if key in sheet_map:
+        return sheet_map[key]
+    # Recover the embedded SchDoc leaf from altium_monkey ≥ 2026.7 page ids
+    # when the compile-time map is missing (legacy netlist fallback).
+    if key.startswith("physical:"):
+        for part in name.replace("\\", "/").split(":"):
+            if part.lower().endswith(".schdoc"):
+                return part
+    return name.replace("\\", "/")
+
+
+def _sheet_name_matches(
+    schdoc_name: str,
+    source_sheets: list[str],
+    *,
+    proj: ExtractedProject | None = None,
+) -> bool:
     # A net with no recorded sheet provenance (e.g. a global/power net) cannot
     # contradict the inferred instance sheet, so it is accepted. This is the
     # one remaining permissive path; cross-instance mis-binding is bounded by
@@ -840,14 +879,17 @@ def _sheet_name_matches(schdoc_name: str, source_sheets: list[str]) -> bool:
         return True
     if not schdoc_name:
         return False
-    target_full = schdoc_name.replace("\\", "/").lower()
-    target_base = Path(schdoc_name).name.lower()
+    sheet_map = _physical_sheet_file_map(proj)
+    target = _logical_schdoc_name(schdoc_name, sheet_map)
+    target_full = target.replace("\\", "/").lower()
+    target_base = Path(target).name.lower()
     has_dir = "/" in target_full
     for sheet in source_sheets:
-        s = sheet.replace("\\", "/").lower()
+        resolved = _logical_schdoc_name(sheet, sheet_map)
+        s = resolved.replace("\\", "/").lower()
         if s == target_full:
             return True
-        if not has_dir and Path(sheet).name.lower() == target_base:
+        if not has_dir and Path(resolved).name.lower() == target_base:
             return True
     return False
 
@@ -860,6 +902,7 @@ def _resolve_local_net_pins(
     *,
     routed_pin_keys: set[str] | None = None,
     pcb_designator: str | None = None,
+    proj: ExtractedProject | None = None,
 ) -> list[str]:
     """Return pin designators on ``sch_designator`` for a local sheet net name.
 
@@ -881,7 +924,7 @@ def _resolve_local_net_pins(
         if not any(_local_net_label_matches(n, local_net_name, des_candidates) for n in names):
             continue
         net_sheets = list(getattr(net, "source_sheets", ()) or ())
-        if not _sheet_name_matches(schdoc_name, net_sheets):
+        if not _sheet_name_matches(schdoc_name, net_sheets, proj=proj):
             continue
         for term in net.terminals:
             if term.designator.upper() not in des_candidates:
@@ -953,7 +996,7 @@ def _resolve_alias_fallback_pads(
                     for n in names
                 ):
                     continue
-                if not _sheet_name_matches(schdoc_name, list(sheets)):
+                if not _sheet_name_matches(schdoc_name, list(sheets), proj=proj):
                     continue
                 matched.append(pad)
                 seen_pins.add(pin_key)
@@ -1045,6 +1088,7 @@ def _resolve_terminal(
                 net_name,
                 routed_pin_keys=routed_pin_keys or None,
                 pcb_designator=designator,
+                proj=proj,
             )
             if local_pins:
                 wanted_pins = {pin.upper() for pin in local_pins}

--- a/fypa/altium/extract.py
+++ b/fypa/altium/extract.py
@@ -398,7 +398,10 @@ class RawStackupLayer:
 @dataclass(frozen=True, slots=True)
 class RawSchComponent:
     designator: str
-    schdoc_name: str          # filename only, e.g. 'Power.SchDoc'
+    # Project-relative SchDoc path (forward slashes, original casing preserved
+    # for diagnostics), e.g. ``Power.SchDoc`` or ``mod/Child.SchDoc``. Absolute
+    # path string when the file sits outside the ``.PrjPcb`` tree.
+    schdoc_name: str
     parameters: dict[str, str]  # name -> text (case-preserved keys)
     pin_designators: tuple[str, ...]
 
@@ -421,6 +424,15 @@ class ExtractedProject:
     # Compiled schematic netlist (multi-sheet aware). Used to translate local
     # sheet net names in PDN_*_NET parameters to per-instance PCB connectivity.
     compiled_netlist: Any | None = None
+    # Absolute SchDoc paths keyed by project-relative lowercase path (forward
+    # slashes). When a basename is unique in the project it is also registered
+    # as an alias key (``"child.schdoc"``) so callers that only know the
+    # filename still resolve. Used for lazy per-sheet netlist compiles.
+    schdoc_paths: dict[str, str] = field(default_factory=dict)
+    # Lazily filled single-sheet netlists, keyed like :attr:`schdoc_paths`.
+    # Empty until a child-sheet local-net fallback needs a sheet; keeps the
+    # design-info pickle small.
+    sheet_netlists: dict[str, Any] = field(default_factory=dict)
     # altium_monkey ≥ 2026.7 maps netlist ``source_sheets`` to physical page
     # ids (``physical:0:logical:0:main.SchDoc:child:…``). This tuple maps each
     # physical page id → logical schematic file name (``power.SchDoc``) so
@@ -1342,10 +1354,37 @@ def _extract_sch_component(comp, schdoc_name: str) -> RawSchComponent | None:
     )
 
 
-def _extract_sch_components(design) -> tuple[RawSchComponent, ...]:
+def _schdoc_storage_key(abs_path: Path, project_root: Path) -> str:
+    """Stable lowercase dict key for one SchDoc path.
+
+    Prefer a path relative to the ``.PrjPcb`` directory (lowercase, ``/``).
+    Files outside that tree use the absolute path so two external sheets with
+    the same basename do not collide.
+    """
+    return _schdoc_display_path(abs_path, project_root).lower()
+
+
+def _schdoc_display_path(abs_path: Path, project_root: Path) -> str:
+    """Case-preserving relative (or absolute) SchDoc path for annotations/UI."""
+    abs_path = abs_path.resolve()
+    root = project_root.resolve()
+    try:
+        return str(abs_path.relative_to(root)).replace("\\", "/")
+    except ValueError:
+        return str(abs_path).replace("\\", "/")
+
+
+def _extract_sch_components(
+    design,
+    prjpcb_path: Path,
+) -> tuple[RawSchComponent, ...]:
     out: list[RawSchComponent] = []
+    root = prjpcb_path.parent
     for sd in design.schdocs:
-        schdoc_name = sd.filepath.name
+        if not getattr(sd, "filepath", None):
+            continue
+        # Preserve casing for diagnostics; lookups lower-case on compare.
+        schdoc_name = _schdoc_display_path(Path(sd.filepath), root)
         for comp in sd.components:
             rec = _extract_sch_component(comp, schdoc_name)
             if rec is not None:
@@ -1414,6 +1453,36 @@ def _compile_schematic_netlist(
         return None, ()
 
 
+def _collect_schdoc_paths(
+    design: AltiumDesign,
+    prjpcb_path: Path,
+) -> dict[str, str]:
+    """Map unique SchDoc keys → absolute path strings for lazy sheet compiles.
+
+    Primary key is :func:`_schdoc_storage_key` (project-relative, or absolute
+    when outside the tree). When a basename is unique across the project it is
+    also registered so callers that only know ``Child.SchDoc`` still resolve.
+    """
+    root = prjpcb_path.parent
+    entries: list[tuple[str, str, str]] = []
+    basename_counts: dict[str, int] = {}
+    for sch in design.schdocs:
+        if not getattr(sch, "filepath", None):
+            continue
+        abs_path = Path(sch.filepath).resolve()
+        key = _schdoc_storage_key(abs_path, root)
+        base = abs_path.name.lower()
+        entries.append((key, str(abs_path), base))
+        basename_counts[base] = basename_counts.get(base, 0) + 1
+
+    out: dict[str, str] = {}
+    for key, abs_s, base in entries:
+        out[key] = abs_s
+        if basename_counts.get(base, 0) == 1:
+            out[base] = abs_s
+    return out
+
+
 def extract_project(prjpcb_path: str | Path,
                     pcbdoc_selector: str | Path | None = None,
                     ) -> ExtractedProject:
@@ -1433,6 +1502,11 @@ def extract_project(prjpcb_path: str | Path,
         raise FileNotFoundError(f"PrjPcb not found: {prjpcb_path}")
 
     log.info("Loading Altium project: %s", prjpcb_path)
+    # Drop annotation memoization from any previous project so a reload of the
+    # same path cannot reuse stale child-sheet / resolver state.
+    from fypa.altium.annotations import clear_annotation_caches
+    clear_annotation_caches()
+
     design = AltiumDesign.from_prjpcb(str(prjpcb_path))
     pcb = design.load_pcbdoc(selector=pcbdoc_selector)
     if pcb is None:
@@ -1452,6 +1526,7 @@ def extract_project(prjpcb_path: str | Path,
     oy_mm = mils_to_mm(origin_y_mils)
 
     compiled_netlist, physical_sheet_names = _compile_schematic_netlist(design)
+    schdoc_paths = _collect_schdoc_paths(design, prjpcb_path)
 
     return ExtractedProject(
         prjpcb_path=prjpcb_path,
@@ -1467,8 +1542,10 @@ def extract_project(prjpcb_path: str | Path,
         pcb_components=_extract_pcb_components(pcb, ox_mm, oy_mm),
         nets=_extract_nets(pcb),
         stackup=_extract_stackup(pcb),
-        sch_components=_extract_sch_components(design),
+        sch_components=_extract_sch_components(design, prjpcb_path),
         compiled_netlist=compiled_netlist,
+        schdoc_paths=schdoc_paths,
+        sheet_netlists={},
         physical_sheet_names=physical_sheet_names,
         board_origin_mm=Pt2D(ox_mm, oy_mm),
         board_outline=_extract_board_outline(pcb, ox_mm, oy_mm),

--- a/fypa/altium/extract.py
+++ b/fypa/altium/extract.py
@@ -421,6 +421,11 @@ class ExtractedProject:
     # Compiled schematic netlist (multi-sheet aware). Used to translate local
     # sheet net names in PDN_*_NET parameters to per-instance PCB connectivity.
     compiled_netlist: Any | None = None
+    # altium_monkey ≥ 2026.7 maps netlist ``source_sheets`` to physical page
+    # ids (``physical:0:logical:0:main.SchDoc:child:…``). This tuple maps each
+    # physical page id → logical schematic file name (``power.SchDoc``) so
+    # local-net sheet matching stays compatible with sch_components.
+    physical_sheet_names: tuple[tuple[str, str], ...] = ()
     # User-defined Altium origin (Board6/ORIGINX,ORIGINY), in mm. Every
     # Pt2D produced above has already had this subtracted, so coordinates
     # match what Altium displays when the user has set a custom origin.
@@ -1369,10 +1374,31 @@ def list_pcbdoc_paths(prjpcb_path: str | Path) -> list[Path]:
     return list(AltiumPrjPcb(prjpcb_path).get_pcbdoc_paths())
 
 
-def _compile_schematic_netlist(design: AltiumDesign) -> Netlist | None:
-    """Compile the project schematic netlist for local-net name resolution."""
+def _compile_schematic_netlist(
+    design: AltiumDesign,
+) -> tuple[Netlist | None, tuple[tuple[str, str], ...]]:
+    """Compile the project schematic netlist for local-net name resolution.
+
+    Returns ``(netlist, physical_sheet_names)`` where ``physical_sheet_names``
+    maps compiled physical page ids to logical ``*.SchDoc`` file names
+    (altium_monkey ≥ 2026.7). Empty map when compilation fails or the
+    older single-sheet path has no physical pages.
+    """
     if not design.schdocs:
-        return None
+        return None, ()
+    try:
+        compiled = design.compile()
+        netlist = compiled.to_netlist()
+        sheet_names = tuple(
+            (str(doc.id), str(doc.file_name))
+            for doc in (getattr(compiled, "physical_documents", None) or ())
+            if getattr(doc, "id", None) and getattr(doc, "file_name", None)
+        )
+        return netlist, sheet_names
+    except Exception as exc:
+        log.warning("Could not compile schematic netlist via design.compile(): %s",
+                    exc)
+    # Fallback: legacy compile_netlist facade (no physical-page map).
     try:
         from altium_monkey.altium_netlist_compilation import compile_netlist
         from altium_monkey.altium_netlist_options import NetlistOptions
@@ -1382,10 +1408,10 @@ def _compile_schematic_netlist(design: AltiumDesign) -> Netlist | None:
             if design.project is not None
             else NetlistOptions()
         )
-        return compile_netlist(design.schdocs, design.project, options)
+        return compile_netlist(design.schdocs, design.project, options), ()
     except Exception as exc:
         log.warning("Could not compile schematic netlist: %s", exc)
-        return None
+        return None, ()
 
 
 def extract_project(prjpcb_path: str | Path,
@@ -1425,7 +1451,7 @@ def extract_project(prjpcb_path: str | Path,
     ox_mm = mils_to_mm(origin_x_mils)
     oy_mm = mils_to_mm(origin_y_mils)
 
-    compiled_netlist = _compile_schematic_netlist(design)
+    compiled_netlist, physical_sheet_names = _compile_schematic_netlist(design)
 
     return ExtractedProject(
         prjpcb_path=prjpcb_path,
@@ -1443,6 +1469,7 @@ def extract_project(prjpcb_path: str | Path,
         stackup=_extract_stackup(pcb),
         sch_components=_extract_sch_components(design),
         compiled_netlist=compiled_netlist,
+        physical_sheet_names=physical_sheet_names,
         board_origin_mm=Pt2D(ox_mm, oy_mm),
         board_outline=_extract_board_outline(pcb, ox_mm, oy_mm),
         **_plane_rule_kwargs(pcb),

--- a/fypa/altium/extract.py
+++ b/fypa/altium/extract.py
@@ -404,6 +404,9 @@ class RawSchComponent:
     schdoc_name: str
     parameters: dict[str, str]  # name -> text (case-preserved keys)
     pin_designators: tuple[str, ...]
+    # Pin designators (upper-cased) marked PDN_IGNORE on the schematic pin
+    # itself. Empty when no pin-level ignore parameters were found.
+    ignored_pins: frozenset[str] = frozenset()
 
 
 @dataclass(frozen=True, slots=True)
@@ -1322,11 +1325,124 @@ def _splice_plane_layers(
     return rebuilt
 
 
-def _extract_sch_component(comp, schdoc_name: str) -> RawSchComponent | None:
+def _is_pdn_ignore_param(name: str | None, text: str | None) -> bool:
+    """True when a schematic pin parameter means "exclude from PDN terminals".
+
+    Accepts ``PDN_IGNORE`` with a truthy value (``1`` / ``TRUE`` / ``YES`` /
+    ``IGNORE``) or the alias name ``PDN`` with value ``IGNORE``. Empty values
+    do not count.
+    """
+    if name is None:
+        return False
+    n = str(name).strip().upper()
+    v = str(text).strip().upper() if text is not None else ""
+    if not v:
+        return False
+    if n == "PDN_IGNORE":
+        return v in ("1", "TRUE", "YES", "IGNORE")
+    if n == "PDN":
+        return v == "IGNORE"
+    return False
+
+
+def _sch_component_pins(comp) -> list:
+    """Typed pin objects for a schematic component (``pins`` or children)."""
+    pins = list(getattr(comp, "pins", ()) or ())
+    if pins:
+        return pins
+    return [
+        c for c in (getattr(comp, "children", ()) or ())
+        if type(c).__name__ == "AltiumSchPin"
+    ]
+
+
+def _is_pin_owned_parameter(obj) -> bool:
+    """True for AltiumSchParameter or a duck-typed name/text/owner_index object."""
+    cls = type(obj).__name__
+    if cls == "AltiumSchPin":
+        return False
+    if cls == "AltiumSchParameter":
+        return True
+    return (
+        hasattr(obj, "name")
+        and hasattr(obj, "text")
+        and hasattr(obj, "owner_index")
+    )
+
+
+def _sheet_ignored_pins_by_component(
+    components: list,
+    all_objects,
+) -> list[frozenset[str]]:
+    """One pass over ``all_objects``: ignored pin sets parallel to ``components``.
+
+    Builds a sheet-wide pin-index → (component index, designator) map, then
+    scans parameters once instead of re-scanning the sheet per component.
+    """
+    ignored: list[set[str]] = [set() for _ in components]
+    pin_index_to_comp_des: dict[int, tuple[int, str]] = {}
+
+    for ci, comp in enumerate(components):
+        for pin in _sch_component_pins(comp):
+            des = getattr(pin, "designator", None)
+            if not des:
+                continue
+            des_s = str(des)
+            idx = getattr(pin, "_record_index", None)
+            if idx is not None:
+                try:
+                    pin_index_to_comp_des[int(idx)] = (ci, des_s)
+                except (TypeError, ValueError):
+                    pass
+            for param in getattr(pin, "pin_parameters", ()) or ():
+                if _is_pdn_ignore_param(
+                    getattr(param, "name", None), getattr(param, "text", None),
+                ):
+                    ignored[ci].add(des_s.upper())
+
+    if pin_index_to_comp_des:
+        for obj in all_objects or ():
+            if not _is_pin_owned_parameter(obj):
+                continue
+            owner = getattr(obj, "owner_index", None)
+            if owner is None:
+                continue
+            try:
+                owner_i = int(owner)
+            except (TypeError, ValueError):
+                continue
+            hit = pin_index_to_comp_des.get(owner_i)
+            if hit is None:
+                continue
+            if _is_pdn_ignore_param(
+                getattr(obj, "name", None), getattr(obj, "text", None),
+            ):
+                ci, des_s = hit
+                ignored[ci].add(des_s.upper())
+
+    return [frozenset(s) for s in ignored]
+
+
+def _ignored_pins_from_sch_component(comp, all_objects) -> frozenset[str]:
+    """Collect pin designators with a pin-owned PDN_IGNORE parameter.
+
+    Thin wrapper around :func:`_sheet_ignored_pins_by_component` for a single
+    component (unit tests and callers that already have one part).
+    """
+    return _sheet_ignored_pins_by_component([comp], all_objects)[0]
+
+
+def _extract_sch_component(
+    comp, schdoc_name: str, ignored_pins: frozenset[str] | None = None,
+) -> RawSchComponent | None:
     """Extract one component's designator + parameters + pin list from its children.
 
     Returns None if the component has no AltiumSchDesignator child (rare; usually
     means a non-instantiated symbol — safe to skip for PDN purposes).
+
+    ``ignored_pins`` comes from the sheet-level batch in
+    :func:`_extract_sch_components`; when omitted, pin-owned ignores are not
+    resolved here (callers must pass them or use the batch path).
     """
     designator: str | None = None
     parameters: dict[str, str] = {}
@@ -1346,11 +1462,19 @@ def _extract_sch_component(comp, schdoc_name: str) -> RawSchComponent | None:
                 pins.append(str(pin_designator))
     if designator is None:
         return None
+    # Prefer pin list from the typed ``pins`` collection when children
+    # enumeration missed some (OwnerIndex hierarchy).
+    if not pins:
+        for pin in getattr(comp, "pins", ()) or ():
+            des = getattr(pin, "designator", None)
+            if des:
+                pins.append(str(des))
     return RawSchComponent(
         designator=designator,
         schdoc_name=schdoc_name,
         parameters=parameters,
         pin_designators=tuple(pins),
+        ignored_pins=ignored_pins if ignored_pins is not None else frozenset(),
     )
 
 
@@ -1385,8 +1509,11 @@ def _extract_sch_components(
             continue
         # Preserve casing for diagnostics; lookups lower-case on compare.
         schdoc_name = _schdoc_display_path(Path(sd.filepath), root)
-        for comp in sd.components:
-            rec = _extract_sch_component(comp, schdoc_name)
+        all_objects = getattr(sd, "all_objects", None) or ()
+        components = list(sd.components)
+        ignored_sets = _sheet_ignored_pins_by_component(components, all_objects)
+        for comp, ignored in zip(components, ignored_sets):
+            rec = _extract_sch_component(comp, schdoc_name, ignored)
             if rec is not None:
                 out.append(rec)
     return tuple(out)

--- a/fypa/altium/extract.py
+++ b/fypa/altium/extract.py
@@ -1378,6 +1378,13 @@ def _sheet_ignored_pins_by_component(
 
     Builds a sheet-wide pin-index → (component index, designator) map, then
     scans parameters once instead of re-scanning the sheet per component.
+
+    Pin-owned ``PDN_IGNORE`` is discovered two ways (both match altium_monkey
+    SchDoc layout): ``pin.pin_parameters`` when the library attached them, and
+    sheet ``all_objects`` parameters whose ``owner_index`` equals the pin's
+    ``_record_index``. Component-owned parameters (owner → component record)
+    are ignored here — use ``PDN_IGNORE_PINS`` on the part when pin-level
+    ownership cannot be resolved.
     """
     ignored: list[set[str]] = [set() for _ in components]
     pin_index_to_comp_des: dict[int, tuple[int, str]] = {}

--- a/fypa/altium/loader.py
+++ b/fypa/altium/loader.py
@@ -143,6 +143,12 @@ COUPLING_RESISTANCE_OHM: float = 100.0e-3
 # the coupling to equalise — at any value).
 SOURCE_COUPLING_RESISTANCE_OHM: float = 1.0e-6
 
+# When True, multi-pin star coupling resistances are scaled inversely with
+# each pin's pad area (R_i = R_base * A_mean / A_i) so larger pads take a
+# larger share of terminal current when copper potentials are similar.
+# Off by default — equal R per pin matches historical behaviour.
+AREA_WEIGHTED_PIN_COUPLING: bool = False
+
 
 log = logging.getLogger(__name__)
 
@@ -192,6 +198,8 @@ class SolveSettings:
     # Conductive-fill override: "auto" (per-via from Altium IPC-4761 data),
     # "all" (force every via filled), or "none" (force none filled).
     conductive_fill_mode: str = CONDUCTIVE_FILL_MODE
+    # Scale multi-pin star coupling R inversely with pad area.
+    area_weighted_pin_coupling: bool = AREA_WEIGHTED_PIN_COUPLING
     # Meshing
     mesh_min_angle_deg: float = 20.0
     mesh_max_size_mm: float = 0.6
@@ -234,6 +242,9 @@ class SolveSettings:
             self.conductive_fill_resistivity_ohm_mm
         )
         globals()["CONDUCTIVE_FILL_MODE"] = self.conductive_fill_mode
+        globals()["AREA_WEIGHTED_PIN_COUPLING"] = bool(
+            self.area_weighted_pin_coupling
+        )
 
     @classmethod
     def from_metadata(cls, metadata: dict | None) -> SolveSettings:
@@ -271,6 +282,10 @@ class SolveSettings:
         mode = phys.get("conductive_fill_mode")
         if isinstance(mode, str) and mode in ("auto", "all", "none"):
             s.conductive_fill_mode = mode
+        if "area_weighted_pin_coupling" in phys:
+            s.area_weighted_pin_coupling = bool(
+                phys["area_weighted_pin_coupling"]
+            )
         if "temperature_c" in phys:
             s.temperature_c = float(phys["temperature_c"])
         if "copper_temp_coefficient_per_c" in phys:
@@ -551,6 +566,49 @@ def _collect_active_nets(directives, extracted: ExtractedProject) -> set[int]:
     return active
 
 
+def _pin_coupling_resistances(
+    areas_mm2: list[float],
+    r_base: float,
+    *,
+    area_weighted: bool | None = None,
+) -> list[float]:
+    """Per-pin star coupling resistances for a multi-pin terminal.
+
+    When ``area_weighted`` is False (default module flag), every pin gets
+    ``r_base``. When True, ``R_i = r_base * A_mean / A_i`` so conductance
+    scales with pad area. Degenerate / missing areas are replaced by the
+    mean of the valid areas in the terminal; if none are valid, every pin
+    keeps ``r_base`` (equal share).
+    """
+    if area_weighted is None:
+        area_weighted = AREA_WEIGHTED_PIN_COUPLING
+    n = len(areas_mm2)
+    if n == 0:
+        return []
+    if not area_weighted or n == 1:
+        return [float(r_base)] * n
+
+    valid = [a for a in areas_mm2 if a is not None and a > 0.0]
+    if not valid:
+        return [float(r_base)] * n
+    a_mean = sum(valid) / len(valid)
+    out: list[float] = []
+    for a in areas_mm2:
+        ai = a if (a is not None and a > 0.0) else a_mean
+        out.append(float(r_base) * (a_mean / ai))
+    return out
+
+
+def _pin_area_mm2(pin: TerminalPin) -> float:
+    poly = pin.pad_polygon
+    if poly is None or getattr(poly, "is_empty", False):
+        return 0.0
+    try:
+        return float(poly.area)
+    except Exception:
+        return 0.0
+
+
 def _terminal_connections(
     term: TerminalSpec,
     main_node: _pp.NodeID,
@@ -575,6 +633,10 @@ def _terminal_connections(
     :data:`SOURCE_COUPLING_RESISTANCE_OHM` for VOLTAGE-forcing terminals so
     high-current sources don't see a ~1 V drop per pin to their virtual
     hub.
+
+    When :data:`AREA_WEIGHTED_PIN_COUPLING` is on, each star resistor is
+    scaled inversely with that pin's pad area (see
+    :func:`_pin_coupling_resistances`).
 
     Pins whose ``(layer, net)`` pair has no padne Layer (e.g. internal planes
     pending implementation, or a net with no extracted copper on that layer)
@@ -602,9 +664,13 @@ def _terminal_connections(
             region=pin.pad_polygon,
         )], []
 
+    areas = [_pin_area_mm2(pin) for _layer, pin in valid]
+    resistances = _pin_coupling_resistances(
+        areas, coupling_resistance_ohm,
+    )
     conns: list[_pp.Connection] = []
     aux: list[_pp.BaseLumped] = []
-    for layer, pin in valid:
+    for (layer, pin), r_pin in zip(valid, resistances):
         pin_node = _pp.NodeID()
         conns.append(_pp.Connection(
             layer=layer,
@@ -613,7 +679,7 @@ def _terminal_connections(
             region=pin.pad_polygon,
         ))
         aux.append(_pp.Resistor(
-            a=pin_node, b=main_node, resistance=coupling_resistance_ohm,
+            a=pin_node, b=main_node, resistance=r_pin,
         ))
     return conns, aux
 
@@ -2431,6 +2497,7 @@ def build_solve_metadata(
             "plating_thickness_mm": PLATING_THICKNESS_MM,
             "fallback_via_resistance_ohm": FALLBACK_VIA_RESISTANCE_OHM,
             "coupling_resistance_ohm": COUPLING_RESISTANCE_OHM,
+            "area_weighted_pin_coupling": AREA_WEIGHTED_PIN_COUPLING,
             "conductive_fill_resistivity_ohm_mm":
                 CONDUCTIVE_FILL_RESISTIVITY_OHM_MM,
             "conductive_fill_mode": CONDUCTIVE_FILL_MODE,
@@ -2448,7 +2515,10 @@ def build_solve_metadata(
             "note_coupling_resistance": (
                 "When a directive terminal has multiple pins, each pin attaches "
                 "to a per-pin NodeID coupled back to the main terminal NodeID "
-                "via this resistance (padne star-coupling convention)."
+                "via this resistance (padne star-coupling convention). When "
+                "area_weighted_pin_coupling is true, each pin's resistance is "
+                "scaled as R_i = R * A_mean / A_i so larger pads take more "
+                "current at equal copper potential."
             ),
         },
         "directives": directives,
@@ -2519,12 +2589,20 @@ def _terminal_summary(term, nets) -> dict:
     for pin in term.pins:
         net_name = (nets[pin.net_index].name
                     if 0 <= pin.net_index < len(nets) else "(none)")
+        area = 0.0
+        poly = pin.pad_polygon
+        if poly is not None and not getattr(poly, "is_empty", False):
+            try:
+                area = float(poly.area)
+            except Exception:
+                area = 0.0
         pins.append({
             "pad": pin.pad_designator,
             "layer_id": pin.layer_id,
             "net": net_name,
             "x_mm": pin.point.x,
             "y_mm": pin.point.y,
+            "area_mm2": area,
         })
     return {
         "pin_count": len(pins),

--- a/fypa/altium/loader.py
+++ b/fypa/altium/loader.py
@@ -424,6 +424,10 @@ class LoadedProject:
             lines.append(f"  Warnings ({len(self.annotations.warnings)}):")
             for w in self.annotations.warnings:
                 lines.append(f"    ! {w}")
+        if self.annotations.infos:
+            lines.append(f"  Infos ({len(self.annotations.infos)}):")
+            for i in self.annotations.infos:
+                lines.append(f"    i {i}")
         if self.annotations.errors:
             lines.append(f"  Errors ({len(self.annotations.errors)}):")
             for e in self.annotations.errors:
@@ -524,6 +528,7 @@ def clone_loaded_for_edit(loaded: LoadedProject) -> LoadedProject:
     new_annotations.directives = list(loaded.annotations.directives)
     new_annotations.warnings = list(loaded.annotations.warnings)
     new_annotations.errors = list(loaded.annotations.errors)
+    new_annotations.infos = list(getattr(loaded.annotations, "infos", []))
     new_annotations.open_loop_rails = list(
         getattr(loaded.annotations, "open_loop_rails", [])
     )
@@ -4095,6 +4100,8 @@ def load_project(prjpcb_path: str | Path,
         log.warning("Annotation: %s", w)
     for e in annotations.errors:
         log.error("Annotation error: %s", e)
+    for i in getattr(annotations, "infos", []):
+        log.info("Annotation: %s", i)
 
     return LoadedProject(
         extracted=extracted,

--- a/fypa/altium_viewer.py
+++ b/fypa/altium_viewer.py
@@ -6364,9 +6364,23 @@ class _SettingsTabMixin:
         )
         self._settings_adaptive_check.toggled.connect(
             self._on_settings_field_changed)
+        self._settings_area_weighted_check = QCheckBox(
+            "Weight multi-pin coupling by pad area")
+        self._settings_area_weighted_check.setChecked(
+            bool(getattr(
+                self._solve_settings, "area_weighted_pin_coupling", False)))
+        self._settings_area_weighted_check.setToolTip(
+            "Scale each multi-pin star coupling resistor inversely with that "
+            "pin's pad area (R ∝ 1/A), so larger pads — including QFN thermal "
+            "pads on GND — take a larger share of supply and return current "
+            "when copper access is similar. Off = equal R per pin (default)."
+        )
+        self._settings_area_weighted_check.toggled.connect(
+            self._on_settings_field_changed)
         _solve_layout = solve_box.layout()
         if _solve_layout is not None:
             _solve_layout.addRow(self._settings_adaptive_check)
+            _solve_layout.addRow(self._settings_area_weighted_check)
         # Adaptive SMPS regulator-gain iteration — moved here from the editor
         # canvas overlay. Same attribute name + handler as before, so the
         # solve-time reads and resolve-enable logic are unchanged. Enabled only
@@ -7122,6 +7136,9 @@ class _SettingsTabMixin:
         chk = getattr(self, "_settings_adaptive_check", None)
         if chk is not None:
             chk.setChecked(bool(defaults.adaptive_mesh))
+        aw = getattr(self, "_settings_area_weighted_check", None)
+        if aw is not None:
+            aw.setChecked(bool(defaults.area_weighted_pin_coupling))
         mode_combo = getattr(self, "_fill_mode_combo", None)
         if mode_combo is not None:
             idx = mode_combo.findData(defaults.conductive_fill_mode)
@@ -7187,6 +7204,14 @@ class _SettingsTabMixin:
             dirty = bool(chk.isChecked()) != bool(
                 getattr(self._solve_settings, "adaptive_mesh", False))
             mark(chk, dirty)
+            any_dirty = any_dirty or dirty
+
+        aw = getattr(self, "_settings_area_weighted_check", None)
+        if aw is not None:
+            dirty = bool(aw.isChecked()) != bool(
+                getattr(
+                    self._solve_settings, "area_weighted_pin_coupling", False))
+            mark(aw, dirty)
             any_dirty = any_dirty or dirty
 
         mode_combo = getattr(self, "_fill_mode_combo", None)
@@ -15296,23 +15321,48 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
                 for term_name, term in (d.get("terminals") or {}).items():
                     term_pins = term.get("pins") or []
                     is_n_side = term_name in _N_SIDE_TERMINALS
-                    # Per-pin current = directive total / pins in THIS
-                    # terminal. The lumped element couples to each pin in
-                    # a terminal through equal-valued star resistors, so
-                    # with similar copper potentials at the pins the
-                    # current splits evenly. A terminal with no pins
-                    # (multi-channel directives can have empty terminals)
-                    # contributes no markers, so the divisor is never 0.
+                    # Per-pin current estimate for hover. Equal split when
+                    # area weighting is off; I * A_i / ΣA when the solve used
+                    # area-weighted star coupling (physics_constants flag).
+                    # Same equal-potential approximation as the star model —
+                    # FEM pin currents can still differ when copper access
+                    # to the pads is unequal.
                     n_pins = len(term_pins)
+                    area_weighted = bool(
+                        ((self.metadata or {}).get("physics_constants") or {})
+                        .get("area_weighted_pin_coupling")
+                    )
+                    per_pin_currents: list[float | None]
                     if (directive_current is not None
                             and np.isfinite(directive_current)
                             and n_pins > 0):
-                        per_pin_current: float | None = (
-                            directive_current / n_pins
-                        )
+                        if area_weighted:
+                            areas = [
+                                float(p.get("area_mm2") or 0.0)
+                                for p in term_pins
+                            ]
+                            positive = [a for a in areas if a > 0.0]
+                            if positive:
+                                a_mean = sum(positive) / len(positive)
+                                weights = [
+                                    a if a > 0.0 else a_mean for a in areas
+                                ]
+                                wsum = sum(weights) or 1.0
+                                per_pin_currents = [
+                                    directive_current * w / wsum
+                                    for w in weights
+                                ]
+                            else:
+                                per_pin_currents = [
+                                    directive_current / n_pins
+                                ] * n_pins
+                        else:
+                            per_pin_currents = [
+                                directive_current / n_pins
+                            ] * n_pins
                     else:
-                        per_pin_current = None
-                    for pin in term_pins:
+                        per_pin_currents = [None] * n_pins
+                    for pin_i, pin in enumerate(term_pins):
                         lid = pin.get("layer_id")
                         if lid not in target_layer_ids:
                             continue
@@ -15346,7 +15396,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
                                 "terminal": term_name,
                                 "net": pin.get("net", ""),
                                 "physical": phys_for_pin or "",
-                                "current_a": per_pin_current,
+                                "current_a": per_pin_currents[pin_i],
                                 "directive_current_a": directive_current,
                                 "terminal_pin_count": n_pins,
                                 "size_px": int(
@@ -22441,6 +22491,9 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         chk = getattr(self, "_settings_adaptive_check", None)
         if chk is not None:
             kwargs["adaptive_mesh"] = chk.isChecked()
+        aw = getattr(self, "_settings_area_weighted_check", None)
+        if aw is not None:
+            kwargs["area_weighted_pin_coupling"] = aw.isChecked()
         mode_combo = getattr(self, "_fill_mode_combo", None)
         if mode_combo is not None:
             data = mode_combo.currentData()
@@ -28503,6 +28556,12 @@ def _format_setup_html(solution, metadata: dict | None,
                      f"<tr><th>Multi-pin coupling resistance</th>"
                      f"<td class='num'>{phys.get('coupling_resistance_ohm', 0)*1000:.3f} mΩ</td>"
                      f"<td class='muted'>{_esc(phys.get('note_coupling_resistance', ''))}</td></tr>"
+                     f"<tr><th>Area-weighted pin coupling</th>"
+                     f"<td class='num'>"
+                     f"{'on' if phys.get('area_weighted_pin_coupling') else 'off'}"
+                     f"</td>"
+                     f"<td class='muted'>When on, each multi-pin star R scales "
+                     f"as R ∝ 1/pad area (supply and GND).</td></tr>"
                      "</table>")
 
     # Directives — each heading is a clickable toggle (collapsed by default).

--- a/fypa/cli.py
+++ b/fypa/cli.py
@@ -1044,6 +1044,10 @@ def _try_load_cached_design_info(
         log.info("Design-info cache: fingerprint mismatch — re-extracting.")
         return None
     log.info("Design-info cache hit — reusing the design extract.")
+    # Same as extract_project: drop resolvers memoized against a prior
+    # ExtractedProject identity so a cache hit cannot reuse stale state.
+    from fypa.altium.annotations import clear_annotation_caches
+    clear_annotation_caches()
     return blob.get("loaded")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "matplotlib==3.10.9",
 
     # --- ParaView VTU export (File > Export > ParaView, and `FYPA paraview` CLI) ---
-    "lxml==5.3.0",
+    "lxml==6.0.2",
 
     # --- Gerber + Excellon import (File > Import Gerber Files…) ---
     # Pure-Python RS-274X / NC-drill parser. Pulls flask / quart / h2 as
@@ -90,7 +90,7 @@ package = false
 [tool.uv.sources]
 # altium_monkey is fetched directly from the upstream repo at a pinned tag.
 # To bump: edit the tag, then `uv lock --upgrade-package altium-monkey`.
-altium-monkey = { git = "https://github.com/wavenumber-eng/altium_monkey", tag = "v2026.5.20" }
+altium-monkey = { git = "https://github.com/wavenumber-eng/altium_monkey", tag = "v2026.7.29" }
 
 [tool.pytest.ini_options]
 # Tests import `pdnsolver` (and, for regression tests, shell out to FYPA.py),

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -3002,3 +3002,318 @@ def test_format_solve_blockers_lists_errors():
     assert "PDN2_PIN" in text
     assert "no SOURCE or REGULATOR" in text
     assert "fypa.log" in text
+
+
+# --- PDN_IGNORE / PDN_IGNORE_PINS --------------------------------------------
+
+def test_resolve_terminal_excludes_ignore_pins_from_net_match():
+    from fypa.altium.annotations import _ignore_pins_for_channel
+
+    proj = _minimal_proj(
+        nets=(RawNet("VIN"), RawNet("GND")),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 0, 0.0),
+            _pad(0, "2", 0, 1.0),   # enable hard-tied to VIN
+            _pad(0, "3", 1, 2.0),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={"Comment": "IC"},
+                pin_designators=("1", "2", "3"),
+                ignored_pins=frozenset({"2"}),
+            ),
+        ),
+    )
+    warnings: list[str] = []
+    ign = _ignore_pins_for_channel(
+        {}, None, frozenset({"2"}),
+    )
+    spec, errs = _resolve_terminal(
+        proj, 0, "VIN", None, [1], "SINK P",
+        warnings=warnings, ignore_pins=ign,
+    )
+    assert not errs and spec is not None
+    assert [p.pad_designator for p in spec.pins] == ["1"]
+    assert any("ignoring pin" in w and "2" in w for w in warnings)
+
+
+def test_resolve_terminal_ignore_wins_over_include_list():
+    proj = _minimal_proj(
+        nets=(RawNet("VIN"),),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 0, 0.0),
+            _pad(0, "EN", 0, 1.0),
+        ),
+    )
+    warnings: list[str] = []
+    spec, errs = _resolve_terminal(
+        proj, 0, "VIN", ["1", "EN"], [1], "SINK P",
+        warnings=warnings, ignore_pins=frozenset({"EN"}),
+    )
+    assert not errs and spec is not None
+    assert [p.pad_designator for p in spec.pins] == ["1"]
+
+
+def test_parse_sink_honours_pdn_ignore_pins_list():
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+3V3")),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "500mA",
+                    "PDN_P_NET": "+3V3",
+                    "PDN_N_NET": "GND",
+                    "PDN_IGNORE_PINS": "EN",
+                },
+                pin_designators=("1", "EN", "GND"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1, 0.0),
+            _pad(0, "EN", 1, 1.0),
+            _pad(0, "GND", 0, 2.0),
+        ),
+    )
+    result = parse_annotations(proj)
+    assert not result.errors, result.errors
+    assert len(result.directives) == 1
+    sink = result.directives[0]
+    assert isinstance(sink, SinkSpec)
+    assert [p.pad_designator for p in sink.p.pins] == ["1"]
+    assert any("IGNORE" in w for w in result.warnings)
+
+
+def test_parse_sink_channel_ignore_pins():
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("AVDD"), RawNet("DVDD")),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "10mA",
+                    "PDN_P_NET": "AVDD",
+                    "PDN_N_NET": "GND",
+                    "PDN1_I": "20mA",
+                    "PDN1_P_NET": "DVDD",
+                    "PDN1_N_NET": "GND",
+                    "PDN1_IGNORE_PINS": "4",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1, 0.0),  # AVDD
+            _pad(0, "2", 0, 1.0),  # GND
+            _pad(0, "3", 2, 2.0),  # DVDD
+            _pad(0, "4", 2, 3.0),  # DVDD enable-like
+        ),
+    )
+    result = parse_annotations(proj)
+    assert not result.errors, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 2
+    by_ch = {d.channel_index: d for d in sinks}
+    assert [p.pad_designator for p in by_ch[None].p.pins] == ["1"]
+    assert [p.pad_designator for p in by_ch[1].p.pins] == ["3"]
+
+
+def test_is_pdn_ignore_param_alias():
+    from fypa.altium.extract import _is_pdn_ignore_param
+
+    assert _is_pdn_ignore_param("PDN_IGNORE", "1")
+    assert _is_pdn_ignore_param("PDN_IGNORE", "TRUE")
+    assert _is_pdn_ignore_param("PDN", "IGNORE")
+    assert not _is_pdn_ignore_param("PDN_IGNORE", "")
+    assert not _is_pdn_ignore_param("PDN", "1")
+    assert not _is_pdn_ignore_param("OTHER", "IGNORE")
+
+
+def test_ignored_pins_from_sch_component_owner_index():
+    from types import SimpleNamespace
+
+    from fypa.altium.extract import _ignored_pins_from_sch_component
+
+    pin = SimpleNamespace(
+        designator="EN",
+        _record_index=42,
+        pin_parameters=[],
+    )
+    comp = SimpleNamespace(pins=[pin], children=[])
+    param = SimpleNamespace(
+        name="PDN_IGNORE", text="1", owner_index=42,
+    )
+    assert _ignored_pins_from_sch_component(comp, [param]) == frozenset({"EN"})
+
+
+def test_warn_unknown_does_not_flag_ignore_pins():
+    result = AnnotationResult()
+    comp = PdnParameterSource(
+        designator="U1", schdoc_name="Pwr.SchDoc",
+        parameters={
+            "PDN_ROLE": "SINK",
+            "PDN_I": "100mA",
+            "PDN_P_NET": "+3V3",
+            "PDN_N_NET": "GND",
+            "PDN_IGNORE_PINS": "EN",
+        },
+    )
+    _warn_unknown_pdn_params(comp, "SINK", result)
+    assert not any("IGNORE_PINS" in w for w in result.warnings)
+def test_parse_annotations_honours_sch_ignored_pins():
+    """End-to-end: pin-level ignored_pins on RawSchComponent reach the sink."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+3V3")),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "500mA",
+                    "PDN_P_NET": "+3V3",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "EN", "GND"),
+                ignored_pins=frozenset({"EN"}),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1, 0.0),
+            _pad(0, "EN", 1, 1.0),
+            _pad(0, "GND", 0, 2.0),
+        ),
+    )
+    result = parse_annotations(proj)
+    assert not result.errors, result.errors
+    sink = result.directives[0]
+    assert isinstance(sink, SinkSpec)
+    assert [p.pad_designator for p in sink.p.pins] == ["1"]
+    assert any("IGNORE" in w for w in result.warnings)
+
+
+def test_sch_ignored_pins_empty_sheet_match_does_not_import_other_sheet():
+    """Matching sheet with no ignores must not fall back to another sheet."""
+    from fypa.altium.annotations import _sch_ignored_pins
+
+    proj = _minimal_proj(
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={}, pin_designators=("1", "EN"),
+                ignored_pins=frozenset(),
+            ),
+            RawSchComponent(
+                designator="U1", schdoc_name="Other.SchDoc",
+                parameters={}, pin_designators=("1", "EN"),
+                ignored_pins=frozenset({"EN"}),
+            ),
+        ),
+    )
+    assert _sch_ignored_pins(proj, "U1", "Pwr.SchDoc") == frozenset()
+
+
+def test_sch_ignored_pins_fallback_when_sheet_missing():
+    from fypa.altium.annotations import _sch_ignored_pins
+
+    proj = _minimal_proj(
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={}, pin_designators=("1", "EN"),
+                ignored_pins=frozenset({"EN"}),
+            ),
+        ),
+    )
+    assert _sch_ignored_pins(proj, "U1", "Missing.SchDoc") == frozenset({"EN"})
+
+
+def test_sch_ignored_pins_blank_sheet_does_not_union_ambiguous():
+    """Blank/None schdoc must not merge ignores across same designators."""
+    from fypa.altium.annotations import _sch_ignored_pins
+
+    proj = _minimal_proj(
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={}, pin_designators=("1", "EN"),
+                ignored_pins=frozenset(),
+            ),
+            RawSchComponent(
+                designator="U1", schdoc_name="Other.SchDoc",
+                parameters={}, pin_designators=("1", "EN"),
+                ignored_pins=frozenset({"EN"}),
+            ),
+        ),
+    )
+    assert _sch_ignored_pins(proj, "U1", "") == frozenset()
+    assert _sch_ignored_pins(proj, "U1", None) == frozenset()
+
+
+def test_sch_ignored_pins_blank_sheet_unique_placement_ok():
+    from fypa.altium.annotations import _sch_ignored_pins
+
+    proj = _minimal_proj(
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={}, pin_designators=("1", "EN"),
+                ignored_pins=frozenset({"EN"}),
+            ),
+        ),
+    )
+    assert _sch_ignored_pins(proj, "U1", "") == frozenset({"EN"})
+    assert _sch_ignored_pins(proj, "U1", None) == frozenset({"EN"})
+
+
+def test_sch_ignored_pins_missing_sheet_ambiguous_no_fallback_union():
+    """Mismatched sheet + multiple placements → empty, not a cross-sheet union."""
+    from fypa.altium.annotations import _sch_ignored_pins
+
+    proj = _minimal_proj(
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={}, pin_designators=("1",),
+                ignored_pins=frozenset({"1"}),
+            ),
+            RawSchComponent(
+                designator="U1", schdoc_name="Other.SchDoc",
+                parameters={}, pin_designators=("EN",),
+                ignored_pins=frozenset({"EN"}),
+            ),
+        ),
+    )
+    assert _sch_ignored_pins(proj, "U1", "Missing.SchDoc") == frozenset()

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -3004,7 +3004,370 @@ def test_format_solve_blockers_lists_errors():
     assert "fypa.log" in text
 
 
-# --- PDN_IGNORE / PDN_IGNORE_PINS --------------------------------------------
+# --- PDN_PINS_ONLY / PDN_EXTRA_PINS / PDN_IGNORE ------------------------------
+
+def test_allow_pins_for_part_union_and_none():
+    from fypa.altium.annotations import _allow_pins_for_part
+
+    assert _allow_pins_for_part({}) is None
+    assert _allow_pins_for_part({"PDN_PINS_ONLY": "1, EP"}) == frozenset({"1", "EP"})
+    assert _allow_pins_for_part({"PDN_EXTRA_PINS": "SNS"}) == frozenset({"SNS"})
+    assert _allow_pins_for_part({
+        "PDN_PINS_ONLY": "1,2",
+        "PDN_EXTRA_PINS": "EP",
+    }) == frozenset({"1", "2", "EP"})
+
+
+def test_resolve_terminal_honours_pins_only_allowlist():
+    proj = _minimal_proj(
+        nets=(RawNet("VIN"), RawNet("GND")),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 0, 0.0),
+            _pad(0, "EN", 0, 1.0),
+            _pad(0, "GND", 1, 2.0),
+        ),
+    )
+    warnings: list[str] = []
+    spec, errs = _resolve_terminal(
+        proj, 0, "VIN", None, [1], "SINK P",
+        warnings=warnings, allow_pins=frozenset({"1", "GND"}),
+    )
+    assert not errs and spec is not None
+    assert [p.pad_designator for p in spec.pins] == ["1"]
+
+
+def test_resolve_terminal_extra_pins_extends_allowlist():
+    from fypa.altium.annotations import _allow_pins_for_part
+
+    allow = _allow_pins_for_part({
+        "PDN_PINS_ONLY": "1",
+        "PDN_EXTRA_PINS": "EP",
+    })
+    proj = _minimal_proj(
+        nets=(RawNet("GND"),),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 0, 0.0),
+            _pad(0, "EP", 0, 1.0),
+            _pad(0, "EN", 0, 2.0),
+        ),
+    )
+    spec, errs = _resolve_terminal(
+        proj, 0, "GND", None, [1], "SINK N",
+        allow_pins=allow,
+    )
+    assert not errs and spec is not None
+    assert sorted(p.pad_designator for p in spec.pins) == ["1", "EP"]
+
+
+def test_resolve_terminal_override_pins_bypass_allowlist():
+    proj = _minimal_proj(
+        nets=(RawNet("VIN"),),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 0, 0.0),
+            _pad(0, "EN", 0, 1.0),
+        ),
+    )
+    spec, errs = _resolve_terminal(
+        proj, 0, "VIN", ["EN"], [1], "SINK P",
+        allow_pins=frozenset({"1"}),
+    )
+    assert not errs and spec is not None
+    assert [p.pad_designator for p in spec.pins] == ["EN"]
+
+
+def test_parse_sink_pins_only_keeps_en_off_rail():
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+3V3")),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "500mA",
+                    "PDN_P_NET": "+3V3",
+                    "PDN_N_NET": "GND",
+                    "PDN_PINS_ONLY": "1,GND",
+                },
+                pin_designators=("1", "EN", "GND"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1, 0.0),
+            _pad(0, "EN", 1, 1.0),
+            _pad(0, "GND", 0, 2.0),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert not result.errors
+    sink = next(d for d in result.directives if isinstance(d, SinkSpec))
+    assert sorted(p.pad_designator for p in sink.p.pins) == ["1"]
+    assert sorted(p.pad_designator for p in sink.n.pins) == ["GND"]
+
+
+def test_allowlist_empty_pool_errors_once_for_two_terminals():
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+3V3")),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+3V3",
+                    "PDN_N_NET": "GND",
+                    "PDN_PINS_ONLY": "NOSUCH",
+                },
+                pin_designators=("1", "GND"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1, 0.0),
+            _pad(0, "GND", 0, 1.0),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    empty = [
+        e for e in result.errors
+        if "no pads match PDN_PINS_ONLY" in e
+    ]
+    assert len(empty) == 1
+    assert empty[0].startswith("U1:")
+
+
+def test_allowlist_missing_pin_warns_once_for_two_terminals():
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+3V3")),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+3V3",
+                    "PDN_N_NET": "GND",
+                    "PDN_PINS_ONLY": "1,GND,MISSING",
+                },
+                pin_designators=("1", "GND"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1, 0.0),
+            _pad(0, "GND", 0, 1.0),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    miss = [
+        w for w in result.warnings
+        if "not on the PCB" in w and "MISSING" in w
+    ]
+    assert len(miss) == 1
+
+
+def test_resolve_terminal_allowlist_error_names_excluded_net_pads():
+    proj = _minimal_proj(
+        nets=(RawNet("VIN"), RawNet("GND")),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1, 0.0),   # on GND — in allowlist
+            _pad(0, "EN", 0, 1.0),  # on VIN — outside allowlist
+        ),
+    )
+    spec, errs = _resolve_terminal(
+        proj, 0, "VIN", None, [1], "SINK P",
+        allow_pins=frozenset({"1"}),
+    )
+    assert spec is None
+    assert errs
+    assert "no allowlisted pad on net" in errs[0]
+    assert "EN" in errs[0]
+    assert "PDN_PINS_ONLY" in errs[0]
+
+
+def test_parse_sink_pins_only_partitions_multi_channel_rails():
+    # Nets: 0=GND, 1=+3V3, 2=+1V8 — EN hard-tied to +3V3 must stay off both.
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+3V3"), RawNet("+1V8")),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "500mA",
+                    "PDN_P_NET": "+3V3",
+                    "PDN_N_NET": "GND",
+                    "PDN1_I": "250mA",
+                    "PDN1_P_NET": "+1V8",
+                    "PDN1_N_NET": "GND",
+                    "PDN_PINS_ONLY": "A1,A2,GND",
+                },
+                pin_designators=("A1", "A2", "EN", "GND"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="BGA", source_designator="U1",
+            ),
+        ),
+        pads=(
+            _pad(0, "A1", 1, 0.0),
+            _pad(0, "A2", 2, 1.0),
+            _pad(0, "EN", 1, 2.0),
+            _pad(0, "GND", 0, 3.0),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert not result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 2
+    by_ch = {d.channel_index: d for d in sinks}
+    assert sorted(p.pad_designator for p in by_ch[None].p.pins) == ["A1"]
+    assert sorted(p.pad_designator for p in by_ch[1].p.pins) == ["A2"]
+    for s in sinks:
+        assert sorted(p.pad_designator for p in s.n.pins) == ["GND"]
+
+
+def test_parse_regulator_honours_pins_only_on_in_and_out():
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V"), RawNet("+3V3")),
+        sch_components=(
+            RawSchComponent(
+                designator="U2", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_V": "3.3",
+                    "PDN_GAIN": "0.9",
+                    "PDN_OUT_P_NET": "+3V3",
+                    "PDN_OUT_N_NET": "GND",
+                    "PDN_IN_P_NET": "+5V",
+                    "PDN_IN_N_NET": "GND",
+                    "PDN_PINS_ONLY": "IN,OUT,GND",
+                },
+                pin_designators=("IN", "OUT", "EN", "GND"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U2", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOT", source_designator="U2",
+            ),
+        ),
+        pads=(
+            _pad(0, "IN", 1, 0.0),
+            _pad(0, "OUT", 2, 1.0),
+            _pad(0, "EN", 1, 2.0),  # on +5V, must not join IN
+            _pad(0, "GND", 0, 3.0),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert not result.errors
+    reg = next(d for d in result.directives if isinstance(d, RegulatorSpec))
+    assert sorted(p.pad_designator for p in reg.in_p.pins) == ["IN"]
+    assert sorted(p.pad_designator for p in reg.out_p.pins) == ["OUT"]
+    assert sorted(p.pad_designator for p in reg.in_n.pins) == ["GND"]
+    assert sorted(p.pad_designator for p in reg.out_n.pins) == ["GND"]
+
+
+def test_resolve_terminal_allowlist_then_ignore():
+    proj = _minimal_proj(
+        nets=(RawNet("VIN"),),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 0, 0.0),
+            _pad(0, "2", 0, 1.0),
+            _pad(0, "EN", 0, 2.0),
+        ),
+    )
+    warnings: list[str] = []
+    spec, errs = _resolve_terminal(
+        proj, 0, "VIN", None, [1], "SINK P",
+        warnings=warnings,
+        allow_pins=frozenset({"1", "2"}),
+        ignore_pins=frozenset({"2"}),
+    )
+    assert not errs and spec is not None
+    assert [p.pad_designator for p in spec.pins] == ["1"]
+    assert any("ignoring pin" in w and "2" in w for w in warnings)
+
+
+def test_warn_unknown_flags_indexed_pins_only():
+    result = AnnotationResult()
+    comp = PdnParameterSource(
+        designator="U1", schdoc_name="Pwr.SchDoc",
+        parameters={
+            "PDN_ROLE": "SINK",
+            "PDN_I": "100mA",
+            "PDN_P_NET": "+3V3",
+            "PDN_N_NET": "GND",
+            "PDN1_PINS_ONLY": "1,2",
+        },
+    )
+    _warn_unknown_pdn_params(comp, "SINK", result)
+    assert any("PDN1_PINS_ONLY" in w and "part-wide" in w for w in result.warnings)
+
+
+def test_warn_unknown_does_not_flag_pins_only():
+    result = AnnotationResult()
+    comp = PdnParameterSource(
+        designator="U1", schdoc_name="Pwr.SchDoc",
+        parameters={
+            "PDN_ROLE": "SINK",
+            "PDN_I": "100mA",
+            "PDN_P_NET": "+3V3",
+            "PDN_N_NET": "GND",
+            "PDN_PINS_ONLY": "1,GND",
+            "PDN_EXTRA_PINS": "EP",
+        },
+    )
+    _warn_unknown_pdn_params(comp, "SINK", result)
+    assert not any("PINS_ONLY" in w or "EXTRA_PINS" in w for w in result.warnings)
+
 
 def test_resolve_terminal_excludes_ignore_pins_from_net_match():
     from fypa.altium.annotations import _ignore_pins_for_channel

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -880,6 +880,55 @@ def test_sheet_name_matches_full_path_not_basename_collision():
     )
 
 
+def test_sheet_name_matches_physical_page_id_via_map():
+    """altium_monkey ≥ 2026.7 emits physical page ids in source_sheets."""
+    physical = (
+        "physical:0:logical:0:main.SchDoc:child:1:sheet_symbol:U_PWR"
+        ":sheet:power.SchDoc"
+    )
+    proj = _minimal_proj(
+        physical_sheet_names=((physical, "Power.SchDoc"),),
+    )
+    assert _sheet_name_matches(
+        "Power.SchDoc", [physical], proj=proj,
+    )
+    assert not _sheet_name_matches(
+        "Other.SchDoc", [physical], proj=proj,
+    )
+
+
+def test_sheet_name_matches_physical_page_id_without_map():
+    """Embedded ``*.SchDoc`` leaf is recovered when the compile map is absent."""
+    physical = (
+        "physical:0:logical:0:Power.SchDoc:child:1:sheet_symbol:X"
+    )
+    assert _sheet_name_matches("Power.SchDoc", [physical])
+    assert not _sheet_name_matches("Other.SchDoc", [physical])
+
+
+def test_resolve_local_net_pins_physical_source_sheet():
+    physical = (
+        "physical:0:logical:0:main.SchDoc:child:1:sheet_symbol:U_PWR"
+        ":sheet:power.SchDoc"
+    )
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="Sheet1_+3V3",
+            aliases=["+3V3"],
+            source_sheets=[physical],
+            terminals=[_FakeTerminal("U1", "14"), _FakeTerminal("C1", "1")],
+        ),
+    ])
+    proj = _minimal_proj(
+        physical_sheet_names=((physical, "Power.SchDoc"),),
+        compiled_netlist=netlist,
+    )
+    pins = _resolve_local_net_pins(
+        netlist, "U1", "Power.SchDoc", "+3V3", proj=proj,
+    )
+    assert pins == ["14"]
+
+
 def test_pcb_sourced_local_net_scoped_per_instance():
     """Blanket/ECO PCB parameters resolve local net names per pcb_index."""
     netlist = _FakeNetlist(nets=[

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -2893,6 +2893,85 @@ def test_stray_pdn_params_without_any_role_warns():
     result = parse_annotations(proj, enabled_layers=[1])
     assert not result.directives
     assert any("no PDN_ROLE or PDN<n>_ROLE" in w for w in result.warnings)
+    assert not result.infos
+
+
+def test_pin_filter_sch_with_pcb_role_emits_no_info():
+    # Expected Blanket/ECO workflow: SchLib carries PDN_PINS_ONLY only;
+    # role+values live on the PCB. Suppress the pin-filter INFO.
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+3V3")),
+        sch_components=(
+            RawSchComponent(
+                designator="U2", schdoc_name="Mcu.SchDoc",
+                parameters={
+                    "PDN_PINS_ONLY": "1,2,TP",
+                    "PDN_EXTRA_PINS": "EP",
+                    "PDN_IGNORE_PINS": "NC",
+                },
+                pin_designators=("1", "2", "TP", "EP", "NC"),
+            ),
+            # Multipart twin — same designator, still no INFO spam.
+            RawSchComponent(
+                designator="U2", schdoc_name="Mcu.SchDoc",
+                parameters={"PDN_PINS_ONLY": "1,2,TP"},
+                pin_designators=("1", "2", "TP"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U2", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U2",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "10mA",
+                    "PDN_P_NET": "+3V3",
+                    "PDN_N_NET": "GND",
+                    "PDN_PINS_ONLY": "1,2,TP",
+                },
+            ),
+        ),
+        pads=(_pad(0, "1", 1, 0), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert not any("pin-filter parameter" in i for i in result.infos)
+    assert not any("U2" in w and "no PDN_ROLE" in w for w in result.warnings)
+    assert any(isinstance(d, SinkSpec) and d.designator == "U2"
+               for d in result.directives)
+
+
+def test_pin_filter_only_without_pcb_role_is_info_once():
+    # Pin-filter on the symbol with no role anywhere → INFO (forgotten ECO),
+    # but only once per designator even with multiple schematic parts.
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+3V3")),
+        sch_components=(
+            RawSchComponent(
+                designator="U2", schdoc_name="Mcu.SchDoc",
+                parameters={"PDN_PINS_ONLY": "1,2"},
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="U2", schdoc_name="Mcu.SchDoc",
+                parameters={"PDN_PINS_ONLY": "1,2"},
+                pin_designators=("1", "2"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U2", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U2",
+            ),
+        ),
+        pads=(_pad(0, "1", 1, 0), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    pin_filter_infos = [
+        i for i in result.infos if "pin-filter parameter" in i and "U2" in i
+    ]
+    assert len(pin_filter_infos) == 1
+    assert not result.directives
+    assert not any("no PDN_ROLE" in w for w in result.warnings)
 
 
 def test_indexed_roles_only_source_channel_contributes_supply_voltage():

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -878,6 +878,81 @@ def test_sheet_name_matches_full_path_not_basename_collision():
         "Power.SchDoc",
         ["SubB/Power.SchDoc"],
     )
+    # Path-qualified annotation vs basename-only netlist provenance.
+    assert _sheet_name_matches(
+        "mod/Child.SchDoc",
+        ["Child.SchDoc"],
+    )
+    assert _sheet_name_matches(
+        "mod/Child.SchDoc",
+        ["child.schdoc"],
+    )
+
+
+def test_resolve_local_net_relative_schdoc_with_basename_source_sheets():
+    """Nested relative schdoc_name must still hit project-netlist pins."""
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="RAIL",
+            aliases=["VIN_LOCAL"],
+            source_sheets=["Child.SchDoc"],  # basename only
+            terminals=[_FakeTerminal("R1", "1")],
+        ),
+    ])
+    proj = _minimal_proj(
+        nets=(RawNet("VIN_GROUP"),),
+        pcb_components=(
+            RawPcbComponent(
+                designator="R1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1005R", source_designator="R1",
+            ),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="R1", schdoc_name="mod/Child.SchDoc",
+                parameters={}, pin_designators=("1", "2"),
+            ),
+        ),
+        pads=(_pad(0, "1", 0),),
+        compiled_netlist=netlist,
+        schdoc_paths={"mod/child.schdoc": r"C:\proj\mod\Child.SchDoc"},
+        sheet_netlists={},
+    )
+    # Must resolve via project netlist (not require child-sheet compile).
+    with patch(
+        "fypa.altium.annotations._compile_sheet_netlist_at_path",
+    ) as compile_mock:
+        spec, err = _resolve_terminal(
+            proj, 0, "VIN_LOCAL", None, [1], "SERIES P",
+            sch_lookup_designator="R1", schdoc_name="mod/Child.SchDoc",
+        )
+    assert not err and spec is not None
+    assert spec.pins[0].net_index == 0
+    compile_mock.assert_not_called()
+
+
+def test_netlist_options_for_project_does_not_cache_load_failure():
+    from fypa.altium.annotations import (
+        _netlist_options_for_project,
+        clear_annotation_caches,
+    )
+
+    clear_annotation_caches()
+    proj = _minimal_proj(prjpcb_path=Path("C:/proj/board.PrjPcb"))
+    sentinel = object()
+    with patch(
+        "altium_monkey.altium_prjpcb.AltiumPrjPcb",
+        side_effect=[RuntimeError("locked"), object()],
+    ):
+        with patch(
+            "altium_monkey.altium_netlist_options.NetlistOptions.from_prjpcb",
+            return_value=sentinel,
+        ) as from_prj:
+            first = _netlist_options_for_project(proj)
+            second = _netlist_options_for_project(proj)
+    assert first is not sentinel  # defaults after failure
+    assert second is sentinel
+    assert from_prj.call_count == 1
 
 
 def test_sheet_name_matches_physical_page_id_via_map():
@@ -1103,6 +1178,358 @@ def test_resolve_local_net_pins_dot_channel_alias_scoped():
         pcb_designator="J3.4",
     )
     assert pins == []
+
+
+def test_resolve_terminal_child_sheet_fallback_when_project_netlist_incomplete():
+    """Nested REPEAT: project netlist may omit R1.3 while R1.1 exists."""
+    full_netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="RAIL_A",
+            aliases=["VIN_LOCAL.1"],
+            source_sheets=["Child.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "1")],
+        ),
+        _FakeNet(
+            name="RAIL_B",
+            aliases=["VOUT.1"],
+            source_sheets=["Child.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "2")],
+        ),
+    ])
+    child_netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="VIN_LOCAL",
+            source_sheets=["Child.SchDoc"],
+            terminals=[_FakeTerminal("R1", "1")],
+        ),
+        _FakeNet(
+            name="VOUT",
+            source_sheets=["Child.SchDoc"],
+            terminals=[_FakeTerminal("R1", "2")],
+        ),
+    ])
+    proj = _minimal_proj(
+        nets=(RawNet("VIN_GROUP.2"), RawNet("VOUT.3")),
+        pcb_components=(
+            RawPcbComponent(
+                designator="R1.3", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1005R", source_designator="R1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 0),
+            _pad(0, "2", 1),
+        ),
+        compiled_netlist=full_netlist,
+        sheet_netlists={"child.schdoc": child_netlist},
+    )
+    p_spec, p_err = _resolve_terminal(
+        proj, 0, "VIN_LOCAL", None, [1], "SERIES P",
+        sch_lookup_designator="R1", schdoc_name="Child.SchDoc",
+    )
+    n_spec, n_err = _resolve_terminal(
+        proj, 0, "VOUT", None, [1], "SERIES N",
+        sch_lookup_designator="R1", schdoc_name="Child.SchDoc",
+    )
+    assert not p_err and not n_err
+    assert p_spec is not None and n_spec is not None
+    assert p_spec.pins[0].net_index == 0
+    assert n_spec.pins[0].net_index == 1
+
+
+def test_expand_net_names_child_sheet_fallback():
+    """expand_net_names must use sheet_netlists when project netlist omits the instance."""
+    full_netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="RAIL_A",
+            aliases=["VIN_LOCAL.1"],
+            source_sheets=["Child.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "1")],
+        ),
+    ])
+    child_netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="VIN_LOCAL",
+            source_sheets=["Child.SchDoc"],
+            terminals=[_FakeTerminal("R1", "1")],
+        ),
+    ])
+    proj = _minimal_proj(
+        nets=(RawNet("VIN_GROUP.2"),),
+        pcb_components=(
+            RawPcbComponent(
+                designator="R1.3", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1005R", source_designator="R1",
+            ),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="R1", schdoc_name="Child.SchDoc",
+                parameters={}, pin_designators=("1", "2"),
+            ),
+        ),
+        pads=(_pad(0, "1", 0),),
+        compiled_netlist=full_netlist,
+        sheet_netlists={"child.schdoc": child_netlist},
+    )
+    names = _instance_resolver(proj).expand_net_names("VIN_LOCAL", 0)
+    assert "VIN_GROUP.2" in names
+    assert "VIN_LOCAL" in names
+
+
+def test_resolve_local_net_pins_child_sheet_direct():
+    child_netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="VIN_LOCAL",
+            terminals=[_FakeTerminal("R1", "1")],
+        ),
+    ])
+    proj = _minimal_proj(sheet_netlists={"child.schdoc": child_netlist})
+    from fypa.altium.annotations import _resolve_local_net_pins_child_sheet
+    pins = _resolve_local_net_pins_child_sheet(
+        proj, "R1", "Child.SchDoc", "VIN_LOCAL",
+        routed_pin_keys={"1"},
+    )
+    assert pins == ["1"]
+    assert _resolve_local_net_pins_child_sheet(
+        proj, "R1", "Child.SchDoc", "VIN_LOCAL",
+        routed_pin_keys={"2"},
+    ) == []
+
+
+def test_base_sch_designator_strips_numeric_channel():
+    from fypa.altium.annotations import _base_sch_designator
+    assert _base_sch_designator("R1.3") == "R1"
+    assert _base_sch_designator("R1") == "R1"
+    assert _base_sch_designator("J3_SL8M7") == "J3_SL8M7"
+    assert _base_sch_designator("U1.A") == "U1.A"
+
+
+def test_child_sheet_resolves_channel_designator_without_source_designator():
+    """PCB designator R1.3 with no source_designator still matches child R1."""
+    full_netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="RAIL_A",
+            aliases=["VIN_LOCAL.1"],
+            source_sheets=["Child.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "1")],
+        ),
+    ])
+    child_netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="VIN_LOCAL",
+            source_sheets=["Child.SchDoc"],
+            terminals=[_FakeTerminal("R1", "1")],
+        ),
+    ])
+    proj = _minimal_proj(
+        nets=(RawNet("VIN_GROUP.2"),),
+        pcb_components=(
+            RawPcbComponent(
+                designator="R1.3", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1005R",
+                source_designator="",  # missing — lookup falls back to R1.3
+            ),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="R1", schdoc_name="Child.SchDoc",
+                parameters={}, pin_designators=("1", "2"),
+            ),
+        ),
+        pads=(_pad(0, "1", 0),),
+        compiled_netlist=full_netlist,
+        sheet_netlists={"child.schdoc": child_netlist},
+    )
+    spec, err = _resolve_terminal(
+        proj, 0, "VIN_LOCAL", None, [1], "SERIES P",
+        sch_lookup_designator="R1.3", schdoc_name="Child.SchDoc",
+    )
+    assert not err and spec is not None
+    assert spec.pins[0].net_index == 0
+    names = _instance_resolver(proj).expand_net_names("VIN_LOCAL", 0)
+    assert "VIN_GROUP.2" in names
+
+
+def test_schdoc_path_key_prefers_relative_path_on_basename_collision():
+    from fypa.altium.annotations import _get_child_sheet_netlist, _schdoc_path_key
+
+    nl_a = _FakeNetlist(nets=[
+        _FakeNet(name="VIN", terminals=[_FakeTerminal("R1", "1")]),
+    ])
+    nl_b = _FakeNetlist(nets=[
+        _FakeNet(name="VOUT", terminals=[_FakeTerminal("R1", "1")]),
+    ])
+    # Collision: same basename, no basename alias — only relative keys.
+    proj = _minimal_proj(
+        schdoc_paths={
+            "mod_a/child.schdoc": r"C:\proj\mod_a\Child.SchDoc",
+            "mod_b/child.schdoc": r"C:\proj\mod_b\Child.SchDoc",
+        },
+        sheet_netlists={
+            "mod_a/child.schdoc": nl_a,
+            "mod_b/child.schdoc": nl_b,
+        },
+    )
+    assert _schdoc_path_key(proj, "mod_a/Child.SchDoc") == "mod_a/child.schdoc"
+    assert _schdoc_path_key(proj, "mod_b/Child.SchDoc") == "mod_b/child.schdoc"
+    assert _get_child_sheet_netlist(proj, "mod_a/Child.SchDoc") is nl_a
+    assert _get_child_sheet_netlist(proj, "mod_b/Child.SchDoc") is nl_b
+
+
+def test_schdoc_path_key_refuses_ambiguous_basename_only():
+    """Basename-only lookup must not guess when two sheets share the name."""
+    from fypa.altium.annotations import _get_child_sheet_netlist, _schdoc_path_key
+
+    nl_a = _FakeNetlist(nets=[
+        _FakeNet(name="VIN", terminals=[_FakeTerminal("R1", "1")]),
+    ])
+    proj = _minimal_proj(
+        schdoc_paths={
+            "mod_a/child.schdoc": r"C:\proj\mod_a\Child.SchDoc",
+            "mod_b/child.schdoc": r"C:\proj\mod_b\Child.SchDoc",
+        },
+        sheet_netlists={
+            "mod_a/child.schdoc": nl_a,
+            "child.schdoc": nl_a,  # must not be used under ambiguity
+        },
+    )
+    assert _schdoc_path_key(proj, "Child.SchDoc") is None
+    assert _get_child_sheet_netlist(proj, "Child.SchDoc") is None
+
+
+def test_get_child_sheet_netlist_lazy_compile_memoizes():
+    from fypa.altium.annotations import _get_child_sheet_netlist
+
+    child_nl = _FakeNetlist(nets=[
+        _FakeNet(name="VIN", terminals=[_FakeTerminal("R1", "1")]),
+    ])
+    proj = _minimal_proj(
+        schdoc_paths={"child.schdoc": r"C:\proj\Child.SchDoc"},
+        sheet_netlists={},
+    )
+    with patch(
+        "fypa.altium.annotations._compile_sheet_netlist_at_path",
+        return_value=child_nl,
+    ) as compile_mock:
+        first = _get_child_sheet_netlist(proj, "Child.SchDoc")
+        second = _get_child_sheet_netlist(proj, "Child.SchDoc")
+    assert first is child_nl
+    assert second is child_nl
+    assert compile_mock.call_count == 1
+    assert proj.sheet_netlists.get("child.schdoc") is child_nl
+
+
+def test_get_child_sheet_netlist_does_not_cache_failed_compile():
+    from fypa.altium.annotations import _get_child_sheet_netlist
+
+    child_nl = _FakeNetlist(nets=[
+        _FakeNet(name="VIN", terminals=[_FakeTerminal("R1", "1")]),
+    ])
+    proj = _minimal_proj(
+        schdoc_paths={"child.schdoc": r"C:\proj\Child.SchDoc"},
+        sheet_netlists={},
+    )
+    with patch(
+        "fypa.altium.annotations._compile_sheet_netlist_at_path",
+        side_effect=[None, child_nl],
+    ) as compile_mock:
+        assert _get_child_sheet_netlist(proj, "Child.SchDoc") is None
+        assert "child.schdoc" not in proj.sheet_netlists
+        assert _get_child_sheet_netlist(proj, "Child.SchDoc") is child_nl
+    assert compile_mock.call_count == 2
+
+
+def test_compile_sheet_netlist_uses_project_netlist_options():
+    from fypa.altium.annotations import (
+        _compile_sheet_netlist_at_path,
+        clear_annotation_caches,
+    )
+
+    clear_annotation_caches()
+    proj = _minimal_proj(prjpcb_path=Path("C:/proj/board.PrjPcb"))
+    sentinel = object()
+    with (
+        patch(
+            "fypa.altium.annotations._netlist_options_for_project",
+            return_value=sentinel,
+        ) as opts_mock,
+        patch("altium_monkey.altium_schdoc.AltiumSchDoc") as sch_cls,
+        patch(
+            "altium_monkey.altium_netlist_compilation.compile_netlist",
+            return_value="NL",
+        ) as compile_mock,
+    ):
+        sch_cls.return_value = object()
+        assert _compile_sheet_netlist_at_path(r"C:\proj\Child.SchDoc", proj) == "NL"
+    opts_mock.assert_called_once_with(proj)
+    assert compile_mock.call_args.args[2] is sentinel
+
+
+def test_collect_schdoc_paths_unique_basename_alias_only():
+    from fypa.altium.extract import _collect_schdoc_paths
+
+    @dataclass
+    class _Sch:
+        filepath: str
+
+    @dataclass
+    class _Design:
+        schdocs: list
+
+    root = Path("C:/proj")
+    design = _Design(schdocs=[
+        _Sch(filepath=str(root / "Power.SchDoc")),
+        _Sch(filepath=str(root / "mod_a" / "Child.SchDoc")),
+        _Sch(filepath=str(root / "mod_b" / "Child.SchDoc")),
+    ])
+    paths = _collect_schdoc_paths(design, root / "board.PrjPcb")
+    assert paths["power.schdoc"].lower().endswith("power.schdoc")
+    assert "child.schdoc" not in paths  # basename collision — no alias
+    assert "mod_a/child.schdoc" in paths
+    assert "mod_b/child.schdoc" in paths
+
+
+def test_collect_schdoc_paths_outside_root_uses_absolute_key():
+    from fypa.altium.extract import (
+        _collect_schdoc_paths,
+        _schdoc_display_path,
+        _schdoc_storage_key,
+    )
+
+    @dataclass
+    class _Sch:
+        filepath: str
+
+    @dataclass
+    class _Design:
+        schdocs: list
+
+    root = Path("C:/proj")
+    outside_a = Path("D:/libs/Shared.SchDoc")
+    outside_b = Path("E:/other/Shared.SchDoc")
+    design = _Design(schdocs=[
+        _Sch(filepath=str(outside_a)),
+        _Sch(filepath=str(outside_b)),
+    ])
+    paths = _collect_schdoc_paths(design, root / "board.PrjPcb")
+    key_a = _schdoc_storage_key(outside_a, root)
+    key_b = _schdoc_storage_key(outside_b, root)
+    assert key_a != key_b
+    assert key_a == _schdoc_display_path(outside_a, root).lower()
+    assert "shared.schdoc" not in paths  # colliding basenames — no alias
+    assert paths[key_a].lower().endswith("shared.schdoc")
+    assert paths[key_b].lower().endswith("shared.schdoc")
+
+
+def test_schdoc_display_path_preserves_casing():
+    from fypa.altium.extract import _schdoc_display_path, _schdoc_storage_key
+
+    root = Path("C:/proj")
+    abs_path = root / "mod" / "Child.SchDoc"
+    display = _schdoc_display_path(abs_path, root)
+    assert display == "mod/Child.SchDoc"
+    assert _schdoc_storage_key(abs_path, root) == "mod/child.schdoc"
 
 
 def test_schdoc_inference_pin_centric_without_net_name_match():

--- a/tests/test_extract_pin_ignore.py
+++ b/tests/test_extract_pin_ignore.py
@@ -1,0 +1,95 @@
+"""Sheet-level PDN_IGNORE extraction mirrors altium_monkey SchDoc layout.
+
+Real ``.SchDoc`` binaries are not checked in (anonymize / size). These fixtures
+use the same type names and ownership links altium_monkey sets:
+``AltiumSchPin._record_index`` ↔ ``AltiumSchParameter.owner_index``, plus the
+optional ``pin.pin_parameters`` list after library attach.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fypa.altium.extract import (
+    _extract_sch_component,
+    _sheet_ignored_pins_by_component,
+)
+
+
+class AltiumSchPin:
+    def __init__(self, designator, record_index, pin_parameters=None):
+        self.designator = designator
+        self._record_index = record_index
+        self.pin_parameters = list(pin_parameters or [])
+        self.owner_index = 0
+
+
+class AltiumSchParameter:
+    def __init__(self, name, text, owner_index):
+        self.name = name
+        self.text = text
+        self.owner_index = owner_index
+
+
+class AltiumSchDesignator:
+    def __init__(self, text):
+        self.text = text
+
+
+def _sch_comp(designator: str, pins: list[AltiumSchPin]):
+    return SimpleNamespace(
+        children=[AltiumSchDesignator(designator), *pins],
+        pins=pins,
+        parameters={},
+    )
+
+
+def test_sheet_ignore_via_all_objects_owner_index_multi_component():
+    """Two parts on one sheet; only the pin whose record owns PDN_IGNORE."""
+    u1_en = AltiumSchPin("EN", record_index=10)
+    u1_pwr = AltiumSchPin("1", record_index=11)
+    u2_en = AltiumSchPin("EN", record_index=20)
+    comps = [
+        _sch_comp("U1", [u1_en, u1_pwr]),
+        _sch_comp("U2", [u2_en]),
+    ]
+    all_objects = [
+        comps[0],
+        u1_en,
+        u1_pwr,
+        AltiumSchParameter("PDN_IGNORE", "1", owner_index=10),
+        comps[1],
+        u2_en,
+        # Component-owned param must not mark U2's EN (owner is component idx 5
+        # in a real file; here use an index that is not a pin record).
+        AltiumSchParameter("PDN_IGNORE", "1", owner_index=99),
+    ]
+    ignored = _sheet_ignored_pins_by_component(comps, all_objects)
+    assert ignored[0] == frozenset({"EN"})
+    assert ignored[1] == frozenset()
+
+
+def test_sheet_ignore_via_pin_parameters_and_owner_index_union():
+    pin = AltiumSchPin(
+        "EP",
+        record_index=7,
+        pin_parameters=[AltiumSchParameter("PDN", "IGNORE", owner_index=7)],
+    )
+    comps = [_sch_comp("U3", [pin])]
+    all_objects = [
+        AltiumSchParameter("PDN_IGNORE", "TRUE", owner_index=7),
+    ]
+    ignored = _sheet_ignored_pins_by_component(comps, all_objects)
+    assert ignored[0] == frozenset({"EP"})
+
+
+def test_extract_sch_component_carries_batch_ignored_pins():
+    pin = AltiumSchPin("EN", record_index=3)
+    comp = _sch_comp("U1", [pin])
+    ignored = _sheet_ignored_pins_by_component(
+        [comp],
+        [AltiumSchParameter("PDN_IGNORE", "YES", owner_index=3)],
+    )[0]
+    rec = _extract_sch_component(comp, "Pwr.SchDoc", ignored)
+    assert rec is not None
+    assert rec.ignored_pins == frozenset({"EN"})
+    assert "EN" in rec.pin_designators

--- a/tests/test_pin_coupling_area.py
+++ b/tests/test_pin_coupling_area.py
@@ -1,0 +1,94 @@
+"""Area-weighted multi-pin star coupling resistances."""
+from __future__ import annotations
+
+import pytest
+
+from fypa.altium.loader import (
+    AREA_WEIGHTED_PIN_COUPLING,
+    SolveSettings,
+    _pin_coupling_resistances,
+)
+
+
+def test_equal_areas_keep_base_r():
+    rs = _pin_coupling_resistances([1.0, 1.0, 1.0], 0.1, area_weighted=True)
+    assert rs == [0.1, 0.1, 0.1]
+
+
+def test_double_area_halves_r():
+    rs = _pin_coupling_resistances([1.0, 2.0], 0.1, area_weighted=True)
+    # A_mean = 1.5 → R = 0.1 * 1.5/1 = 0.15, 0.1 * 1.5/2 = 0.075
+    assert rs[0] == pytest.approx(0.15)
+    assert rs[1] == pytest.approx(0.075)
+    # Conductance ratio matches area ratio
+    assert (1.0 / rs[1]) / (1.0 / rs[0]) == pytest.approx(2.0)
+
+
+def test_area_weighted_off_equal_r():
+    rs = _pin_coupling_resistances([1.0, 10.0], 0.2, area_weighted=False)
+    assert rs == [0.2, 0.2]
+
+
+def test_degenerate_areas_fall_back_to_equal_r():
+    rs = _pin_coupling_resistances([0.0, 0.0], 0.1, area_weighted=True)
+    assert rs == [0.1, 0.1]
+
+
+def test_mixed_zero_uses_mean_for_missing():
+    rs = _pin_coupling_resistances([2.0, 0.0], 0.1, area_weighted=True)
+    # only valid area is 2.0 → mean = 2.0; missing uses mean → both R = 0.1
+    assert rs == [0.1, 0.1]
+
+
+def test_solve_settings_round_trip_area_weighted_flag():
+    assert AREA_WEIGHTED_PIN_COUPLING is False
+    s = SolveSettings(area_weighted_pin_coupling=True)
+    s.apply_to_modules()
+    try:
+        from fypa.altium import loader as L
+        assert L.AREA_WEIGHTED_PIN_COUPLING is True
+        restored = SolveSettings.from_metadata({
+            "physics_constants": {"area_weighted_pin_coupling": True},
+        })
+        assert restored.area_weighted_pin_coupling is True
+    finally:
+        SolveSettings().apply_to_modules()
+
+
+def test_terminal_connections_emits_unequal_resistors_when_weighted():
+    """``_terminal_connections`` must wire area-scaled star resistors."""
+    from types import SimpleNamespace
+
+    import shapely.geometry
+    from pdnsolver import problem as pp
+
+    from fypa.altium.annotations import TerminalPin, TerminalSpec
+    from fypa.altium.extract import Pt2D
+    from fypa.altium.loader import _terminal_connections
+
+    poly_small = shapely.geometry.box(0, 0, 1, 1)   # area 1
+    poly_large = shapely.geometry.box(0, 0, 2, 2)   # area 4
+    layer = SimpleNamespace(shape=shapely.geometry.box(-10, -10, 10, 10))
+    term = TerminalSpec(pins=(
+        TerminalPin(
+            pad_designator="1", layer_id=1, net_index=0,
+            point=Pt2D(0.5, 0.5), pad_polygon=poly_small,
+        ),
+        TerminalPin(
+            pad_designator="2", layer_id=1, net_index=0,
+            point=Pt2D(1.0, 1.0), pad_polygon=poly_large,
+        ),
+    ))
+    layers = {(1, 0): layer}
+    SolveSettings(area_weighted_pin_coupling=True).apply_to_modules()
+    try:
+        _conns, aux = _terminal_connections(
+            term, pp.NodeID(), layers, coupling_resistance_ohm=0.1,
+        )
+        assert len(aux) == 2
+        rs = sorted(float(r.resistance) for r in aux)
+        # A_mean = 2.5 → R = 0.1*2.5/1 = 0.25, 0.1*2.5/4 = 0.0625
+        assert rs[0] == pytest.approx(0.0625)
+        assert rs[1] == pytest.approx(0.25)
+    finally:
+        SolveSettings().apply_to_modules()

--- a/uv.lock
+++ b/uv.lock
@@ -12,62 +12,6 @@ wheels = [
 ]
 
 [[package]]
-name = "aiohappyeyeballs"
-version = "2.6.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/33/c6/61a2d7b7572279226bb2e7f61d7a19ca7c90da0329c93fa0d560cbf288d8/aiohappyeyeballs-2.6.2.tar.gz", hash = "sha256:e202810ee718bd01fc6ef49e8ea53d023d5cb6b581076d7925aa499fa55dbe64", size = 22591, upload-time = "2026-05-20T15:12:24.631Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/fc/a7bf5b6e4e617b45f90f2d9d2a68519c249c81dd4fc2658c7a2a61c4f4b7/aiohappyeyeballs-2.6.2-py3-none-any.whl", hash = "sha256:4708045e2d7a6c6bdf8aafa8ed39649eaf926a4543b54560659129e3365953c4", size = 15062, upload-time = "2026-05-20T15:12:23.328Z" },
-]
-
-[[package]]
-name = "aiohttp"
-version = "3.13.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohappyeyeballs" },
-    { name = "aiosignal" },
-    { name = "attrs" },
-    { name = "frozenlist" },
-    { name = "multidict" },
-    { name = "propcache" },
-    { name = "yarl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/6f/353954c29e7dcce7cf00280a02c75f30e133c00793c7a2ed3776d7b2f426/aiohttp-3.13.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:023ecba036ddd840b0b19bf195bfae970083fd7024ce1ac22e9bba90464620e9", size = 748876, upload-time = "2026-03-31T21:57:36.319Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/1b/428a7c64687b3b2e9cd293186695affc0e1e54a445d0361743b231f11066/aiohttp-3.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15c933ad7920b7d9a20de151efcd05a6e38302cbf0e10c9b2acb9a42210a2416", size = 499557, upload-time = "2026-03-31T21:57:38.236Z" },
-    { url = "https://files.pythonhosted.org/packages/29/47/7be41556bfbb6917069d6a6634bb7dd5e163ba445b783a90d40f5ac7e3a7/aiohttp-3.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab2899f9fa2f9f741896ebb6fa07c4c883bfa5c7f2ddd8cf2aafa86fa981b2d2", size = 500258, upload-time = "2026-03-31T21:57:39.923Z" },
-    { url = "https://files.pythonhosted.org/packages/67/84/c9ecc5828cb0b3695856c07c0a6817a99d51e2473400f705275a2b3d9239/aiohttp-3.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a60eaa2d440cd4707696b52e40ed3e2b0f73f65be07fd0ef23b6b539c9c0b0b4", size = 1749199, upload-time = "2026-03-31T21:57:41.938Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/d3/3c6d610e66b495657622edb6ae7c7fd31b2e9086b4ec50b47897ad6042a9/aiohttp-3.13.5-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:55b3bdd3292283295774ab585160c4004f4f2f203946997f49aac032c84649e9", size = 1721013, upload-time = "2026-03-31T21:57:43.904Z" },
-    { url = "https://files.pythonhosted.org/packages/49/a0/24409c12217456df0bae7babe3b014e460b0b38a8e60753d6cb339f6556d/aiohttp-3.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2b2355dc094e5f7d45a7bb262fe7207aa0460b37a0d87027dcf21b5d890e7d5", size = 1781501, upload-time = "2026-03-31T21:57:46.285Z" },
-    { url = "https://files.pythonhosted.org/packages/98/9d/b65ec649adc5bccc008b0957a9a9c691070aeac4e41cea18559fef49958b/aiohttp-3.13.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b38765950832f7d728297689ad78f5f2cf79ff82487131c4d26fe6ceecdc5f8e", size = 1878981, upload-time = "2026-03-31T21:57:48.734Z" },
-    { url = "https://files.pythonhosted.org/packages/57/d8/8d44036d7eb7b6a8ec4c5494ea0c8c8b94fbc0ed3991c1a7adf230df03bf/aiohttp-3.13.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b18f31b80d5a33661e08c89e202edabf1986e9b49c42b4504371daeaa11b47c1", size = 1767934, upload-time = "2026-03-31T21:57:51.171Z" },
-    { url = "https://files.pythonhosted.org/packages/31/04/d3f8211f273356f158e3464e9e45484d3fb8c4ce5eb2f6fe9405c3273983/aiohttp-3.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:33add2463dde55c4f2d9635c6ab33ce154e5ecf322bd26d09af95c5f81cfa286", size = 1566671, upload-time = "2026-03-31T21:57:53.326Z" },
-    { url = "https://files.pythonhosted.org/packages/41/db/073e4ebe00b78e2dfcacff734291651729a62953b48933d765dc513bf798/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:327cc432fdf1356fb4fbc6fe833ad4e9f6aacb71a8acaa5f1855e4b25910e4a9", size = 1705219, upload-time = "2026-03-31T21:57:55.385Z" },
-    { url = "https://files.pythonhosted.org/packages/48/45/7dfba71a2f9fd97b15c95c06819de7eb38113d2cdb6319669195a7d64270/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:7c35b0bf0b48a70b4cb4fc5d7bed9b932532728e124874355de1a0af8ec4bc88", size = 1743049, upload-time = "2026-03-31T21:57:57.341Z" },
-    { url = "https://files.pythonhosted.org/packages/18/71/901db0061e0f717d226386a7f471bb59b19566f2cae5f0d93874b017271f/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:df23d57718f24badef8656c49743e11a89fd6f5358fa8a7b96e728fda2abf7d3", size = 1749557, upload-time = "2026-03-31T21:57:59.626Z" },
-    { url = "https://files.pythonhosted.org/packages/08/d5/41eebd16066e59cd43728fe74bce953d7402f2b4ddfdfef2c0e9f17ca274/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:02e048037a6501a5ec1f6fc9736135aec6eb8a004ce48838cb951c515f32c80b", size = 1558931, upload-time = "2026-03-31T21:58:01.972Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e6/4a799798bf05740e66c3a1161079bda7a3dd8e22ca392481d7a7f9af82a6/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:31cebae8b26f8a615d2b546fee45d5ffb76852ae6450e2a03f42c9102260d6fe", size = 1774125, upload-time = "2026-03-31T21:58:04.007Z" },
-    { url = "https://files.pythonhosted.org/packages/84/63/7749337c90f92bc2cb18f9560d67aa6258c7060d1397d21529b8004fcf6f/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:888e78eb5ca55a615d285c3c09a7a91b42e9dd6fc699b166ebd5dee87c9ccf14", size = 1732427, upload-time = "2026-03-31T21:58:06.337Z" },
-    { url = "https://files.pythonhosted.org/packages/98/de/cf2f44ff98d307e72fb97d5f5bbae3bfcb442f0ea9790c0bf5c5c2331404/aiohttp-3.13.5-cp312-cp312-win32.whl", hash = "sha256:8bd3ec6376e68a41f9f95f5ed170e2fcf22d4eb27a1f8cb361d0508f6e0557f3", size = 433534, upload-time = "2026-03-31T21:58:08.712Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/ca/eadf6f9c8fa5e31d40993e3db153fb5ed0b11008ad5d9de98a95045bed84/aiohttp-3.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:110e448e02c729bcebb18c60b9214a87ba33bac4a9fa5e9a5f139938b56c6cb1", size = 460446, upload-time = "2026-03-31T21:58:10.945Z" },
-]
-
-[[package]]
-name = "aiosignal"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "frozenlist" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
-]
-
-[[package]]
 name = "altgraph"
 version = "0.17.5"
 source = { registry = "https://pypi.org/simple" }
@@ -78,23 +22,15 @@ wheels = [
 
 [[package]]
 name = "altium-monkey"
-version = "2026.5.20"
-source = { git = "https://github.com/wavenumber-eng/altium_monkey?tag=v2026.5.20#b295cfafc7c7feba0409716cb45721a1da71a586" }
+version = "2026.7.29"
+source = { git = "https://github.com/wavenumber-eng/altium_monkey?tag=v2026.7.29#dbed1f835e235bbbcd67ab657234fbca4f0d8c1a" }
 dependencies = [
-    { name = "cadquery" },
     { name = "freetype-py" },
-    { name = "numpy" },
+    { name = "lxml" },
+    { name = "lz4" },
     { name = "pillow" },
     { name = "uharfbuzz" },
-]
-
-[[package]]
-name = "attrs"
-version = "26.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+    { name = "wn-geometer" },
 ]
 
 [[package]]
@@ -104,60 +40,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
-]
-
-[[package]]
-name = "cadquery"
-version = "2.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cadquery-ocp" },
-    { name = "casadi" },
-    { name = "ezdxf" },
-    { name = "multimethod" },
-    { name = "nlopt" },
-    { name = "path" },
-    { name = "pyparsing" },
-    { name = "runtype" },
-    { name = "trame" },
-    { name = "trame-components" },
-    { name = "trame-vtk" },
-    { name = "trame-vuetify" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/03/c7/23e200821c307b7765661f19494edea93aa3ae9d28fee0db72ab20448855/cadquery-2.7.0.tar.gz", hash = "sha256:224e7d861c018bedd9e77b9727bc2a86b086f630596124d13ccc8a92b2151ee6", size = 270261, upload-time = "2026-02-13T16:50:47.701Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/46/2544f1d16a912770ecfed25602a273ab0ad4648838decf974781a8f83b78/cadquery-2.7.0-py3-none-any.whl", hash = "sha256:13bdffe3a1c9a7b29d86d43313021173b1620f45223929d2631cf8d4c5dbe2c0", size = 182553, upload-time = "2026-02-13T16:50:46.085Z" },
-]
-
-[[package]]
-name = "cadquery-ocp"
-version = "7.8.1.1.post1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "vtk" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/98/7b81196dd990bfbbdeff7858db7d319dede6fef2fb6c153ede9eb409a9e9/cadquery_ocp-7.8.1.1.post1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0022e854a3840efd5c7fc14fe933772613794777d5eb056a4754d44a86baf02a", size = 68590290, upload-time = "2025-01-29T14:34:16.804Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/b3/aea4e4d84916b6a26bc3635a0aeaa3737b24671ac90c117e5779554eebbb/cadquery_ocp-7.8.1.1.post1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:53dc24aed402b2ae52634a29b3b17e9c01e857b8ac34bb101d4e8fa76d3cd7f7", size = 69523485, upload-time = "2025-01-29T14:34:27.338Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/3f/4b28aedbbb7c6cd5f1aa4e1d6e9a0f88d138941096a3d70f1878a406075f/cadquery_ocp-7.8.1.1.post1-cp312-cp312-manylinux_2_31_x86_64.whl", hash = "sha256:4882074e86722208153579baaee246be4fb10bda22dc20d101c4151f364207b9", size = 70313551, upload-time = "2025-01-29T14:34:36.484Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/2f/d8473c8db5f0820449819bf5ce606292ead9e2072712cbdcc5657995f6cb/cadquery_ocp-7.8.1.1.post1-cp312-cp312-win_amd64.whl", hash = "sha256:06982855db94fa0056b922276f0ca94154e5d1eb16f6cba854d704885844924a", size = 51755169, upload-time = "2025-01-29T14:34:45.096Z" },
-]
-
-[[package]]
-name = "casadi"
-version = "3.7.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/92/62/1e98662024915ecb09c6894c26a3f497f4afa66570af3f53db4651fc45f1/casadi-3.7.2.tar.gz", hash = "sha256:b4d7bd8acdc4180306903ae1c9eddaf41be2a3ae2fa7154c57174ae64acdc60d", size = 6053600, upload-time = "2025-09-10T10:05:49.521Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/c8/689d085447b1966f42bdb8aa4fbebef49a09697dbee32ab02a865c17ac1b/casadi-3.7.2-cp312-none-macosx_10_13_x86_64.macosx_10_13_intel.whl", hash = "sha256:309ea41a69c9230390d349b0dd899c6a19504d1904c0756bef463e47fb5c8f9a", size = 47116756, upload-time = "2025-09-10T07:53:00.931Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/c0/3c4704394a6fd4dfb2123a4fd71ba64a001f340670a3eba45be7a19ac736/casadi-3.7.2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:6033381234db810b2247d16c6352e679a009ec4365d04008fc768866e011ed58", size = 42293718, upload-time = "2025-09-10T08:07:16.415Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/24/4cf05469ddf8544da5e92f359f96d716a97e7482999f085a632bc4ef344a/casadi-3.7.2-cp312-none-manylinux2014_aarch64.whl", hash = "sha256:732f2804d0766454bb75596339e4f2da6662ffb669621da0f630ed4af9e83d6a", size = 47276175, upload-time = "2025-09-10T08:08:09.29Z" },
-    { url = "https://files.pythonhosted.org/packages/82/08/b5f57fea03128efd5c860673b6ac44776352e6c1af862b8177f4c503fffe/casadi-3.7.2-cp312-none-manylinux2014_i686.whl", hash = "sha256:cf17298ff0c162735bdf9bf72b765c636ae732130604017a3b52e26e35402857", size = 72430454, upload-time = "2025-09-10T08:09:10.781Z" },
-    { url = "https://files.pythonhosted.org/packages/24/ab/d7233c915b12c005655437c6c4cf0ae46cbbb2b20d743cb5e4881ad3104a/casadi-3.7.2-cp312-none-manylinux2014_x86_64.whl", hash = "sha256:cde616930fa1440ad66f1850670399423edd37354eed9b12e74b3817b98d1187", size = 75568903, upload-time = "2025-09-10T08:10:07.108Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/b9/5b984124f539656efdf079f3d8f09d73667808ec8d0546e6bce6dc60ade6/casadi-3.7.2-cp312-none-win_amd64.whl", hash = "sha256:81d677d2b020c1307c1eb25eae15686e5de199bb066828c3eaabdfaaaf457ffd", size = 50991347, upload-time = "2025-09-10T08:10:46.629Z" },
 ]
 
 [[package]]
@@ -213,29 +95,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ezdxf"
-version = "1.4.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "fonttools" },
-    { name = "numpy" },
-    { name = "pyparsing" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/d7/1b7be8db364f1c4838dfc1a40ca96577aba405deabf896a4eb3aaeb15a62/ezdxf-1.4.4.tar.gz", hash = "sha256:da5a5e0e6bdbb6656f9c017b47edc7eafceb419d61a2b5de64ffb344c168e593", size = 1866886, upload-time = "2026-05-14T09:19:19.511Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/3d/98648d221ffa047b5ba898c8e152010861dc71a66b531dcf15053075010e/ezdxf-1.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d723d35d08223318c17080a32a05192a1449e544dee867c9d9c6f25998fac303", size = 3563916, upload-time = "2026-05-14T09:25:32.879Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/f1/84bbaa571412f840c22deeae185e54d4a67aa52f03e1728fd8425748c548/ezdxf-1.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6b0c73b46085521bdbd4a3e7d88998da7bec5713ba89bbb502fdeffe6b42fc7e", size = 3016857, upload-time = "2026-05-14T09:25:34.607Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/ff/f2eb77d22d26aa98abbe0961470871d8b85ef4e73e5527f544d25f958d6e/ezdxf-1.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ac3e83a70c1f866dd5114192a6fab6e75cc83b75e907bc08c5d94b98cce14cc0", size = 3003336, upload-time = "2026-05-14T09:25:35.947Z" },
-    { url = "https://files.pythonhosted.org/packages/65/7d/2a6ddd6beef5d9a8593078619f3920a0cd76b1db4c6a974ac37045543219/ezdxf-1.4.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8ebe09717ab6636bf48780eabdab51e3ab2135f7963bb52452444b6d95e03d12", size = 5788485, upload-time = "2026-05-14T09:27:32.176Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/29/2094fd7719146ca7bb236be9751b5929d431f643cbab669aed89cf121883/ezdxf-1.4.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:44af248af0860fe8b1a39ca40e1cd2fa8ac37b22142b14b20c6a0caf1b50f932", size = 5816781, upload-time = "2026-05-14T09:27:13.96Z" },
-    { url = "https://files.pythonhosted.org/packages/19/8d/669b8047cca162204c53b874183d73b5f6c4b1d5d48fa1e515a32d56f5ac/ezdxf-1.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:02a097794625e9fc948e637dfe07057e98167b4fe215357a59645759fef6db3f", size = 5754006, upload-time = "2026-05-14T09:27:33.858Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/44/b753997173327250e43ae50f11f0c69016b1e78482e0bd3857c3495236e7/ezdxf-1.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f093bd2228f5782d483aed3bd89cdb74b672b5f90c677c4125cd236ee5649151", size = 5861860, upload-time = "2026-05-14T09:27:15.758Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/99/2e81cb168e0f09adfb05fb40e5f890ff87ac2c00e98079cf09837dd76330/ezdxf-1.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:3e518d9ed4dcbe525d57f14c25c5e592f82660a690fdec39b03b092e6cdc4771", size = 2963238, upload-time = "2026-05-14T09:23:47.924Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/09/5ecb6f82d35a2f4a4334d0a608fcf764827fa69dccdf5987ce309c16b6c1/ezdxf-1.4.4-py3-none-any.whl", hash = "sha256:666edda631ba717270293b734f5d58dd97a1d1aba4787187f09d0cc584645865", size = 1331217, upload-time = "2026-05-14T09:19:26.601Z" },
-]
-
-[[package]]
 name = "flask"
 version = "3.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -284,31 +143,6 @@ wheels = [
 ]
 
 [[package]]
-name = "frozenlist"
-version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/29/948b9aa87e75820a38650af445d2ef2b6b8a6fab1a23b6bb9e4ef0be2d59/frozenlist-1.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:78f7b9e5d6f2fdb88cdde9440dc147259b62b9d3b019924def9f6478be254ac1", size = 87782, upload-time = "2025-10-06T05:36:06.649Z" },
-    { url = "https://files.pythonhosted.org/packages/64/80/4f6e318ee2a7c0750ed724fa33a4bdf1eacdc5a39a7a24e818a773cd91af/frozenlist-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:229bf37d2e4acdaf808fd3f06e854a4a7a3661e871b10dc1f8f1896a3b05f18b", size = 50594, upload-time = "2025-10-06T05:36:07.69Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/94/5c8a2b50a496b11dd519f4a24cb5496cf125681dd99e94c604ccdea9419a/frozenlist-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f833670942247a14eafbb675458b4e61c82e002a148f49e68257b79296e865c4", size = 50448, upload-time = "2025-10-06T05:36:08.78Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:494a5952b1c597ba44e0e78113a7266e656b9794eec897b19ead706bd7074383", size = 242411, upload-time = "2025-10-06T05:36:09.801Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/83/f61505a05109ef3293dfb1ff594d13d64a2324ac3482be2cedc2be818256/frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f423a119f4777a4a056b66ce11527366a8bb92f54e541ade21f2374433f6d4", size = 243014, upload-time = "2025-10-06T05:36:11.394Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/cb/cb6c7b0f7d4023ddda30cf56b8b17494eb3a79e3fda666bf735f63118b35/frozenlist-1.8.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3462dd9475af2025c31cc61be6652dfa25cbfb56cbbf52f4ccfe029f38decaf8", size = 234909, upload-time = "2025-10-06T05:36:12.598Z" },
-    { url = "https://files.pythonhosted.org/packages/31/c5/cd7a1f3b8b34af009fb17d4123c5a778b44ae2804e3ad6b86204255f9ec5/frozenlist-1.8.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4c800524c9cd9bac5166cd6f55285957fcfc907db323e193f2afcd4d9abd69b", size = 250049, upload-time = "2025-10-06T05:36:14.065Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/01/2f95d3b416c584a1e7f0e1d6d31998c4a795f7544069ee2e0962a4b60740/frozenlist-1.8.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d6a5df73acd3399d893dafc71663ad22534b5aa4f94e8a2fabfe856c3c1b6a52", size = 256485, upload-time = "2025-10-06T05:36:15.39Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/03/024bf7720b3abaebcff6d0793d73c154237b85bdf67b7ed55e5e9596dc9a/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:405e8fe955c2280ce66428b3ca55e12b3c4e9c336fb2103a4937e891c69a4a29", size = 237619, upload-time = "2025-10-06T05:36:16.558Z" },
-    { url = "https://files.pythonhosted.org/packages/69/fa/f8abdfe7d76b731f5d8bd217827cf6764d4f1d9763407e42717b4bed50a0/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:908bd3f6439f2fef9e85031b59fd4f1297af54415fb60e4254a95f75b3cab3f3", size = 250320, upload-time = "2025-10-06T05:36:17.821Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/3c/b051329f718b463b22613e269ad72138cc256c540f78a6de89452803a47d/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:294e487f9ec720bd8ffcebc99d575f7eff3568a08a253d1ee1a0378754b74143", size = 246820, upload-time = "2025-10-06T05:36:19.046Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/ae/58282e8f98e444b3f4dd42448ff36fa38bef29e40d40f330b22e7108f565/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:74c51543498289c0c43656701be6b077f4b265868fa7f8a8859c197006efb608", size = 250518, upload-time = "2025-10-06T05:36:20.763Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/96/007e5944694d66123183845a106547a15944fbbb7154788cbf7272789536/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:776f352e8329135506a1d6bf16ac3f87bc25b28e765949282dcc627af36123aa", size = 239096, upload-time = "2025-10-06T05:36:22.129Z" },
-    { url = "https://files.pythonhosted.org/packages/66/bb/852b9d6db2fa40be96f29c0d1205c306288f0684df8fd26ca1951d461a56/frozenlist-1.8.0-cp312-cp312-win32.whl", hash = "sha256:433403ae80709741ce34038da08511d4a77062aa924baf411ef73d1146e74faf", size = 39985, upload-time = "2025-10-06T05:36:23.661Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/af/38e51a553dd66eb064cdf193841f16f077585d4d28394c2fa6235cb41765/frozenlist-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:34187385b08f866104f0c0617404c8eb08165ab1272e884abc89c112e9c00746", size = 44591, upload-time = "2025-10-06T05:36:24.958Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/06/1dc65480ab147339fecc70797e9c2f69d9cea9cf38934ce08df070fdb9cb/frozenlist-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:fe3c58d2f5db5fbd18c2987cba06d51b0529f52bc3a6cdc33d3f4eab725104bd", size = 40102, upload-time = "2025-10-06T05:36:26.333Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
-]
-
-[[package]]
 name = "fypa"
 version = "0.0.0"
 source = { virtual = "." }
@@ -344,13 +178,13 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "altium-monkey", git = "https://github.com/wavenumber-eng/altium_monkey?tag=v2026.5.20" },
+    { name = "altium-monkey", git = "https://github.com/wavenumber-eng/altium_monkey?tag=v2026.7.29" },
     { name = "gerbonara", specifier = "==1.5.0" },
-    { name = "lxml", specifier = "==5.3.0" },
+    { name = "lxml", specifier = "==6.0.2" },
     { name = "matplotlib", specifier = "==3.10.9" },
     { name = "numpy", specifier = "==2.2.3" },
-    { name = "pynavlib", marker = "(sys_platform == 'darwin' and extra == 'spacemouse') or (sys_platform == 'win32' and extra == 'spacemouse')", specifier = "==0.9.4" },
     { name = "pyclipr", specifier = "==0.1.8" },
+    { name = "pynavlib", marker = "(sys_platform == 'darwin' and extra == 'spacemouse') or (sys_platform == 'win32' and extra == 'spacemouse')", specifier = "==0.9.4" },
     { name = "pyopengl", specifier = "==3.1.10" },
     { name = "pyopengl-accelerate", specifier = "==3.1.10" },
     { name = "pypardiso", specifier = "==0.4.7" },
@@ -438,15 +272,6 @@ wheels = [
 ]
 
 [[package]]
-name = "idna"
-version = "3.16"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -529,27 +354,44 @@ wheels = [
 
 [[package]]
 name = "lxml"
-version = "5.3.0"
+version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/6b/20c3a4b24751377aaa6307eb230b66701024012c29dd374999cc92983269/lxml-5.3.0.tar.gz", hash = "sha256:4e109ca30d1edec1ac60cdbe341905dc3b8f55b16855e03a54aaf59e51ec8c6f", size = 3679318, upload-time = "2024-08-10T18:17:29.668Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/88/262177de60548e5a2bfc46ad28232c9e9cbde697bd94132aeb80364675cb/lxml-6.0.2.tar.gz", hash = "sha256:cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62", size = 4073426, upload-time = "2025-09-22T04:04:59.287Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/6d/d1f1c5e40c64bf62afd7a3f9b34ce18a586a1cccbf71e783cd0a6d8e8971/lxml-5.3.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:e99f5507401436fdcc85036a2e7dc2e28d962550afe1cbfc07c40e454256a859", size = 8171753, upload-time = "2024-08-10T18:11:07.859Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/83/26b1864921869784355459f374896dcf8b44d4af3b15d7697e9156cb2de9/lxml-5.3.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:384aacddf2e5813a36495233b64cb96b1949da72bef933918ba5c84e06af8f0e", size = 4441955, upload-time = "2024-08-10T18:11:12.251Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/d2/e9bff9fb359226c25cda3538f664f54f2804f4b37b0d7c944639e1a51f69/lxml-5.3.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:874a216bf6afaf97c263b56371434e47e2c652d215788396f60477540298218f", size = 5050778, upload-time = "2024-08-10T18:11:16.233Z" },
-    { url = "https://files.pythonhosted.org/packages/88/69/6972bfafa8cd3ddc8562b126dd607011e218e17be313a8b1b9cc5a0ee876/lxml-5.3.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:65ab5685d56914b9a2a34d67dd5488b83213d680b0c5d10b47f81da5a16b0b0e", size = 4748628, upload-time = "2024-08-10T18:11:19.507Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/ea/a6523c7c7f6dc755a6eed3d2f6d6646617cad4d3d6d8ce4ed71bfd2362c8/lxml-5.3.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aac0bbd3e8dd2d9c45ceb82249e8bdd3ac99131a32b4d35c8af3cc9db1657179", size = 5322215, upload-time = "2024-08-10T18:11:23.708Z" },
-    { url = "https://files.pythonhosted.org/packages/99/37/396fbd24a70f62b31d988e4500f2068c7f3fd399d2fd45257d13eab51a6f/lxml-5.3.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b369d3db3c22ed14c75ccd5af429086f166a19627e84a8fdade3f8f31426e52a", size = 4813963, upload-time = "2024-08-10T18:11:26.997Z" },
-    { url = "https://files.pythonhosted.org/packages/09/91/e6136f17459a11ce1757df864b213efbeab7adcb2efa63efb1b846ab6723/lxml-5.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c24037349665434f375645fa9d1f5304800cec574d0310f618490c871fd902b3", size = 4923353, upload-time = "2024-08-10T18:11:30.478Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/7c/2eeecf87c9a1fca4f84f991067c693e67340f2b7127fc3eca8fa29d75ee3/lxml-5.3.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:62d172f358f33a26d6b41b28c170c63886742f5b6772a42b59b4f0fa10526cb1", size = 4740541, upload-time = "2024-08-10T18:11:34.344Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/ed/4c38ba58defca84f5f0d0ac2480fdcd99fc7ae4b28fc417c93640a6949ae/lxml-5.3.0-cp312-cp312-manylinux_2_28_ppc64le.whl", hash = "sha256:c1f794c02903c2824fccce5b20c339a1a14b114e83b306ff11b597c5f71a1c8d", size = 5346504, upload-time = "2024-08-10T18:11:37.595Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/22/bbd3995437e5745cb4c2b5d89088d70ab19d4feabf8a27a24cecb9745464/lxml-5.3.0-cp312-cp312-manylinux_2_28_s390x.whl", hash = "sha256:5d6a6972b93c426ace71e0be9a6f4b2cfae9b1baed2eed2006076a746692288c", size = 4898077, upload-time = "2024-08-10T18:11:40.867Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/6e/94537acfb5b8f18235d13186d247bca478fea5e87d224644e0fe907df976/lxml-5.3.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:3879cc6ce938ff4eb4900d901ed63555c778731a96365e53fadb36437a131a99", size = 4946543, upload-time = "2024-08-10T18:11:44.954Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/e8/4b15df533fe8e8d53363b23a41df9be907330e1fa28c7ca36893fad338ee/lxml-5.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:74068c601baff6ff021c70f0935b0c7bc528baa8ea210c202e03757c68c5a4ff", size = 4816841, upload-time = "2024-08-10T18:11:49.046Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/e7/03f390ea37d1acda50bc538feb5b2bda6745b25731e4e76ab48fae7106bf/lxml-5.3.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ecd4ad8453ac17bc7ba3868371bffb46f628161ad0eefbd0a855d2c8c32dd81a", size = 5417341, upload-time = "2024-08-10T18:11:52.295Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/99/d1133ab4c250da85a883c3b60249d3d3e7c64f24faff494cf0fd23f91e80/lxml-5.3.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:7e2f58095acc211eb9d8b5771bf04df9ff37d6b87618d1cbf85f92399c98dae8", size = 5327539, upload-time = "2024-08-10T18:11:55.98Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/ed/e6276c8d9668028213df01f598f385b05b55a4e1b4662ee12ef05dab35aa/lxml-5.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e63601ad5cd8f860aa99d109889b5ac34de571c7ee902d6812d5d9ddcc77fa7d", size = 5012542, upload-time = "2024-08-10T18:11:59.351Z" },
-    { url = "https://files.pythonhosted.org/packages/36/88/684d4e800f5aa28df2a991a6a622783fb73cf0e46235cfa690f9776f032e/lxml-5.3.0-cp312-cp312-win32.whl", hash = "sha256:17e8d968d04a37c50ad9c456a286b525d78c4a1c15dd53aa46c1d8e06bf6fa30", size = 3486454, upload-time = "2024-08-10T18:12:02.696Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/82/ace5a5676051e60355bd8fb945df7b1ba4f4fb8447f2010fb816bfd57724/lxml-5.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:c1a69e58a6bb2de65902051d57fde951febad631a20a64572677a1052690482f", size = 3816857, upload-time = "2024-08-10T18:12:06.456Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c8/8ff2bc6b920c84355146cd1ab7d181bc543b89241cfb1ebee824a7c81457/lxml-6.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a59f5448ba2ceccd06995c95ea59a7674a10de0810f2ce90c9006f3cbc044456", size = 8661887, upload-time = "2025-09-22T04:01:17.265Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/9aae1008083bb501ef63284220ce81638332f9ccbfa53765b2b7502203cf/lxml-6.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e8113639f3296706fbac34a30813929e29247718e88173ad849f57ca59754924", size = 4667818, upload-time = "2025-09-22T04:01:19.688Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ca/31fb37f99f37f1536c133476674c10b577e409c0a624384147653e38baf2/lxml-6.0.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a8bef9b9825fa8bc816a6e641bb67219489229ebc648be422af695f6e7a4fa7f", size = 4950807, upload-time = "2025-09-22T04:01:21.487Z" },
+    { url = "https://files.pythonhosted.org/packages/da/87/f6cb9442e4bada8aab5ae7e1046264f62fdbeaa6e3f6211b93f4c0dd97f1/lxml-6.0.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:65ea18d710fd14e0186c2f973dc60bb52039a275f82d3c44a0e42b43440ea534", size = 5109179, upload-time = "2025-09-22T04:01:23.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/20/a7760713e65888db79bbae4f6146a6ae5c04e4a204a3c48896c408cd6ed2/lxml-6.0.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c371aa98126a0d4c739ca93ceffa0fd7a5d732e3ac66a46e74339acd4d334564", size = 5023044, upload-time = "2025-09-22T04:01:25.118Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b0/7e64e0460fcb36471899f75831509098f3fd7cd02a3833ac517433cb4f8f/lxml-6.0.2-cp312-cp312-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:700efd30c0fa1a3581d80a748157397559396090a51d306ea59a70020223d16f", size = 5359685, upload-time = "2025-09-22T04:01:27.398Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e1/e5df362e9ca4e2f48ed6411bd4b3a0ae737cc842e96877f5bf9428055ab4/lxml-6.0.2-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c33e66d44fe60e72397b487ee92e01da0d09ba2d66df8eae42d77b6d06e5eba0", size = 5654127, upload-time = "2025-09-22T04:01:29.629Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d1/232b3309a02d60f11e71857778bfcd4acbdb86c07db8260caf7d008b08f8/lxml-6.0.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90a345bbeaf9d0587a3aaffb7006aa39ccb6ff0e96a57286c0cb2fd1520ea192", size = 5253958, upload-time = "2025-09-22T04:01:31.535Z" },
+    { url = "https://files.pythonhosted.org/packages/35/35/d955a070994725c4f7d80583a96cab9c107c57a125b20bb5f708fe941011/lxml-6.0.2-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:064fdadaf7a21af3ed1dcaa106b854077fbeada827c18f72aec9346847cd65d0", size = 4711541, upload-time = "2025-09-22T04:01:33.801Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/be/667d17363b38a78c4bd63cfd4b4632029fd68d2c2dc81f25ce9eb5224dd5/lxml-6.0.2-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fbc74f42c3525ac4ffa4b89cbdd00057b6196bcefe8bce794abd42d33a018092", size = 5267426, upload-time = "2025-09-22T04:01:35.639Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/62c70aa4a1c26569bc958c9ca86af2bb4e1f614e8c04fb2989833874f7ae/lxml-6.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6ddff43f702905a4e32bc24f3f2e2edfe0f8fde3277d481bffb709a4cced7a1f", size = 5064917, upload-time = "2025-09-22T04:01:37.448Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/55/6ceddaca353ebd0f1908ef712c597f8570cc9c58130dbb89903198e441fd/lxml-6.0.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:6da5185951d72e6f5352166e3da7b0dc27aa70bd1090b0eb3f7f7212b53f1bb8", size = 4788795, upload-time = "2025-09-22T04:01:39.165Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e8/fd63e15da5e3fd4c2146f8bbb3c14e94ab850589beab88e547b2dbce22e1/lxml-6.0.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:57a86e1ebb4020a38d295c04fc79603c7899e0df71588043eb218722dabc087f", size = 5676759, upload-time = "2025-09-22T04:01:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/76/47/b3ec58dc5c374697f5ba37412cd2728f427d056315d124dd4b61da381877/lxml-6.0.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2047d8234fe735ab77802ce5f2297e410ff40f5238aec569ad7c8e163d7b19a6", size = 5255666, upload-time = "2025-09-22T04:01:43.363Z" },
+    { url = "https://files.pythonhosted.org/packages/19/93/03ba725df4c3d72afd9596eef4a37a837ce8e4806010569bedfcd2cb68fd/lxml-6.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6f91fd2b2ea15a6800c8e24418c0775a1694eefc011392da73bc6cef2623b322", size = 5277989, upload-time = "2025-09-22T04:01:45.215Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/80/c06de80bfce881d0ad738576f243911fccf992687ae09fd80b734712b39c/lxml-6.0.2-cp312-cp312-win32.whl", hash = "sha256:3ae2ce7d6fedfb3414a2b6c5e20b249c4c607f72cb8d2bb7cc9c6ec7c6f4e849", size = 3611456, upload-time = "2025-09-22T04:01:48.243Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/d7/0cdfb6c3e30893463fb3d1e52bc5f5f99684a03c29a0b6b605cfae879cd5/lxml-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:72c87e5ee4e58a8354fb9c7c84cbf95a1c8236c127a5d1b7683f04bed8361e1f", size = 4011793, upload-time = "2025-09-22T04:01:50.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7b/93c73c67db235931527301ed3785f849c78991e2e34f3fd9a6663ffda4c5/lxml-6.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:61cb10eeb95570153e0c0e554f58df92ecf5109f75eacad4a95baa709e26c3d6", size = 3672836, upload-time = "2025-09-22T04:01:52.145Z" },
+]
+
+[[package]]
+name = "lz4"
+version = "4.4.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/51/f1b86d93029f418033dddf9b9f79c8d2641e7454080478ee2aab5123173e/lz4-4.4.5.tar.gz", hash = "sha256:5f0b9e53c1e82e88c10d7c180069363980136b9d7a8306c4dca4f760d60c39f0", size = 172886, upload-time = "2025-11-03T13:02:36.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/ac/016e4f6de37d806f7cc8f13add0a46c9a7cfc41a5ddc2bc831d7954cf1ce/lz4-4.4.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:df5aa4cead2044bab83e0ebae56e0944cc7fcc1505c7787e9e1057d6d549897e", size = 207163, upload-time = "2025-11-03T13:01:45.895Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/df/0fadac6e5bd31b6f34a1a8dbd4db6a7606e70715387c27368586455b7fc9/lz4-4.4.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6d0bf51e7745484d2092b3a51ae6eb58c3bd3ce0300cf2b2c14f76c536d5697a", size = 207150, upload-time = "2025-11-03T13:01:47.205Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/17/34e36cc49bb16ca73fb57fbd4c5eaa61760c6b64bce91fcb4e0f4a97f852/lz4-4.4.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7b62f94b523c251cf32aa4ab555f14d39bd1a9df385b72443fd76d7c7fb051f5", size = 1292045, upload-time = "2025-11-03T13:01:48.667Z" },
+    { url = "https://files.pythonhosted.org/packages/90/1c/b1d8e3741e9fc89ed3b5f7ef5f22586c07ed6bb04e8343c2e98f0fa7ff04/lz4-4.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c3ea562c3af274264444819ae9b14dbbf1ab070aff214a05e97db6896c7597e", size = 1279546, upload-time = "2025-11-03T13:01:50.159Z" },
+    { url = "https://files.pythonhosted.org/packages/55/d9/e3867222474f6c1b76e89f3bd914595af69f55bf2c1866e984c548afdc15/lz4-4.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24092635f47538b392c4eaeff14c7270d2c8e806bf4be2a6446a378591c5e69e", size = 1368249, upload-time = "2025-11-03T13:01:51.273Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e7/d667d337367686311c38b580d1ca3d5a23a6617e129f26becd4f5dc458df/lz4-4.4.5-cp312-cp312-win32.whl", hash = "sha256:214e37cfe270948ea7eb777229e211c601a3e0875541c1035ab408fbceaddf50", size = 88189, upload-time = "2025-11-03T13:01:52.605Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/0b/a54cd7406995ab097fceb907c7eb13a6ddd49e0b231e448f1a81a50af65c/lz4-4.4.5-cp312-cp312-win_amd64.whl", hash = "sha256:713a777de88a73425cf08eb11f742cd2c98628e79a8673d6a52e3c5f0c116f33", size = 99497, upload-time = "2025-11-03T13:01:53.477Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7e/dc28a952e4bfa32ca16fa2eb026e7a6ce5d1411fcd5986cd08c74ec187b9/lz4-4.4.5-cp312-cp312-win_arm64.whl", hash = "sha256:a88cbb729cc333334ccfb52f070463c21560fca63afcf636a9f160a55fac3301", size = 91279, upload-time = "2025-11-03T13:01:54.419Z" },
 ]
 
 [[package]]
@@ -624,81 +466,6 @@ wheels = [
 ]
 
 [[package]]
-name = "more-itertools"
-version = "11.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
-]
-
-[[package]]
-name = "msgpack"
-version = "1.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/bd/8b0d01c756203fbab65d265859749860682ccd2a59594609aeec3a144efa/msgpack-1.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:70a0dff9d1f8da25179ffcf880e10cf1aad55fdb63cd59c9a49a1b82290062aa", size = 81939, upload-time = "2025-10-08T09:15:01.472Z" },
-    { url = "https://files.pythonhosted.org/packages/34/68/ba4f155f793a74c1483d4bdef136e1023f7bcba557f0db4ef3db3c665cf1/msgpack-1.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:446abdd8b94b55c800ac34b102dffd2f6aa0ce643c55dfc017ad89347db3dbdb", size = 85064, upload-time = "2025-10-08T09:15:03.764Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/60/a064b0345fc36c4c3d2c743c82d9100c40388d77f0b48b2f04d6041dbec1/msgpack-1.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c63eea553c69ab05b6747901b97d620bb2a690633c77f23feb0c6a947a8a7b8f", size = 417131, upload-time = "2025-10-08T09:15:05.136Z" },
-    { url = "https://files.pythonhosted.org/packages/65/92/a5100f7185a800a5d29f8d14041f61475b9de465ffcc0f3b9fba606e4505/msgpack-1.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:372839311ccf6bdaf39b00b61288e0557916c3729529b301c52c2d88842add42", size = 427556, upload-time = "2025-10-08T09:15:06.837Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/87/ffe21d1bf7d9991354ad93949286f643b2bb6ddbeab66373922b44c3b8cc/msgpack-1.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2929af52106ca73fcb28576218476ffbb531a036c2adbcf54a3664de124303e9", size = 404920, upload-time = "2025-10-08T09:15:08.179Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/41/8543ed2b8604f7c0d89ce066f42007faac1eaa7d79a81555f206a5cdb889/msgpack-1.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:be52a8fc79e45b0364210eef5234a7cf8d330836d0a64dfbb878efa903d84620", size = 415013, upload-time = "2025-10-08T09:15:09.83Z" },
-    { url = "https://files.pythonhosted.org/packages/41/0d/2ddfaa8b7e1cee6c490d46cb0a39742b19e2481600a7a0e96537e9c22f43/msgpack-1.1.2-cp312-cp312-win32.whl", hash = "sha256:1fff3d825d7859ac888b0fbda39a42d59193543920eda9d9bea44d958a878029", size = 65096, upload-time = "2025-10-08T09:15:11.11Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/ec/d431eb7941fb55a31dd6ca3404d41fbb52d99172df2e7707754488390910/msgpack-1.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1de460f0403172cff81169a30b9a92b260cb809c4cb7e2fc79ae8d0510c78b6b", size = 72708, upload-time = "2025-10-08T09:15:12.554Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/31/5b1a1f70eb0e87d1678e9624908f86317787b536060641d6798e3cf70ace/msgpack-1.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:be5980f3ee0e6bd44f3a9e9dea01054f175b50c3e6cdb692bc9424c0bbb8bf69", size = 64119, upload-time = "2025-10-08T09:15:13.589Z" },
-]
-
-[[package]]
-name = "multidict"
-version = "6.7.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/9c/f20e0e2cf80e4b2e4b1c365bf5fe104ee633c751a724246262db8f1a0b13/multidict-6.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a90f75c956e32891a4eda3639ce6dd86e87105271f43d43442a3aedf3cddf172", size = 76893, upload-time = "2026-01-26T02:43:52.754Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/cf/18ef143a81610136d3da8193da9d80bfe1cb548a1e2d1c775f26b23d024a/multidict-6.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fccb473e87eaa1382689053e4a4618e7ba7b9b9b8d6adf2027ee474597128cd", size = 45456, upload-time = "2026-01-26T02:43:53.893Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/65/1caac9d4cd32e8433908683446eebc953e82d22b03d10d41a5f0fefe991b/multidict-6.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0fa96985700739c4c7853a43c0b3e169360d6855780021bfc6d0f1ce7c123e7", size = 43872, upload-time = "2026-01-26T02:43:55.041Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/3b/d6bd75dc4f3ff7c73766e04e705b00ed6dbbaccf670d9e05a12b006f5a21/multidict-6.7.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cb2a55f408c3043e42b40cc8eecd575afa27b7e0b956dfb190de0f8499a57a53", size = 251018, upload-time = "2026-01-26T02:43:56.198Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/80/c959c5933adedb9ac15152e4067c702a808ea183a8b64cf8f31af8ad3155/multidict-6.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb0ce7b2a32d09892b3dd6cc44877a0d02a33241fafca5f25c8b6b62374f8b75", size = 258883, upload-time = "2026-01-26T02:43:57.499Z" },
-    { url = "https://files.pythonhosted.org/packages/86/85/7ed40adafea3d4f1c8b916e3b5cc3a8e07dfcdcb9cd72800f4ed3ca1b387/multidict-6.7.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c3a32d23520ee37bf327d1e1a656fec76a2edd5c038bf43eddfa0572ec49c60b", size = 242413, upload-time = "2026-01-26T02:43:58.755Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/57/b8565ff533e48595503c785f8361ff9a4fde4d67de25c207cd0ba3befd03/multidict-6.7.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9c90fed18bffc0189ba814749fdcc102b536e83a9f738a9003e569acd540a733", size = 268404, upload-time = "2026-01-26T02:44:00.216Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/50/9810c5c29350f7258180dfdcb2e52783a0632862eb334c4896ac717cebcb/multidict-6.7.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:da62917e6076f512daccfbbde27f46fed1c98fee202f0559adec8ee0de67f71a", size = 269456, upload-time = "2026-01-26T02:44:02.202Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961", size = 256322, upload-time = "2026-01-26T02:44:03.56Z" },
-    { url = "https://files.pythonhosted.org/packages/31/6e/d8a26d81ac166a5592782d208dd90dfdc0a7a218adaa52b45a672b46c122/multidict-6.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3758692429e4e32f1ba0df23219cd0b4fc0a52f476726fff9337d1a57676a582", size = 253955, upload-time = "2026-01-26T02:44:04.845Z" },
-    { url = "https://files.pythonhosted.org/packages/59/4c/7c672c8aad41534ba619bcd4ade7a0dc87ed6b8b5c06149b85d3dd03f0cd/multidict-6.7.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:398c1478926eca669f2fd6a5856b6de9c0acf23a2cb59a14c0ba5844fa38077e", size = 251254, upload-time = "2026-01-26T02:44:06.133Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/bd/84c24de512cbafbdbc39439f74e967f19570ce7924e3007174a29c348916/multidict-6.7.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c102791b1c4f3ab36ce4101154549105a53dc828f016356b3e3bcae2e3a039d3", size = 252059, upload-time = "2026-01-26T02:44:07.518Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/ba/f5449385510825b73d01c2d4087bf6d2fccc20a2d42ac34df93191d3dd03/multidict-6.7.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:a088b62bd733e2ad12c50dad01b7d0166c30287c166e137433d3b410add807a6", size = 263588, upload-time = "2026-01-26T02:44:09.382Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/11/afc7c677f68f75c84a69fe37184f0f82fce13ce4b92f49f3db280b7e92b3/multidict-6.7.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3d51ff4785d58d3f6c91bdbffcb5e1f7ddfda557727043aa20d20ec4f65e324a", size = 259642, upload-time = "2026-01-26T02:44:10.73Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/17/ebb9644da78c4ab36403739e0e6e0e30ebb135b9caf3440825001a0bddcb/multidict-6.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc5907494fccf3e7d3f94f95c91d6336b092b5fc83811720fae5e2765890dfba", size = 251377, upload-time = "2026-01-26T02:44:12.042Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/a4/840f5b97339e27846c46307f2530a2805d9d537d8b8bd416af031cad7fa0/multidict-6.7.1-cp312-cp312-win32.whl", hash = "sha256:28ca5ce2fd9716631133d0e9a9b9a745ad7f60bac2bccafb56aa380fc0b6c511", size = 41887, upload-time = "2026-01-26T02:44:14.245Z" },
-    { url = "https://files.pythonhosted.org/packages/80/31/0b2517913687895f5904325c2069d6a3b78f66cc641a86a2baf75a05dcbb/multidict-6.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcee94dfbd638784645b066074b338bc9cc155d4b4bffa4adce1615c5a426c19", size = 46053, upload-time = "2026-01-26T02:44:15.371Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/5b/aba28e4ee4006ae4c7df8d327d31025d760ffa992ea23812a601d226e682/multidict-6.7.1-cp312-cp312-win_arm64.whl", hash = "sha256:ba0a9fb644d0c1a2194cf7ffb043bd852cea63a57f66fbd33959f7dae18517bf", size = 43307, upload-time = "2026-01-26T02:44:16.852Z" },
-    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
-]
-
-[[package]]
-name = "multimethod"
-version = "1.12"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ed/f3/930a6dc1d35b2ab65faffa2a75bbcc67f12d8227857188273783df4e5134/multimethod-1.12.tar.gz", hash = "sha256:8db8ef2a8d2a247e3570cc23317680892fdf903d84c8c1053667c8e8f7671a67", size = 17423, upload-time = "2024-07-04T16:10:08.179Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/98/cff14d53a2f2f67d7fe8a4e235a383ee71aba6a1da12aeea24b325d0c72a/multimethod-1.12-py3-none-any.whl", hash = "sha256:fd0c473c43558908d97cc06e4d68e8f69202f167db46f7b4e4058893e7dbdf60", size = 10646, upload-time = "2024-07-04T16:10:06.482Z" },
-]
-
-[[package]]
-name = "nlopt"
-version = "2.10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/39/76558756c758962fcf2c6f8450384e43a8e65cb8dfbb8a93d40014b09b3a/nlopt-2.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:19e7a5dd823eab1d167a4fb2f3da13978b997029c9b5e6164d33c747fc7ec542", size = 637168, upload-time = "2025-12-23T15:23:59.667Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/57/87a00a49664ae90f312cf9fd12262a3803d4f81709e01653bc2be6299b63/nlopt-2.10.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:939a0f3ed1710a6b9493a029744e07e8703f56aea4cfd3010d8619c4fba0df8e", size = 440214, upload-time = "2025-12-23T15:24:00.774Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/03/3140b6417a4cb113cd0f5d53b27ada263f81f158355ad991aaeee770e10e/nlopt-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:8364bdd98c8265eb87779155f4ab144dd67c7990620244b629f2ebc024d727d1", size = 641684, upload-time = "2025-12-23T15:24:02.094Z" },
-]
-
-[[package]]
 name = "numpy"
 version = "2.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -732,15 +499,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
-]
-
-[[package]]
-name = "path"
-version = "17.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dd/52/a7bdd5ef8488977d354b7915d1e75009bebbd04f73eff14e52372d5e9435/path-17.1.1.tar.gz", hash = "sha256:2dfcbfec8b4d960f3469c52acf133113c2a8bf12ac7b98d629fa91af87248d42", size = 50528, upload-time = "2025-07-27T20:40:23.79Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/50/11c9ee1ede64b45d687fd36eb8768dafc57afc78b4d83396920cfd69ed30/path-17.1.1-py3-none-any.whl", hash = "sha256:ec7e136df29172e5030dd07e037d55f676bdb29d15bfa09b80da29d07d3b9303", size = 23936, upload-time = "2025-07-27T20:40:22.453Z" },
 ]
 
 [[package]]
@@ -790,32 +548,6 @@ wheels = [
 ]
 
 [[package]]
-name = "propcache"
-version = "0.5.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz", hash = "sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427", size = 50208, upload-time = "2026-05-08T21:02:12.199Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/cb/e27bc2b2737a0bb49962b275efa051e8f1c35a936df7d5139b6b658b7dc9/propcache-0.5.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:806719138ecd720339a12410fb9614ac9b2b2d3a5fdf8235d56981c36f4039ba", size = 95887, upload-time = "2026-05-08T21:00:11.277Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/13/b8ae04c59392f8d11c6cd9fb4011d1dc7c86b81225c770280300e259ffe1/propcache-0.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:db2b80ea58eab4f86b2beec3cc8b39e8ff9276ac20e96b7cce43c8ae84cd6b5a", size = 54654, upload-time = "2026-05-08T21:00:12.604Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/7d/49777a3e20b55863d4794384a38acd460c04157b0a00f8602b0d508b8431/propcache-0.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e5cbfac9f61484f7e9f3597775500cd3ebe8274e9b050c38f9525c77c97520bf", size = 55190, upload-time = "2026-05-08T21:00:13.935Z" },
-    { url = "https://files.pythonhosted.org/packages/44/c7/085d0cd63062e84044e3f05797749c3f8e3938ff3aeb0eb2f69d43fafc91/propcache-0.5.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbc581d2814337da56222fab8dc5f161cd798a434e49bac27930aaef798e144", size = 59995, upload-time = "2026-05-08T21:00:15.526Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/42/32cf8e3009e92b2645cf1e944f701e8ea4e924dffde1ee26db860bcbf7e4/propcache-0.5.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:857187f381f88c8e2fa2fe56ab94879d011b883d5a2ee5a1b60a8cd2a06846d9", size = 63422, upload-time = "2026-05-08T21:00:16.824Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/1b/f112433f99fc979431b87a39ef169e3f8df070d99a72792c56d6937ac48b/propcache-0.5.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:178b4a2cdaac1818e2bf1c5a99b94383fa73ea5382e032a48dec07dc5668dc42", size = 64342, upload-time = "2026-05-08T21:00:18.362Z" },
-    { url = "https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f328175a2cde1f0ff2c4ed8ce968b9dcfb55f3a7153f39e2957ed994da13476", size = 61639, upload-time = "2026-05-08T21:00:19.692Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/da/4d775080b1490c0ae604acda868bd71aabe3a89ed16f2aa4339eb8a283e7/propcache-0.5.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5671d09a36b06d0fd4a3da0fccbcae360e9b1570924171a15e9e0997f0249fba", size = 61588, upload-time = "2026-05-08T21:00:21.155Z" },
-    { url = "https://files.pythonhosted.org/packages/04/ac/f076982cbe2195ee9cf32de5a1e46951d9fb399fc207f390562dd0fd8fb2/propcache-0.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:80168e2ebe4d3ec6599d10ad8f520304ae1cad9b6c5a95372aef1b66b7bfb53a", size = 60029, upload-time = "2026-05-08T21:00:22.713Z" },
-    { url = "https://files.pythonhosted.org/packages/70/60/189be62e0dd898dce3b331e1b8c7a543cd3a405ac0c81fe8ee8a9d5d77e1/propcache-0.5.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:45f11346f884bc47444f6e6647131055844134c3175b629f84952e2b5cd62b64", size = 56774, upload-time = "2026-05-08T21:00:24.001Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/9e/93377b9c7939c1ffae98f878dee955efadfd638078bc86dbc21f9d52f651/propcache-0.5.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8e778ebd44ef4f66ed60a0416b06b489687db264a9c0b3620362f26489492913", size = 63532, upload-time = "2026-05-08T21:00:25.545Z" },
-    { url = "https://files.pythonhosted.org/packages/14/f9/590ef6cfb9b8028d516d287812ece32bb0bc5f11fbb9c8bf6b2e6313fec8/propcache-0.5.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c0cb9ed24c8964e172768d455a38254c2dd8a552905729ce006cad3d3dda59b1", size = 61592, upload-time = "2026-05-08T21:00:27.186Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/5e/70958b3034c297a630bba2f17ca7abc2d5f39a803ad7e370ab79d1ecd022/propcache-0.5.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:1d1ad32d9d4355e2be65574fd0bfd3677e7066b009cd5b9b2dee8aa6a6393b33", size = 64788, upload-time = "2026-05-08T21:00:28.8Z" },
-    { url = "https://files.pythonhosted.org/packages/12/fd/77fe5936d8c3086ca9048f7f415f122ed82e53884a9ec193646b42deef06/propcache-0.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c80f4ba3e8f00189165999a742ee526ebeccedf6c3f7beb0c7df821e9772435a", size = 62514, upload-time = "2026-05-08T21:00:30.098Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/74/66bd798b5b3be70aa1b391f5cc9d6a0a5532d7fd3b19ec0b213e72e6ad9d/propcache-0.5.2-cp312-cp312-win32.whl", hash = "sha256:8c7972d8f193740d9175f0998ab38717e6cd322d5935c5b0fef8c0d323fd9031", size = 39018, upload-time = "2026-05-08T21:00:31.622Z" },
-    { url = "https://files.pythonhosted.org/packages/61/7c/5c0d34aa3024694d6dcb9271cdbdd08c4e47c1c0ad95ec7e7bc74cdea145/propcache-0.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:d9ee8826a7d47863a08ac44e1a5f611a462eefc3a194b492da242128bec75b42", size = 42322, upload-time = "2026-05-08T21:00:32.918Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/91/875812f1a3feb20ceba818ef39fbe4d92f1081e04ac815c822496d0d038b/propcache-0.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:2800a4a8ead6b28cccd1ec54b59346f0def7922ee1c7598e8499c733cfbb7c84", size = 38172, upload-time = "2026-05-08T21:00:35.124Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
-]
-
-[[package]]
 name = "pyclipr"
 version = "0.1.8"
 source = { registry = "https://pypi.org/simple" }
@@ -824,9 +556,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/96/c8049cfb9166c1f50d878535f2d1cdae1303e994dea7783a3f9075aa0679/pyclipr-0.1.8.tar.gz", hash = "sha256:ff8360330f827dc4801a57cd18d3bc925814b6a9a05f14be1e0f8f72cc27488f", size = 4553790, upload-time = "2026-02-01T16:04:55.479Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/9f/26b36527d36d6589fa2e6148eddda63cfb355e6a157080f7887ad5ade88c/pyclipr-0.1.8-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:d20f0e81671ad9e490036d68b475d65a54ad794f890b363ed4525004f4c9bedf", size = 196392, upload-time = "2026-02-01T16:04:36.813Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/1c/6d6e660f015362636bf0b0ae7d2f9eba110b1080d89dec355cdc6c0b8222/pyclipr-0.1.8-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:bcb37cee65c82229f34704c305b3ad174c3e91a108f5b9e95467b68036dd06dd", size = 192257, upload-time = "2026-02-01T16:04:38.276Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/e9/b38300f5d15f404a6f5aa9050d6e33f6dbca334d649e60364cc89a8df1d7/pyclipr-0.1.8-cp311-cp311-win_amd64.whl", hash = "sha256:c453c85664245beb94e1b2bf49f441faa640da73832a59cfa6a6fbd340e3d890", size = 192242, upload-time = "2026-02-01T16:04:39.667Z" },
     { url = "https://files.pythonhosted.org/packages/82/d4/1758ae1390f02f7dccddec8186f04e1e982a59bd978918a381a10e7ccd67/pyclipr-0.1.8-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3517ce2f86f201bb7be0894bfd368d9e446e2b0c74914b80bdeee551ccc6ee82", size = 197991, upload-time = "2026-02-01T16:04:40.771Z" },
     { url = "https://files.pythonhosted.org/packages/bb/bf/e686ab34bf5f45a64548e590a6c794e6dcde56b8c08f1c60bec9ba620ec8/pyclipr-0.1.8-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:f961a754b114f69f1638bafd98df60e2fba672ccd921ea5bf2173e271ede43f9", size = 192797, upload-time = "2026-02-01T16:04:41.726Z" },
     { url = "https://files.pythonhosted.org/packages/a8/a7/756c10ddbf4f69eb37aeb3d895a29824d5285975db254570758eba57656a/pyclipr-0.1.8-cp312-cp312-win_amd64.whl", hash = "sha256:502e3404f72186a5571a0d9dddbc2c9b493cb3b56598d4800de3e67e5dc0a5fd", size = 193346, upload-time = "2026-02-01T16:04:42.669Z" },
@@ -1022,24 +751,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyyaml"
-version = "6.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
-    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
-    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
-    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
-    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
-    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
-]
-
-[[package]]
 name = "quart"
 version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1098,15 +809,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/8c/b1e1666aef7fc6555094d73ae6cd981701781ae85b97ceefc0eebd0b4668/ruff-0.15.13-py3-none-win32.whl", hash = "sha256:4044f94208b3b05ba0fc4a4abd0558cf4d6459bd18325eead7fd8cc66f909b41", size = 10721455, upload-time = "2026-05-14T13:44:35.697Z" },
     { url = "https://files.pythonhosted.org/packages/ab/a6/870a3e8a50590bb92be184ad928c2922f088b00d9dc5c5ec7b924ee08c22/ruff-0.15.13-py3-none-win_amd64.whl", hash = "sha256:7064884d442b7d477b4e7473d12da7f08851d2b1982763c5d3f388a19468a1a4", size = 11900409, upload-time = "2026-05-14T13:44:30.389Z" },
     { url = "https://files.pythonhosted.org/packages/9b/36/9c015cd052fca743dae8cb2aeb16b551444787467db42ceab0fc968865af/ruff-0.15.13-py3-none-win_arm64.whl", hash = "sha256:2471da9bd1068c8c064b5fd9c0c4b6dddffd6369cb1cd68b29993b1709ff1b21", size = 11179336, upload-time = "2026-05-14T13:44:33.026Z" },
-]
-
-[[package]]
-name = "runtype"
-version = "0.5.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/60/76/d8a0f754c834c3d71a0896b1d40a1938244aab4bb5b4bab0b21d21525694/runtype-0.5.3.tar.gz", hash = "sha256:ccaec05c74f8d213342b9fc25e304560d114bc4d72ec117639cd1e7af9c5db1f", size = 30223, upload-time = "2025-03-03T08:39:00.081Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/db/879902580d720925092c86eaab2ceee7493e2fadbb5b718f54289b04d277/runtype-0.5.3-py3-none-any.whl", hash = "sha256:ea8cc6828217ebfda5c159dce969e832efd865a09d6ad1fc993f5bf5e1a627ee", size = 31944, upload-time = "2025-03-03T08:38:58.329Z" },
 ]
 
 [[package]]
@@ -1201,93 +903,6 @@ wheels = [
 ]
 
 [[package]]
-name = "trame"
-version = "3.13.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyyaml" },
-    { name = "trame-client" },
-    { name = "trame-common" },
-    { name = "trame-server" },
-    { name = "wslink" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/c7/790a5f28d75ea166fd9ec0bc6545e42683dc59ddd0b15ed374d00fb8e187/trame-3.13.2.tar.gz", hash = "sha256:9868d1c2bce981ae2c66eb6a16d39e2a14f042eedb1047666266c753ecaf3f64", size = 26386, upload-time = "2026-05-15T03:50:50.626Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/4a/1474a166fa9494162779b4145b4b82adbe482cfb776efffeff59de4ba70f/trame-3.13.2-py3-none-any.whl", hash = "sha256:23e87a65a6ea9241ce1060e9cd01426e48b3b8b72cd9f3cb974fc398649280b6", size = 31514, upload-time = "2026-05-15T03:50:49.129Z" },
-]
-
-[[package]]
-name = "trame-client"
-version = "3.12.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "trame-common" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/90/c895a1dc56c5554105baf00e16a454028f24c94be654430d87df0ff5b788/trame_client-3.12.2.tar.gz", hash = "sha256:a9bfba0226dda4a2ff36805ebf12e649cd7eb94c40672c8495d0674a12d5d381", size = 246220, upload-time = "2026-05-11T16:36:24.677Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/ba/a62b4f6dee5039074f8f92dcfe780dc68b2ca29a9882282da1750808892d/trame_client-3.12.2-py3-none-any.whl", hash = "sha256:829a59bc5e2bf9ae2adc3a254ce9b0183c0312c656b3f5b0c88be35671703c9c", size = 250679, upload-time = "2026-05-11T16:36:22.936Z" },
-]
-
-[[package]]
-name = "trame-common"
-version = "1.2.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/8c/f9e7bcf73d888df9df6115deb8619679444d83b9e92a26604a05f0433307/trame_common-1.2.3.tar.gz", hash = "sha256:125b60d77545d7352fb8eabc0f6e0e12070aa6ada31e992862f16a49f34b73ad", size = 19998, upload-time = "2026-05-08T17:12:33.942Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/80/957a3dae26c1b38a302a96bf49adc53399e5f04c0afdf750d4978216fe14/trame_common-1.2.3-py3-none-any.whl", hash = "sha256:85d13ac87e7e4db853278afc98d19d14972e1fc75394aac9800221be0829e5cd", size = 23482, upload-time = "2026-05-08T17:12:32.548Z" },
-]
-
-[[package]]
-name = "trame-components"
-version = "2.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "trame-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/82/47/d773f35615c22553a7547b4336af62e412548ec3607626fa3db128f30460/trame-components-2.5.0.tar.gz", hash = "sha256:df7a1d387b98c5dd71699737804f5288957ca370eb1a60bbe40e89a1f9f62b12", size = 81972, upload-time = "2025-05-30T14:21:36.718Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/e9/627ebbf56e00d80300940e8bbf54c6594f98fd214e3565b3abaa5450e0d4/trame_components-2.5.0-py3-none-any.whl", hash = "sha256:897a6c0ebcc72d95a461bde28d2c2e37c4bc4922013ad07df3a65e64d4884672", size = 82345, upload-time = "2025-05-30T14:21:35.526Z" },
-]
-
-[[package]]
-name = "trame-server"
-version = "3.12.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "more-itertools" },
-    { name = "trame-common" },
-    { name = "wslink" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/30/dd/5d030d4a8b8e66cad206229cb0eee12cddd4049dfc2284b322e58eaccf60/trame_server-3.12.4.tar.gz", hash = "sha256:95a0d2732fd52eb2912ca05874eba86d91e8d7ea7e4a0a8881ef3f539293645f", size = 37902, upload-time = "2026-05-19T14:26:24.914Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/cf/e5b1e37d7bcc32288075ec8205cac5d03b15c457eab9d7b076614770c6f0/trame_server-3.12.4-py3-none-any.whl", hash = "sha256:987190c63a3b255bd54651fb53a5814d74e2703e3e786d1c3ebdb97a1fe2de9b", size = 44413, upload-time = "2026-05-19T14:26:23.233Z" },
-]
-
-[[package]]
-name = "trame-vtk"
-version = "2.11.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "trame-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/10/de/b72ec543cf8f70ee0ef4645d04e911155db3dcba545a9cf35d6c80e849c9/trame_vtk-2.11.8.tar.gz", hash = "sha256:bef4a35d86d57bf9b4af44dda8f361f917b141e4f624c9ab7278b6c48d171e74", size = 810254, upload-time = "2026-04-24T00:28:17.494Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/11/aff660ffcc0f65546da4340902cd064cafda26e0a7750f6468a27378c717/trame_vtk-2.11.8-py3-none-any.whl", hash = "sha256:31c8220f59dcc3b5f2fcfe6de8b9796e8bdb7db5dcf790ee01df83d44e79a413", size = 831787, upload-time = "2026-04-24T00:28:15.317Z" },
-]
-
-[[package]]
-name = "trame-vuetify"
-version = "3.2.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "trame-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/1a/1701aaf3450def4b17cb3580d0a340361065b1d258e156861eb83a8377f2/trame_vuetify-3.2.2.tar.gz", hash = "sha256:0e111ec5fdfed31e5c189eafb306f4f25aacd75527b3a5612bb5a4cacbb18d8b", size = 5107360, upload-time = "2026-04-28T13:22:53.684Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/3a/0dbff3ce4fd9cc6076fce8ef714c33796bd25d08b3d249ca78ea458a85fd/trame_vuetify-3.2.2-py3-none-any.whl", hash = "sha256:b40ecfa30a675df4ce40d5161b9b6c040cfe5445599933c478a3359afbee91d3", size = 5134630, upload-time = "2026-04-28T13:22:51.132Z" },
-]
-
-[[package]]
 name = "triangle"
 version = "20250106"
 source = { registry = "https://pypi.org/simple" }
@@ -1300,15 +915,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/23/e0/bd0a7e624fc5fc8636d0ad281c5b0624027dc1855218ce6a251c581d7127/triangle-20250106-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b582b342cddb660dffc6bd7d7233f66952d2a3d18ccbc097660a8e370ee38d0c", size = 2009167, upload-time = "2025-01-07T04:56:12.221Z" },
     { url = "https://files.pythonhosted.org/packages/26/3f/7c79202ec374bd122b63250d768be34674043be9b97f6bb8c115df64e880/triangle-20250106-cp312-cp312-win32.whl", hash = "sha256:9532797a15687225a0ee67619ad6f3baeb72bf193541eb96f782e41c577cc81b", size = 1407116, upload-time = "2025-01-07T05:00:13.664Z" },
     { url = "https://files.pythonhosted.org/packages/a1/a5/4a09c3f9d2687d8752c912a97f2c5086cdd83721b3b13f8288f13b771fa7/triangle-20250106-cp312-cp312-win_amd64.whl", hash = "sha256:0327032a7984a7262180ef2ddd78b36dfdcdecbc79f0f9f173732ce7c670b8ed", size = 1426720, upload-time = "2025-01-07T05:00:17.789Z" },
-]
-
-[[package]]
-name = "typing-extensions"
-version = "4.15.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]
@@ -1339,20 +945,6 @@ wheels = [
 ]
 
 [[package]]
-name = "vtk"
-version = "9.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "matplotlib" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/ba/1571d61013f3f5778c11741d5de19db197b437d1a52215560f016662597b/vtk-9.3.1-cp312-cp312-macosx_10_10_x86_64.whl", hash = "sha256:05a4b6e387a906e8c8d6844441f9200116e937069fcf81f43e2600f26eb046de", size = 76832738, upload-time = "2024-06-29T03:15:26.41Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/75/c637c620d23ccecb8ddf58fdb80af1dc56ecdd60f3e018c55e041663398b/vtk-9.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bdbefb1aef9599a0a0b8222c9582f26946732a93534e6ec37d4b8e2c524c627e", size = 70385880, upload-time = "2024-06-29T03:15:33.131Z" },
-    { url = "https://files.pythonhosted.org/packages/01/ee/730d57c6d7353c1afb919ceedfac387a190ccb92e611c4b14f88e6f39066/vtk-9.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f728bb61f43fce850d622ced3b3d51b3116f767685ca4e4e0076f624e2d2307d", size = 92159868, upload-time = "2024-06-29T03:15:39.072Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/34/b9b6de4009be2fe90919c4943ae99ae3d465ada73061e928d4744683f915/vtk-9.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:685988e09070e06c8605886591698fd42d8225489509b6537a5046cd034cc93e", size = 52529544, upload-time = "2024-06-29T03:15:43.967Z" },
-]
-
-[[package]]
 name = "werkzeug"
 version = "3.1.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1365,16 +957,14 @@ wheels = [
 ]
 
 [[package]]
-name = "wslink"
-version = "2.5.7"
+name = "wn-geometer"
+version = "2026.6.10"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "msgpack" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/74/12/c23927be89cf75c24d774a8ee5bf83e368d0feb39fb361462f03ae8efd26/wslink-2.5.7.tar.gz", hash = "sha256:ed14c2b4749ea231a105a23334d2e0c7783204b2033f46104972a189ea235818", size = 29958, upload-time = "2026-05-15T02:57:36.299Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/3c/571e00719a5ce5b295d6bbed62841c51222687530871d8e92a0e64e19acb/wslink-2.5.7-py3-none-any.whl", hash = "sha256:47d729f654d1ee0bb42b6f05b068c48d5fdacd3216e827c1e80ea09eca0fe287", size = 37353, upload-time = "2026-05-15T02:57:35.135Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5d/dc4993dae57914edff4d0e6e2a22dfd457545212225c50e796cee66f4151/wn_geometer-2026.6.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fff41eb880b3a493e1b01ecf4c72d6b40e0a6d6afeb2ccef098df9ba8ce2d522", size = 10659273, upload-time = "2026-06-10T21:56:25.686Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d3/9c97ff141b26bd6ec37de703ffc923677e601d0a4b8001fe6073358b12c5/wn_geometer-2026.6.10-py3-none-manylinux_2_39_aarch64.whl", hash = "sha256:cf50f70882b9eb1e21b9e0c53ba0a64667270c90981931c0dc8fb6192eed719a", size = 13636792, upload-time = "2026-06-10T21:56:28.017Z" },
+    { url = "https://files.pythonhosted.org/packages/06/a9/8c8568c71337be2298966fccf419471b936f18cc0906a2ea201c5ad0fdaf/wn_geometer-2026.6.10-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:e14504894403f52cae6bd79c9c0a56103494638555ba2316ebd33ed8eef5c4de", size = 14292737, upload-time = "2026-06-10T21:56:30.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ab/e32d5960d12c80907571ce9d34b0b467e15ceff3e824974e08b413a2c591/wn_geometer-2026.6.10-py3-none-win_amd64.whl", hash = "sha256:f814ef17a9d09f69e43e843803c522b1890ccecff2cc5c7acf6f8bd193ec4aa3", size = 7224997, upload-time = "2026-06-10T21:56:32.867Z" },
 ]
 
 [[package]]
@@ -1387,35 +977,4 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
-]
-
-[[package]]
-name = "yarl"
-version = "1.24.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "idna" },
-    { name = "multidict" },
-    { name = "propcache" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/79/12/1e8f37460ea0f7eb59c221fdaf0ed75e7ac43e97f8093b9c6f411df50a78/yarl-1.24.2.tar.gz", hash = "sha256:9ac374123c6fd7abf64d1fec93962b0bd4ee2c19751755a762a72dd96c0378f8", size = 210798, upload-time = "2026-05-19T21:31:05.599Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/da/866bcb01076ba49d2b42b309867bed3826421f1c479655eb7a607b44f20b/yarl-1.24.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b975866c184564c827e0877380f0dae57dcca7e52782128381b72feff6dfceb8", size = 129957, upload-time = "2026-05-19T21:28:51.695Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/1d/fcefb70922ea2268a8971d8e5874d9a8218644200fb8465f1dcad55e6851/yarl-1.24.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3b075301a2836a0e297b1b658cb6d6135df535d62efefdd60366bd589c2c82f2", size = 92164, upload-time = "2026-05-19T21:28:53.242Z" },
-    { url = "https://files.pythonhosted.org/packages/29/b6/170e2b8d4e3bc30e6bfdcca53556537f5bf595e938632dfcb059311f3ff6/yarl-1.24.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8ae44649b00947634ab0dab2a374a638f52923a6e67083f2c156cd5cbd1a881d", size = 91688, upload-time = "2026-05-19T21:28:54.865Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/a5/c9f655d5553ea0b99fdac9d6a99ad3f9b3e73b8e5758bb46f58c9831f74c/yarl-1.24.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:507cc19f0b45454e2d6dcd62ff7d062b9f77a2812404e62dbdaec05b50faa035", size = 102902, upload-time = "2026-05-19T21:28:56.963Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/bc/6b9664d815d79af4ee553337f9d606c56bbf269186ada9172de45f1b5f60/yarl-1.24.2-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c4c17bad5a530912d2111825d3f05e89bab2dd376aaa8cbc77e449e6db63e576", size = 97931, upload-time = "2026-05-19T21:28:58.56Z" },
-    { url = "https://files.pythonhosted.org/packages/98/ec/32ba48acae30fecd60928f5791188b80a9d6ee3840507ffda29fecd37b71/yarl-1.24.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f5f0cbb112838a4a293985b6ed73948a547dadcc1ba6d2089938e7abdedceef8", size = 111030, upload-time = "2026-05-19T21:29:00.148Z" },
-    { url = "https://files.pythonhosted.org/packages/82/5a/6f4cd081e5f4934d2ae3a8ef4abe3afacc010d26f0035ee91b35cd7d7c37/yarl-1.24.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ec8356b8a6afcf81fc7aeeef13b1ff7a49dec00f313394bbb9e83830d32ccd7", size = 110392, upload-time = "2026-05-19T21:29:02.155Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/da/323a01c349bd5fb01bb6652e314d9bb218cee630a736bdb810ad50e4013f/yarl-1.24.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e7ebcdef69dec6c6451e616f32b622a6d4a2e92b445c992f7c8e5274a6bbc4c", size = 105612, upload-time = "2026-05-19T21:29:04.247Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/80/264ab684f181e1a876389374519ff05d10248725535ae2ac4e8ac4e563d6/yarl-1.24.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:47a55d6cf6db2f401017a9e96e5288844e5051911fb4e0c8311a3980f5e59a7d", size = 104487, upload-time = "2026-05-19T21:29:06.491Z" },
-    { url = "https://files.pythonhosted.org/packages/41/07/efabe5df87e96d7ad5959760b888344be48cd6884db127b407c6b5503adc/yarl-1.24.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3065657c80a2321225e804048597ad55658a7e76b32d6f5ee4074d04c50401db", size = 102333, upload-time = "2026-05-19T21:29:08.267Z" },
-    { url = "https://files.pythonhosted.org/packages/44/0c/bcf7c42603e1009295f586d8890f2ba032c8b53310e815adf0a202c73d9f/yarl-1.24.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:cb84b80d88e19ede158619b80813968713d8d008b0e2497a576e6a0557d50712", size = 99025, upload-time = "2026-05-19T21:29:10.682Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/82/84482ab1a57a0f21a08afe6a7004c61d741f8f2ecc3b05c321577c612164/yarl-1.24.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:990de4f680b1c217e77ff0d6aa0029f9eb79889c11fb3e9a3942c7eba29c1996", size = 110507, upload-time = "2026-05-19T21:29:12.954Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/8d/a546ba1dfe1b0f290e05fef145cd07614c0f15df1a707195e512d1e39d1d/yarl-1.24.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:abb8ec0323b80161e3802da3150ef660b41d0e9be2048b76a363d93eee992c2b", size = 103719, upload-time = "2026-05-19T21:29:14.893Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/b6/267f2a09213138473adfce6b8a6e17791d7fee70bd4d9003218e4dec58b0/yarl-1.24.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:e7977781f83638a4c73e0f88425563d70173e0dfd90ac006a45c65036293ee3c", size = 110438, upload-time = "2026-05-19T21:29:16.485Z" },
-    { url = "https://files.pythonhosted.org/packages/48/2d/1c8d89c7c5f9cad9fb2902445d94e2ab1d7aa35de029afbb8ae95c42d00f/yarl-1.24.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e30dd55825dc554ec5b66a94953b8eda8745926514c5089dfcacecb9c99b5bd1", size = 105719, upload-time = "2026-05-19T21:29:18.367Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/25/722e3b93bd687009afb2d59a35e13d30ddd8f80571445bb0c4e4ce26ec66/yarl-1.24.2-cp312-cp312-win_amd64.whl", hash = "sha256:7dafe10c12ddd4d120d528c4b5599c953bd7b12845347d507b95451195bb6cad", size = 92901, upload-time = "2026-05-19T21:29:20.014Z" },
-    { url = "https://files.pythonhosted.org/packages/39/47/4486ccfb674c04854a1ef8aa77868b6a6f765feaf69633409d7ca4f02cb8/yarl-1.24.2-cp312-cp312-win_arm64.whl", hash = "sha256:044a09d8401fcf8681977faef6d286b8ade1e2d2e9dceda175d1cfa5ca496f30", size = 87229, upload-time = "2026-05-19T21:29:22.1Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/4d/4b880086bd0d3e034d25647be1d830afc3e3f610e98c4ab3490af6b1b6d5/yarl-1.24.2-py3-none-any.whl", hash = "sha256:2783d9226db8797636cd6896e4de81feed252d1db72265686c9558d97a4d94b9", size = 53576, upload-time = "2026-05-19T21:31:03.909Z" },
 ]


### PR DESCRIPTION
## Motivation

High-current ICs often have many pads on the same supply or return net, but not all of them should carry load current in a PDN solve — enable pins hard-tied to the rail, signal pulls to GND, oversized thermal pads, and so on. Today every pad on `PDN_P_NET` / `PDN_N_NET` joins the lumped terminal, so authors either live with wrong current share or write long per-rail `PDN_P_PINS` / `PDN_N_PINS` lists.

Those per-rail pin lists are awkward in a **SchLib**: multi-rail parts use channel indices (`PDN` / `PDN1` / …) that are board-specific and cannot be fixed in the library. We need a **part-wide, index-free** way to say which pins are PDN-relevant, then let net matching partition them across rails on the schematic.

Separately, when power and thermal pads differ a lot in size, equal star coupling over-weights tiny pads. Area-weighted coupling (off by default) is a better default model for those footprints.

## Summary

- **`PDN_PINS_ONLY`** (optional **`PDN_EXTRA_PINS`**): part-wide allowlist before net matching for SOURCE / SINK / SERIES / REGULATOR (P/N/IN/OUT, indexed and unindexed). Explicit `*_PINS` overrides still win; `PDN_IGNORE` / `PDN_IGNORE_PINS` remain as fine-tuning after the allowlist.
- **Pin-level `PDN_IGNORE`** extraction from SchDoc (OwnerIndex / `pin_parameters`) plus component ignore lists.
- **Settings**: “Weight multi-pin coupling by pad area” (`R ∝ 1/A`), applied on re-solve; hover uses the same weights as an estimate.
- Docs (user guide + README) and tests for allowlist, multi-rail partition, REGULATOR, diagnostics, and extract coverage.

## Dependency note

This branch is based on `fix/nested-local-net-resolution` (relative SchDoc paths / nested local-net work). That commit is **not** yet on upstream `main`, so this PR currently includes it. Prefer merging nested first, or treat this PR as stacked on that change.

## Test plan

- [ ] `pytest tests/test_annotations.py tests/test_extract_pin_ignore.py tests/test_pin_coupling_area.py -k "pins_only or allowlist or ignore or pin_coupling or area_weight or extract_pin or sheet_ignore"`
- [ ] SchLib part with `PDN_PINS_ONLY` + multi-channel nets: enable pin on rail stays off terminals; rails still resolve.
- [ ] Instance `PDN_EXTRA_PINS` adds a pin without replacing the library list.
- [ ] Toggle area-weighted coupling in Settings → Re-run Solver; Setup report shows flag; multi-pad sink hover looks plausible.
- [ ] Reload Design Info after changing SchDoc ignore / allowlist params (not only Re-run).