### PR TITLE
Fix capacitance parsing for spaced Altium Value fields

### DIFF
--- a/fypa/caploop/identify.py
+++ b/fypa/caploop/identify.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass
 import shapely.geometry
 import shapely.geometry.base
 
-from fypa.altium.annotations import parse_si_value
+from fypa.altium.annotations import _normalize_si_text, parse_si_value
 from fypa.altium.extract import (
     NO_NET,
     ExtractedProject,
@@ -179,16 +179,24 @@ def _parse_banded_tokens(
     doesn't land in band, retry lower-cased. The band makes this safe: the
     only case-folding hazard is M(ega)→m(illi), and no plausible band
     contains both readings of the same token.
+
+    Altium ``Value`` fields often separate magnitude and unit (``100 nF``,
+    ``2.2 µF``). :func:`_normalize_si_text` collapses that spacing; bare
+    numeric tokens are also merged with the following token before parsing.
     """
     lo, hi = band
-    for token in _TOKEN_SPLIT_RE.split(text):
-        if not token or not any(c.isalpha() for c in token):
-            continue
+    text = str(text).strip()
+    if not text:
+        return None
+
+    def _try_token(token: str) -> float | None:
+        if not token:
+            return None
         token_l = token.lower()
         if require_char is not None and require_char not in token_l:
-            continue
+            return None
         if exclude_char is not None and exclude_char in token_l:
-            continue
+            return None
         for candidate in (token, token_l):
             try:
                 value = parse_si_value(candidate)
@@ -196,6 +204,23 @@ def _parse_banded_tokens(
                 continue
             if lo <= value <= hi:
                 return value
+        return None
+
+    normalized = _normalize_si_text(text)
+    hit = _try_token(normalized)
+    if hit is not None and (normalized != text or any(c.isalpha() for c in text)):
+        return hit
+
+    tokens = [t for t in _TOKEN_SPLIT_RE.split(text) if t]
+    for i, token in enumerate(tokens):
+        if not any(c.isalpha() for c in token) and i + 1 < len(tokens):
+            hit = _try_token(_normalize_si_text(f"{token} {tokens[i + 1]}"))
+            if hit is not None:
+                return hit
+        if any(c.isalpha() for c in token):
+            hit = _try_token(token)
+            if hit is not None:
+                return hit
     return None
 
 

--- a/tests/test_caploop_identify.py
+++ b/tests/test_caploop_identify.py
@@ -484,8 +484,13 @@ def test_a_pad_sized_copper_island_is_not_a_reference_plane():
 
 @pytest.mark.parametrize("params,expect_c,expect_v", [
     ({"Capacitance": "100nF"}, 1e-7, None),
+    ({"Value": "100 nF"}, 1e-7, None),
+    ({"Value": "2.2 \u00b5F"}, 2.2e-6, None),   # micro sign (Altium default)
+    ({"Value": "2.2 uF"}, 2.2e-6, None),
     ({"Value": "0.1uF/16V"}, 1e-7, 16.0),
+    ({"Value": "0.1 uF / 16 V"}, 1e-7, 16.0),
     ({"Comment": "CAP CER 100NF 25V X7R 0402"}, 1e-7, 25.0),
+    ({"Comment": "CAP CER 100 nF 25V X7R"}, 1e-7, 25.0),
     ({"Comment": "4u7", "Voltage": "6V3"}, 4.7e-6, 6.3),
     ({"Value": "10k"}, None, None),          # a resistor value — out of band
     ({"Comment": "0.1"}, None, None),        # bare number — unit-ambiguous


### PR DESCRIPTION
## Summary
- Parse Altium capacitor Value strings that separate magnitude and unit with a space (e.g. 100 nF, 2.2 uF), which previously left the Capacitors tab C column blank and excluded caps from the impedance model.
- Collapse spacing via _normalize_si_text and merge adjacent numeric/unit tokens in composite comments, while still rejecting bare ambiguous numbers like 0.1.

## Test plan
- [x] pytest tests/test_caploop_identify.py::test_parse_cap_params
- [x] pytest tests/test_caploop_impedance.py
- [ ] Reload a board whose caps use spaced Value fields and confirm Capacitors tab shows C (uF) and Impedance no longer lists them as excluded