### PR TITLE
Open mesh failures from CLI/Altium like File > Import

### DIFF
--- a/fypa/altium/loader.py
+++ b/fypa/altium/loader.py
@@ -2829,6 +2829,89 @@ def build_mesh_failure_records(
     return [stub]
 
 
+def build_stub_lean_solution_from_loaded(loaded: LoadedProject):
+    """Minimal :class:`~fypa.lean_solution.LeanSolution` so the viewer can open
+    without a successful FEM solve (load-only, mesh failure, missing
+    directives).
+
+    One :class:`~fypa.lean_solution.LeanLayer` per copper layer with real
+    geometry; empty per-layer solution arrays. ``solver_info["stub"]`` is the
+    viewer sentinel for pre-solve messaging.
+    """
+    from fypa.lean_solution import (
+        LeanLayer,
+        LeanLayerSolution,
+        LeanProblem,
+        LeanSolution,
+    )
+
+    geom = loaded.geometry
+    lean_layers = [
+        LeanLayer(
+            name=f"{L.name}|(none)",
+            conductance=L.conductance,
+            shape=L.shape,
+            layer_id=L.layer_id,
+            is_plane=L.is_plane,
+            plane_net_name=None,
+        )
+        for L in geom
+    ]
+    lean_solutions = [
+        LeanLayerSolution(
+            vertex_xys=[], triangles=[], potentials=[], power_densities=[],
+        )
+        for _ in geom
+    ]
+    return LeanSolution(
+        problem=LeanProblem(
+            layers=lean_layers,
+            project_name=loaded.project_name,
+        ),
+        layer_solutions=lean_solutions,
+        solver_info={
+            "stub": True,
+            "ground_node_current": 0.0,
+            "residual_norm": 0.0,
+        },
+    )
+
+
+def package_mesh_failure(
+    loaded: LoadedProject,
+    mesh_exc,
+    mesher_config=None,
+    settings: SolveSettings | None = None,
+) -> tuple[object, dict]:
+    """Turn a :class:`~pdnsolver.mesh.MeshingException` into a viewer-ready stub.
+
+    Used by the GUI :class:`~fypa.altium_viewer._SolveWorker` and the headless
+    CLI ``solve`` path so a bad copper island opens (or pickles) with markers
+    instead of aborting. CLI ``gui`` reaches this via the same solve worker.
+    """
+    problem = getattr(mesh_exc, "built_problem", None)
+    via_segment_records = getattr(mesh_exc, "built_via_segment_records", None)
+    stub_pieces_by_pair = getattr(mesh_exc, "built_stub_pieces_by_pair", None)
+    per_net_layers = getattr(mesh_exc, "built_per_net_layers", None)
+    if problem is None or per_net_layers is None:
+        (problem, via_segment_records,
+         stub_pieces_by_pair, per_net_layers) = build_problem(loaded)
+    mesh_failures = build_mesh_failure_records(
+        mesh_exc, problem, loaded, per_net_layers,
+    )
+    stub = build_stub_lean_solution_from_loaded(loaded)
+    metadata = build_solve_metadata(
+        loaded, problem,
+        mesher_config=mesher_config,
+        settings=settings,
+        via_segment_records=via_segment_records or [],
+        stub_pieces_by_pair=stub_pieces_by_pair,
+        per_net_layers=per_net_layers,
+        mesh_failures=mesh_failures,
+    )
+    return stub, metadata
+
+
 def _drop_unreachable_layers(
     pp_layers: list[_pp.Layer],
     layer_by_layer_and_net: dict[tuple[int, int], _pp.Layer],

--- a/fypa/altium_viewer.py
+++ b/fypa/altium_viewer.py
@@ -5162,6 +5162,11 @@ class _SolveWorker(QThread):
                     "Solve cache NOT written: pcbdoc_resolved is None "
                     "(see earlier warning from _resolve_pcbdoc).",
                 )
+            elif (metadata or {}).get("mesh_failures"):
+                _cache_log.info(
+                    "Solve cache NOT written: meshing failed "
+                    "(stub with mesh_failures only).",
+                )
             elif (self._stackup_overrides or self._sink_overrides
                     or self._editor_directives
                     or self._adaptive_regulator_gain):
@@ -5282,35 +5287,20 @@ class _SolveWorker(QThread):
                     stage_callback=self.stage_changed.emit,
                 )
             except _pdn_mesh.MeshingException as mesh_exc:
-                from fypa.altium.loader import build_mesh_failure_records
+                from fypa.altium.loader import package_mesh_failure
 
-                # solve_problem_adaptive built the Problem before meshing
-                # failed and attaches it to the exception — reuse it instead
-                # of rebuilding the whole geometry a second time. Fall back to
-                # a rebuild only if the artifacts are absent (e.g. the failure
-                # came from a path that did not attach them).
-                problem = getattr(mesh_exc, "built_problem", None)
-                per_net_layers = getattr(mesh_exc, "built_per_net_layers", None)
-                stub_pieces_by_pair = getattr(
-                    mesh_exc, "built_stub_pieces_by_pair", None,
-                )
-                if problem is None or per_net_layers is None:
-                    from fypa.altium.loader import build_problem
-                    (problem, _via_segment_records,
-                     stub_pieces_by_pair, per_net_layers) = build_problem(
-                        loaded,
-                    )
-                mesh_failures = build_mesh_failure_records(
-                    mesh_exc, problem, loaded, per_net_layers,
-                )
+                # Same stub packaging as CLI ``gui <PrjPcb>`` (Altium launcher):
+                # open the board with mesh-failure markers instead of dying.
                 if pristine_loaded is not None:
-                    self._emit_stub_and_finish(
-                        loaded, pristine_loaded, _timer,
-                        mesh_failures=mesh_failures,
-                        stub_pieces_by_pair=stub_pieces_by_pair,
-                        per_net_layers=per_net_layers,
-                        stage_message="Meshing failed — opening design…",
+                    # Emit first so the progress dialog updates before the
+                    # (potentially slow) stub + metadata packaging.
+                    self.stage_changed.emit("Meshing failed — opening design…")
+                    stub, fail_md = package_mesh_failure(
+                        loaded, mesh_exc, mesher_config,
+                        settings=self._settings,
                     )
+                    _timer.log_breakdown()
+                    self.finished_ok.emit(stub, fail_md, pristine_loaded)
                     return None
                 raise
             finally:
@@ -5928,14 +5918,22 @@ def _start_launcher_altium_solve(
     window, prjpcb_path: Path, pcbdoc_path: Path | None, *, clean: bool,
     from_recent: bool = False,
 ) -> None:
-    """Launcher-only: run :class:`_SolveWorker` for an Altium import."""
+    """Launcher-only: run :class:`_SolveWorker` for an Altium import.
+
+    Uses the launcher's :attr:`_solve_settings` (Settings tab / CLI ``gui``
+    overrides) and the persisted adaptive-gain preference — same inputs as
+    File > Import from an already-open viewer.
+    """
     if _reject_if_solve_running(window):
         return
     if _reject_if_background_load_running(window):
         return
     from fypa.altium.loader import SolveSettings
 
-    settings = SolveSettings()
+    settings = getattr(window, "_solve_settings", None)
+    if settings is None:
+        settings = SolveSettings()
+        window._solve_settings = settings
     settings.apply_to_modules()
     imp = _altium_import_worker_options(
         prjpcb_path.name, clean=clean,
@@ -5954,12 +5952,17 @@ def _start_launcher_altium_solve(
     _sz = dlg.size()
     dlg.setFixedSize(int(_sz.width() * 1.44), _sz.height())
 
+    adaptive = getattr(window, "_cli_adaptive_regulator_gain", None)
+    if adaptive is None:
+        adaptive = load_adaptive_regulator_gain()
+
     worker = _SolveWorker(
         prjpcb_path, settings,
         pcbdoc_selector=str(pcbdoc_path) if pcbdoc_path else None,
         use_design_cache=imp["use_design_cache"],
         try_solve_cache_first=imp["try_solve_cache_first"],
         load_only=imp["load_only"],
+        adaptive_regulator_gain=bool(adaptive),
         parent=window,
     )
     _stash_pending_altium_recent(
@@ -5976,6 +5979,26 @@ def _start_launcher_altium_solve(
     worker.failed.connect(window._on_solve_failed)
     worker.finished.connect(window._cleanup_solve_worker)
     worker.start()
+
+
+def _schedule_cli_altium_import(window, target: dict) -> None:
+    """Apply CLI ``gui`` overrides, then import like File > Import Altium."""
+    settings = getattr(window, "_solve_settings", None)
+    if settings is not None:
+        if target.get("mesh_min_angle_deg") is not None:
+            settings.mesh_min_angle_deg = float(target["mesh_min_angle_deg"])
+        if target.get("mesh_max_size_mm") is not None:
+            settings.mesh_max_size_mm = float(target["mesh_max_size_mm"])
+    adaptive = target.get("adaptive_regulator_gain")
+    if adaptive is not None:
+        window._cli_adaptive_regulator_gain = bool(adaptive)
+    pcbdoc = target.get("pcbdoc_path")
+    _open_altium_project_at(
+        window,
+        Path(target["prjpcb_path"]),
+        Path(pcbdoc) if pcbdoc else None,
+        clean=bool(target.get("clean", False)),
+    )
 
 
 def _open_altium_project_at(
@@ -6036,6 +6059,7 @@ def _open_altium_project_at(
         use_design_cache=imp["use_design_cache"],
         try_solve_cache_first=imp["try_solve_cache_first"],
         load_only=imp["load_only"],
+        adaptive_regulator_gain=load_adaptive_regulator_gain(),
         is_import=True,
         dialog_title=imp["dialog_title"],
         dialog_text=imp["dialog_text"],
@@ -27859,63 +27883,22 @@ def _maybe_warn_connectivity_breaks(parent_win, metadata) -> None:
 
 
 def _build_stub_lean_solution_from_loaded(loaded):
-    """Create a minimal :class:`LeanSolution` from a Gerber-derived
-    LoadedProject so the viewer can open BEFORE the user has added any
-    editor directives or pressed Resolve.
+    """Create a minimal :class:`LeanSolution` from a LoadedProject.
 
-    The stub carries one :class:`LeanLayer` per copper layer with the
-    real geometry + conductance, and empty per-layer solution arrays.
-    Pre-solve there is no potentials field to interpolate, so we don't
-    pay for constrained-Delaunay triangulation here — the viewer
-    renders copper from ``metadata['all_copper']`` outline rings (the
-    same overlay the per-layer eye icon drives) until the user adds
-    directives and runs Resolve, at which point the FEM solver does
-    its own seeded triangulation.
-
-    ``solver_info`` carries the ``"stub": True`` sentinel so the viewer
-    can pick the right pre-solve messaging and overlay defaults; legacy
-    "all zeroes" fields are preserved for any code that still checks
-    them.
+    Thin wrapper around
+    :func:`fypa.altium.loader.build_stub_lean_solution_from_loaded` (shared
+    with the CLI ``gui`` path so mesh-failure recovery stays in sync).
     """
-    from fypa.lean_solution import (
-        LeanLayer,
-        LeanLayerSolution,
-        LeanProblem,
-        LeanSolution,
-    )
+    from fypa.altium.loader import build_stub_lean_solution_from_loaded
     log = logging.getLogger(__name__)
-    lean_layers: list[LeanLayer] = []
     t_geom0 = time.monotonic()
-    geom = loaded.geometry
-    log.info("Gerber stub: loaded.geometry access took %.2fs (%d layer(s))",
-             time.monotonic() - t_geom0, len(geom))
-    for L in geom:
-        lean_layers.append(LeanLayer(
-            name=f"{L.name}|(none)",
-            conductance=L.conductance,
-            shape=L.shape,
-            layer_id=L.layer_id,
-            is_plane=L.is_plane,
-            plane_net_name=None,
-        ))
-    lean_solutions = [
-        LeanLayerSolution(
-            vertex_xys=[], triangles=[], potentials=[], power_densities=[],
-        )
-        for _ in geom
-    ]
-    return LeanSolution(
-        problem=LeanProblem(
-            layers=lean_layers,
-            project_name=loaded.project_name,
-        ),
-        layer_solutions=lean_solutions,
-        solver_info={
-            "stub": True,
-            "ground_node_current": 0.0,
-            "residual_norm": 0.0,
-        },
+    stub = build_stub_lean_solution_from_loaded(loaded)
+    log.info(
+        "Stub solution: loaded.geometry access took %.2fs (%d layer(s))",
+        time.monotonic() - t_geom0,
+        len(stub.problem.layers),
     )
+    return stub
 
 
 class _GerberImportCancelled(Exception):
@@ -28284,7 +28267,7 @@ def _perform_gerber_import(parent_window) -> tuple | None:
 
 
 def main(solution, warnings_list=None, metadata=None,
-         gerber_import_target=None) -> int:
+         gerber_import_target=None, altium_import_target=None) -> int:
     """CLI entry — show the viewer for the given Solution and run the Qt
     event loop. Returns the QApplication exit code.
 
@@ -28295,6 +28278,12 @@ def main(solution, warnings_list=None, metadata=None,
     the launcher window opens, then immediately triggers the Gerber-import
     flow. Pass a folder Path or a saved ``.fypa`` Path; pass any non-None
     value to open the file picker without pre-selection.
+
+    ``altium_import_target`` (CLI ``FYPA gui <PrjPcb>``): dict with at least
+    ``prjpcb_path`` and a resolved ``pcbdoc_path`` (silent first-board /
+    ``--pcbdoc`` selection — no multi-board picker). Optional ``clean`` and
+    mesh overrides (only when the user passed ``--mesh-*``). Starts the same
+    File > Import Altium Design worker path after the launcher is shown.
     """
     # Route Python warnings.warn() (e.g. padne's SolverWarning) into the
     # logging system for the whole process. Set once here at startup rather
@@ -28328,6 +28317,12 @@ def main(solution, warnings_list=None, metadata=None,
             # pops over it.
             from PySide6.QtCore import QTimer
             QTimer.singleShot(0, win._on_menu_import_gerber)
+        elif altium_import_target is not None:
+            from PySide6.QtCore import QTimer
+            QTimer.singleShot(
+                0,
+                lambda: _schedule_cli_altium_import(win, altium_import_target),
+            )
     else:
         win = PdnViewer(solution, metadata=metadata)
     win.show()
@@ -28336,6 +28331,13 @@ def main(solution, warnings_list=None, metadata=None,
     # to the window so Windows uses our icon for the taskbar grouping.
     _force_native_window_icon(win)
     _set_window_aumid(win)
+    # ``show`` / a direct solution open: still pop the mesh-failure notice
+    # (launcher import uses ``_on_solve_finished`` instead).
+    if solution is not None and (metadata or {}).get("mesh_failures"):
+        from PySide6.QtCore import QTimer
+        QTimer.singleShot(
+            0, lambda: _maybe_show_mesh_failures(win, metadata),
+        )
     if owns_app:
         return app.exec()
     return 0

--- a/fypa/cli.py
+++ b/fypa/cli.py
@@ -7,13 +7,10 @@ CLI entry point. Subcommands:
   annotations   Parse PDN_* annotations and show resolved terminals.
   load          Full pipeline (extract → geometry → annotations) with a
                 solve-readiness verdict.
-  solve         (Stub) Run FEM solver and save a solution pickle.
-  show          (Stub) Open the interactive solution viewer for a pickled solution.
-  gui           (Stub) Run solver + viewer in one step.
-  paraview      (Stub) Export a pickled solution to ParaView VTK.
-
-The stub subcommands print what blocks them — the C++-replacement mesher port
-is the remaining work.
+  solve         Run the FEM solver and pickle the solution.
+  show          Open the interactive solution viewer for a pickled solution.
+  gui           Open the viewer and import a .PrjPcb (same as File > Import).
+  paraview      Export a pickled solution to ParaView VTK.
 """
 from __future__ import annotations
 
@@ -153,12 +150,28 @@ def _build_parser() -> argparse.ArgumentParser:
                     help="Optional path for a per-layer geometry quicklook PNG.")
     _add_pcbdoc_arg(sp)
 
-    def _add_mesh_args(sp_: argparse.ArgumentParser) -> None:
+    def _add_mesh_args(
+        sp_: argparse.ArgumentParser, *, optional: bool = False,
+    ) -> None:
+        """Add ``--mesh-angle`` / ``--mesh-size`` / ``--adaptive-regulator-gain``.
+
+        When ``optional`` is True (CLI ``gui``), mesh size/angle default to
+        ``None`` so the launcher Settings tab is left alone unless the user
+        passes the flags explicitly.
+        """
         default = _pdn_mesh.Mesher.Config()
-        sp_.add_argument("--mesh-angle", type=float, default=default.minimum_angle,
-                         help="Minimum-angle constraint (degrees) for mesh triangles")
-        sp_.add_argument("--mesh-size", type=float, default=default.maximum_size,
-                         help="Maximum edge size for mesh triangles (mm)")
+        sp_.add_argument(
+            "--mesh-angle", type=float,
+            default=(None if optional else default.minimum_angle),
+            help="Minimum-angle constraint (degrees) for mesh triangles"
+                 + (" (default: Settings tab)" if optional else ""),
+        )
+        sp_.add_argument(
+            "--mesh-size", type=float,
+            default=(None if optional else default.maximum_size),
+            help="Maximum edge size for mesh triangles (mm)"
+                 + (" (default: Settings tab)" if optional else ""),
+        )
         sp_.add_argument(
             "--adaptive-regulator-gain", action="store_true",
             help="Iterate SMPS regulator gain from solved input voltage",
@@ -173,13 +186,16 @@ def _build_parser() -> argparse.ArgumentParser:
     sp = sub.add_parser("show", help="Open the interactive solution viewer")
     sp.add_argument("solution", type=Path)
 
-    sp = sub.add_parser("gui", help="Solve + open the viewer in one step")
+    sp = sub.add_parser(
+        "gui",
+        help="Open the viewer and import a .PrjPcb (same as File > Import)",
+    )
     sp.add_argument("prjpcb", type=Path)
     sp.add_argument("--no-cache", action="store_true",
-                    help="Force a full re-solve even if a matching cached "
-                         "solution exists (default: reuse cache when the "
-                         "project and tool source haven't changed).")
-    _add_mesh_args(sp)
+                    help="Force a clean import (ignore design-info / solve "
+                         "caches) — same as File > Import Altium Design "
+                         "(Clean).")
+    _add_mesh_args(sp, optional=True)
     _add_pcbdoc_arg(sp)
 
     sp = sub.add_parser("paraview", help="Export a pickled solution to ParaView VTK")
@@ -315,23 +331,38 @@ def _solve_loaded(loaded, args) -> tuple[LeanSolution, dict]:
     solution + metadata dict. The padne :class:`Solution` is converted
     to :class:`LeanSolution` immediately so the heavy half-edge mesh
     structures can be garbage-collected before anything downstream
-    touches them — slashes cache pickle size by ~80× on typical boards."""
+    touches them — slashes cache pickle size by ~80× on typical boards.
+
+    On a mesh failure, returns a stub LeanSolution + metadata with
+    ``mesh_failures`` populated (same packaging as the GUI solve worker)
+    so headless ``solve`` can report the bad copper instead of aborting.
+    """
     if not loaded.is_solveable:
         print(loaded.diagnostic_summary(), file=sys.stderr)
         raise SystemExit(1)
+    from fypa.altium.loader import SolveSettings as _SolveSettings
+    settings = _SolveSettings()
+    settings.mesh_min_angle_deg = float(args.mesh_angle)
+    settings.mesh_max_size_mm = float(args.mesh_size)
     mesher_config = _pdn_mesh.Mesher.Config(
-        minimum_angle=args.mesh_angle,
-        maximum_size=args.mesh_size,
+        minimum_angle=settings.mesh_min_angle_deg,
+        maximum_size=settings.mesh_max_size_mm,
     )
     adaptive = bool(getattr(args, "adaptive_regulator_gain", False))
-    (padne_solution, problem, via_segment_records,
-     stub_pieces_by_pair, per_net_layers, adaptive_info) = (
-        solve_problem_adaptive(
-            loaded,
-            mesher_config,
-            adaptive_regulator_gain=adaptive,
+    try:
+        (padne_solution, problem, via_segment_records,
+         stub_pieces_by_pair, per_net_layers, adaptive_info) = (
+            solve_problem_adaptive(
+                loaded,
+                mesher_config,
+                adaptive_regulator_gain=adaptive,
+            )
         )
-    )
+    except _pdn_mesh.MeshingException as mesh_exc:
+        from fypa.altium.loader import package_mesh_failure
+        return package_mesh_failure(
+            loaded, mesh_exc, mesher_config, settings=settings,
+        )
     # Always log the solver diagnostic stats. ground_node_current should be
     # ~0 for a well-posed problem; a large value indicates either an isolated
     # GND copper region (no via path to the chosen reference vertex) or a
@@ -1119,6 +1150,16 @@ def save_solution_file(path: Path, solution, metadata: dict | None) -> None:
 def do_solve(args: argparse.Namespace) -> int:
     loaded = load_project(args.prjpcb, pcbdoc_selector=args.pcbdoc)
     solution, metadata = _solve_loaded(loaded, args)
+    if metadata.get("mesh_failures"):
+        for rec in metadata["mesh_failures"]:
+            summary = rec.get("summary") or "Meshing failed."
+            print(summary, file=sys.stderr)
+        print(
+            "Meshing failed — solution not written. "
+            "Open the project with `gui` to inspect the bad copper.",
+            file=sys.stderr,
+        )
+        return 1
     args.output.parent.mkdir(parents=True, exist_ok=True)
     # HIGHEST_PROTOCOL: pickle protocol 5 (Python 3.8+) gets out-of-band
     # numpy buffer support automatically for ndarray fields inside the
@@ -1140,58 +1181,43 @@ def do_show(args: argparse.Namespace) -> int:
 
 
 def do_gui(args: argparse.Namespace) -> int:
+    """Open the viewer launcher and import ``args.prjpcb`` the same way as
+    File > Import Altium Design (progress dialog, ``_SolveWorker``, mesh-
+    failure stub, caches).
+
+    Respects the persisted "Solve automatically on Altium import" preference
+    — when that is off, the design opens as a stub without meshing (same as
+    File > Import). ``--no-cache`` maps to Import (Clean).
+
+    PcbDoc selection stays non-interactive (first board, or ``--pcbdoc``) so
+    Altium ``Run_FYPA.pas`` / automation never block on a picker. Mesh
+    ``--mesh-angle`` / ``--mesh-size`` are applied only when passed; otherwise
+    the launcher Settings-tab values are used.
+    """
     if not _require_pyside6("gui"):
         return 2
     from fypa import altium_viewer
-    log = logging.getLogger(__name__)
-    pcbdoc_path = _resolve_pcbdoc(args.prjpcb, getattr(args, "pcbdoc", None))
-    log.info("Selected PcbDoc: %s", pcbdoc_path.name)
-    # Two-layer cache check (skip both with --no-cache). The solve fingerprint
-    # captures every input that can change the solve result; the design-info
-    # fingerprint captures only what affects the LoadedProject so an isolated
-    # solver/mesher source edit still reuses the cached extract.
-    from fypa.altium.loader import SolveSettings as _SolveSettings
-    _cli_settings = _SolveSettings()
-    _cli_settings.mesh_min_angle_deg = getattr(
-        args, "mesh_angle", _cli_settings.mesh_min_angle_deg)
-    _cli_settings.mesh_max_size_mm = getattr(
-        args, "mesh_size", _cli_settings.mesh_max_size_mm)
-    solve_fp = _project_fingerprint(args.prjpcb, pcbdoc_path,
-                                    settings=_cli_settings)
-    design_fp = _design_info_fingerprint(args.prjpcb, pcbdoc_path)
-    no_cache = getattr(args, "no_cache", False)
-    if not no_cache:
-        cached = _try_load_cached_solution(args.prjpcb, solve_fp,
-                                            pcbdoc_path=pcbdoc_path)
-        if cached is not None and cached[0] is not None:
-            solution, metadata = cached
-            log.info(
-                "Solve cache hit: reusing solution from %s. Pass --no-cache "
-                "to force a re-solve.",
-                _solve_cache_path(args.prjpcb, pcbdoc_path),
-            )
-            return altium_viewer.main(solution, metadata=metadata) or 0
-        log.info("Solve cache miss; checking design-info cache.")
-    else:
-        log.info("--no-cache: ignoring any cached design info / solution.")
 
-    loaded = None
-    if not no_cache:
-        loaded = _try_load_cached_design_info(args.prjpcb, design_fp,
-                                              pcbdoc_path=pcbdoc_path)
-        if loaded is not None:
-            log.info(
-                "Design-info cache hit: reusing extract from %s.",
-                _design_info_cache_path(args.prjpcb, pcbdoc_path),
-            )
-    if loaded is None:
-        loaded = load_project(args.prjpcb, pcbdoc_selector=str(pcbdoc_path))
-        _save_cached_design_info(args.prjpcb, design_fp, loaded,
-                                  pcbdoc_path=pcbdoc_path)
-    solution, metadata = _solve_loaded(loaded, args)
-    _save_cached_solution(args.prjpcb, solve_fp, solution, metadata,
-                          pcbdoc_path=pcbdoc_path)
-    return altium_viewer.main(solution, metadata=metadata) or 0
+    # Always resolve silently — never open the multi-PcbDoc GUI picker.
+    pcbdoc_path = _resolve_pcbdoc(
+        args.prjpcb, getattr(args, "pcbdoc", None),
+    )
+
+    adaptive = getattr(args, "adaptive_regulator_gain", False)
+    target: dict = {
+        "prjpcb_path": args.prjpcb.resolve(),
+        "pcbdoc_path": pcbdoc_path,
+        "clean": bool(getattr(args, "no_cache", False)),
+        # True only when the flag is passed; otherwise the launcher uses
+        # the persisted Settings-tab preference (same as File > Import).
+        "adaptive_regulator_gain": True if adaptive else None,
+    }
+    # Only override Settings-tab mesh values when the user passed the flags.
+    if getattr(args, "mesh_angle", None) is not None:
+        target["mesh_min_angle_deg"] = float(args.mesh_angle)
+    if getattr(args, "mesh_size", None) is not None:
+        target["mesh_max_size_mm"] = float(args.mesh_size)
+    return altium_viewer.main(None, altium_import_target=target) or 0
 
 
 def do_gerber_gui(args: argparse.Namespace) -> int:

--- a/fypa/solve_subprocess.py
+++ b/fypa/solve_subprocess.py
@@ -108,6 +108,20 @@ def _child_entry(job: SolveJob, q: mp.Queue) -> None:
                 adaptive_regulator_gain=job.adaptive_regulator_gain,
                 stage_callback=lambda m: q.put(("stage", m)),
             )
+        except Exception as exc:
+            # Mesh failures must open the same stub + markers as the in-process
+            # worker — not a raw fail traceback.
+            from pdnsolver import mesh as _pdn_mesh
+            if not isinstance(exc, _pdn_mesh.MeshingException):
+                raise
+            from fypa.altium.loader import package_mesh_failure
+            q.put(("stage", "Meshing failed — opening design…"))
+            stub, fail_md = package_mesh_failure(
+                job.loaded, exc, job.mesher_config,
+                settings=job.settings,
+            )
+            q.put(("ok", stub, fail_md))
+            return
         finally:
             for lg in loggers:
                 lg.removeHandler(handler)
@@ -143,7 +157,8 @@ def run_solve_in_subprocess(
 ) -> tuple[object, object] | None:
     """Run ``job`` in a spawned child, forwarding progress to the callbacks.
 
-    Returns ``(lean_solution, metadata)`` on success, or ``None`` if the caller
+    Returns ``(lean_solution, metadata)`` on success (including a mesh-failure
+    stub with ``metadata["mesh_failures"]``), or ``None`` if the caller
     asked to cancel (``is_cancelled()`` went True) — in which case the child is
     terminated. Raises :class:`SolveSubprocessError` if the child fails or dies
     without a result.

--- a/tests/test_mesh_failure_handling.py
+++ b/tests/test_mesh_failure_handling.py
@@ -180,3 +180,238 @@ def test_activate_mesh_failure_layer_enables_and_selects():
     assert viewer._selected_layer == "Bottom"
     assert viewer.synced_eye and viewer.synced_eye2
     assert _activate_mesh_failure_layer(viewer) is False
+
+
+def test_package_mesh_failure_returns_stub_for_cli_gui_path(monkeypatch):
+    """Mesh-failure packaging must keep Settings in metadata for Setup tab."""
+    from types import SimpleNamespace
+
+    from fypa.altium.loader import SolveSettings, package_mesh_failure
+    from fypa.lean_solution import LeanSolution
+
+    poly = shapely.geometry.box(0.0, 0.0, 2.0, 1.0)
+    geom_layer = SimpleNamespace(
+        name="Bottom Layer",
+        conductance=1.0,
+        shape=poly,
+        layer_id=32,
+        is_plane=False,
+    )
+    loaded = SimpleNamespace(
+        project_name="example",
+        geometry=[geom_layer],
+        extracted=SimpleNamespace(
+            nets=[],
+            stackup=[],
+            board_outline=[],
+            enabled_copper_layer_ids=lambda: [32],
+            tracks=[], arcs=[], vias=[], pads=[], regions=[],
+            pcb_components=[], sch_components=[],
+            prjpcb_path="example.PrjPcb",
+            pcbdoc_path="Main.PcbDoc",
+        ),
+        annotations=SimpleNamespace(
+            directives=[], warnings=[], errors=[],
+            open_loop_rails=[], connectivity_breaks=[],
+        ),
+    )
+
+    # Fake a Problem already attached to the exception (solve_problem_adaptive
+    # path) so package_mesh_failure does not call build_problem.
+    fake_layer = SimpleNamespace(
+        name="Bottom Layer|VIN",
+        geoms=[poly],
+    )
+    fake_problem = SimpleNamespace(layers=[fake_layer], networks=[])
+    per_net = [SimpleNamespace(name="Bottom Layer|VIN", layer_id=32)]
+
+    exc = MeshingException(
+        "triangle aborted",
+        layer_name="Bottom Layer|VIN",
+        layer_index=0,
+        geom_index=0,
+        piece_index=0,
+        bounds=(0.0, 0.0, 2.0, 1.0),
+    )
+    exc.built_problem = fake_problem
+    exc.built_via_segment_records = []
+    exc.built_stub_pieces_by_pair = {}
+    exc.built_per_net_layers = per_net
+
+    def _boom(*_a, **_k):
+        raise AssertionError("build_problem should not run when artifacts exist")
+
+    monkeypatch.setattr(
+        "fypa.altium.loader.build_problem", _boom,
+    )
+    captured_settings = {}
+
+    def _fake_meta(*_a, mesh_failures=None, settings=None, **_k):
+        captured_settings["settings"] = settings
+        return {
+            "mesh_failures": list(mesh_failures or []),
+            "project_name": "example",
+        }
+
+    monkeypatch.setattr(
+        "fypa.altium.loader.build_solve_metadata", _fake_meta,
+    )
+
+    settings = SolveSettings()
+    settings.temperature_c = 85.0
+    stub, metadata = package_mesh_failure(
+        loaded, exc, mesher_config=None, settings=settings,
+    )
+    assert isinstance(stub, LeanSolution)
+    assert stub.solver_info.get("stub") is True
+    assert metadata["mesh_failures"]
+    assert "Bottom Layer|VIN" in (metadata["mesh_failures"][0].get("summary") or "")
+    assert captured_settings["settings"] is settings
+    assert captured_settings["settings"].temperature_c == 85.0
+
+
+def test_solve_loaded_opens_stub_instead_of_raising(monkeypatch):
+    """Headless ``solve`` recovers via package_mesh_failure (no GUI worker)."""
+    from types import SimpleNamespace
+
+    from fypa import cli
+    from fypa.lean_solution import LeanProblem, LeanSolution
+
+    exc = MeshingException("triangle aborted", layer_name="Bottom Layer|VIN")
+    stub = LeanSolution(
+        problem=LeanProblem(layers=[], project_name="example"),
+        layer_solutions=[],
+        solver_info={"stub": True},
+    )
+    fail_md = {"mesh_failures": [{"summary": "bad copper"}]}
+
+    def _raise(*_a, **_k):
+        raise exc
+
+    monkeypatch.setattr(cli, "solve_problem_adaptive", _raise)
+    monkeypatch.setattr(
+        "fypa.altium.loader.package_mesh_failure",
+        lambda *_a, **_k: (stub, fail_md),
+    )
+
+    loaded = SimpleNamespace(is_solveable=True)
+    args = SimpleNamespace(
+        mesh_angle=20.0, mesh_size=1.0, adaptive_regulator_gain=False,
+    )
+    solution, metadata = cli._solve_loaded(loaded, args)
+    assert solution is stub
+    assert metadata["mesh_failures"]
+
+
+def test_do_gui_routes_through_viewer_import(monkeypatch, tmp_path):
+    """CLI ``gui`` must use LauncherWindow + _SolveWorker, not CLI solve."""
+    from pathlib import Path
+    from types import SimpleNamespace
+
+    from fypa import cli
+    import fypa.altium_viewer as av
+
+    prj = tmp_path / "example.PrjPcb"
+    prj.write_text("PcbProject", encoding="utf-8")
+    pcb = tmp_path / "Main.PcbDoc"
+    pcb.write_text("PCB", encoding="utf-8")
+    captured: dict = {}
+
+    def _fake_main(solution, **kwargs):
+        captured["solution"] = solution
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(av, "main", _fake_main)
+    monkeypatch.setattr(cli, "_require_pyside6", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        cli, "_resolve_pcbdoc", lambda *_a, **_k: pcb,
+    )
+
+    args = SimpleNamespace(
+        prjpcb=prj,
+        pcbdoc=None,
+        no_cache=True,
+        mesh_angle=None,
+        mesh_size=None,
+        adaptive_regulator_gain=False,
+    )
+    assert cli.do_gui(args) == 0
+    assert captured["solution"] is None
+    tgt = captured["altium_import_target"]
+    assert Path(tgt["prjpcb_path"]) == prj.resolve()
+    assert Path(tgt["pcbdoc_path"]) == pcb
+    assert tgt["clean"] is True
+    # No --mesh-* → do not clobber launcher Settings.
+    assert "mesh_min_angle_deg" not in tgt
+    assert "mesh_max_size_mm" not in tgt
+    assert tgt["adaptive_regulator_gain"] is None
+
+
+def test_do_gui_applies_explicit_mesh_flags(monkeypatch, tmp_path):
+    from pathlib import Path
+    from types import SimpleNamespace
+
+    from fypa import cli
+    import fypa.altium_viewer as av
+
+    prj = tmp_path / "example.PrjPcb"
+    prj.write_text("PcbProject", encoding="utf-8")
+    pcb = tmp_path / "Main.PcbDoc"
+    pcb.write_text("PCB", encoding="utf-8")
+    captured: dict = {}
+
+    monkeypatch.setattr(
+        av, "main",
+        lambda solution, **kwargs: captured.update(
+            {"solution": solution, **kwargs},
+        ) or 0,
+    )
+    monkeypatch.setattr(cli, "_require_pyside6", lambda *_a, **_k: True)
+    monkeypatch.setattr(cli, "_resolve_pcbdoc", lambda *_a, **_k: pcb)
+
+    args = SimpleNamespace(
+        prjpcb=prj,
+        pcbdoc=None,
+        no_cache=False,
+        mesh_angle=25.0,
+        mesh_size=0.5,
+        adaptive_regulator_gain=True,
+    )
+    assert cli.do_gui(args) == 0
+    tgt = captured["altium_import_target"]
+    assert tgt["mesh_min_angle_deg"] == 25.0
+    assert tgt["mesh_max_size_mm"] == 0.5
+    assert tgt["adaptive_regulator_gain"] is True
+
+
+def test_schedule_cli_altium_import_skips_unset_mesh(monkeypatch, tmp_path):
+    """Unset mesh keys must not rewrite launcher Settings."""
+    from types import SimpleNamespace
+
+    from fypa import altium_viewer as av
+    from fypa.altium.loader import SolveSettings
+
+    settings = SolveSettings()
+    settings.mesh_min_angle_deg = 33.0
+    settings.mesh_max_size_mm = 1.25
+    window = SimpleNamespace(_solve_settings=settings)
+    opened = {}
+
+    monkeypatch.setattr(
+        av, "_open_altium_project_at",
+        lambda win, prj, pcb, *, clean=False: opened.update(
+            {"prj": prj, "pcb": pcb, "clean": clean},
+        ),
+    )
+    pcb = tmp_path / "Main.PcbDoc"
+    pcb.write_text("x", encoding="utf-8")
+    av._schedule_cli_altium_import(window, {
+        "prjpcb_path": tmp_path / "example.PrjPcb",
+        "pcbdoc_path": pcb,
+        "clean": False,
+    })
+    assert settings.mesh_min_angle_deg == 33.0
+    assert settings.mesh_max_size_mm == 1.25
+    assert opened["pcb"] == pcb
+    assert opened["clean"] is False

--- a/tests/test_solve_subprocess.py
+++ b/tests/test_solve_subprocess.py
@@ -51,6 +51,56 @@ def test_child_failure_surfaces_as_error():
     assert "Traceback" in str(exc.value) or "Error" in str(exc.value)
 
 
+def test_child_entry_mesh_failure_returns_stub(monkeypatch):
+    """MeshingException in the child becomes an ok stub, not a fail message."""
+    from types import SimpleNamespace
+
+    from fypa.altium.loader import SolveSettings
+    from fypa.lean_solution import LeanProblem, LeanSolution
+    from pdnsolver import mesh as _pdn_mesh
+    from pdnsolver.mesh import MeshingException
+
+    stub = LeanSolution(
+        problem=LeanProblem(layers=[], project_name="example"),
+        layer_solutions=[],
+        solver_info={"stub": True},
+    )
+    fail_md = {"mesh_failures": [{"summary": "bad copper"}]}
+
+    def _boom(*_a, **_k):
+        raise MeshingException("triangle aborted", layer_name="Top|VIN")
+
+    monkeypatch.setattr(
+        "fypa.altium.loader.solve_problem_adaptive", _boom,
+    )
+    monkeypatch.setattr(
+        "fypa.altium.loader.package_mesh_failure",
+        lambda *_a, **_k: (stub, fail_md),
+    )
+
+    msgs: list = []
+
+    class _Q:
+        def put(self, msg) -> None:
+            msgs.append(msg)
+
+    job = S.SolveJob(
+        loaded=SimpleNamespace(),
+        mesher_config=_pdn_mesh.Mesher.Config(
+            minimum_angle=20.0, maximum_size=1.0,
+        ),
+        settings=SolveSettings(),
+    )
+    S._child_entry(job, _Q())
+    kinds = [m[0] for m in msgs]
+    assert "fail" not in kinds
+    assert ("ok", stub, fail_md) in msgs
+    assert any(
+        m[0] == "stage" and "Meshing failed" in m[1] for m in msgs
+    )
+
+
+
 def test_cancel_returns_none_and_kills_child():
     """Cancelling mid-run terminates the child and returns None."""
     if not SANDBOX.exists():


### PR DESCRIPTION
## Summary
- `FYPA.py gui` / Altium `Run_FYPA.pas` used a separate CLI solve path that aborted on `MeshingException`, so bad copper could not be inspected in the viewer.
- Route CLI `gui` through the same launcher import worker as File > Import, and recover mesh failures (in-process and opt-in subprocess) as a stub with markers.
- Keep PcbDoc selection non-interactive for automation; apply `--mesh-*` only when explicitly passed.

## Test plan
- [ ] `FYPA.py gui path\to\board.PrjPcb` on a board with a known mesh failure → viewer opens with markers/dialog (does not exit)
- [ ] Same project via File > Import → same recovery behaviour
- [ ] Altium `Run_FYPA.pas` on that project → same recovery
- [ ] Multi-PcbDoc project without `--pcbdoc` → first board, no picker
- [ ] Without `--mesh-*`, Settings-tab mesh values are not overwritten
- [ ] Optional: enable solve-in-subprocess → mesh failure still opens stub (not a hard fail dialog)
- [ ] `pytest tests/test_mesh_failure_handling.py tests/test_solve_subprocess.py`