### PR TITLE
Rank local-net matches so shared channel aliases cannot short SERIES pads

### DIFF
--- a/docs/user-guide/01-sources-and-sinks.md
+++ b/docs/user-guide/01-sources-and-sinks.md
@@ -342,6 +342,8 @@ connectivity so local-net resolution stays scoped to that instance.
 | Same message, project compiles | Wrong local label or wrong sheet | Check the net label on the child sheet matches `PDN_*_NET` exactly |
 | `component … has no pad on net FOO` | Slot-qualified name on the wrong instance (e.g. `FOO.3` on channel 1) | Use the local name `FOO` instead of a channel suffix |
 | `resolved local net … via schematic pins` (warning) | Normal for repeated sheets | No action needed — mapping succeeded |
+| `P and N terminals share pin(s) … Set PDN_P_PINS / PDN_N_PINS` | Compiled netlist aliases the same local label onto both sides of a SERIES part | Set `PDN_P_PINS` / `PDN_N_PINS` (identical on every channel instance), or use the channel-qualified PCB net names |
+| P-terminal resolves to both PCB nets of a two-pin SERIES | Shared bare alias across hierarchy levels (netlist lists the local label on both nets) | Prefer local labels that FYPA can rank by channel token (`VIN` vs `VIN_L`); if the warning persists, add pin overrides |
 
 > If resolution still fails, verify that the component's schematic
 > designator matches the PCB `source_designator` and that the project

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -466,6 +466,10 @@ class TerminalPin:
     # equipotential ``region`` so the terminal couples over the whole pad
     # footprint instead of a single point. ``None`` for degenerate pads.
     pad_polygon: shapely.geometry.Polygon | None = None
+    # Owning PCB component when known. Used so P/N overlap arbitration does
+    # not treat pad ``"1"`` on J2 and pad ``"1"`` on J3 as the same pin
+    # (multi-connector / banana-jack sources).
+    component_designator: str | None = None
 
 
 @dataclass(frozen=True)
@@ -1257,6 +1261,7 @@ def _resolve_terminal(
             net_index=p.net_index,
             point=p.center,
             pad_polygon=_pad_polygon(p, _tl),
+            component_designator=designator,
         )
         for p in matched
     )
@@ -1675,6 +1680,19 @@ def _resolve_two_terminal(
     return p_spec, n_spec
 
 
+def _terminal_pin_overlap_key(pin: TerminalPin) -> str:
+    """Identity for P/N overlap arbitration.
+
+    Pads on different components with the same pad designator (typical for
+    single-pin lab jacks) are distinct. Without ``component_designator``,
+    fall back to pad name only — same as the historical same-footprint case.
+    """
+    pad = pin.pad_designator.upper()
+    if pin.component_designator:
+        return f"{pin.component_designator.upper()}:{pad}"
+    return pad
+
+
 def _arbitrate_overlapping_terminals(
     p_spec: TerminalSpec,
     n_spec: TerminalSpec,
@@ -1688,9 +1706,13 @@ def _arbitrate_overlapping_terminals(
     Ambiguous local-net aliases can make a SERIES P-terminal claim both pads
     of a two-pin part (shorting the series element). Prefer the higher-quality
     match tier; when tiers tie, require explicit ``PDN_*_PINS`` overrides.
+
+    Overlap is by component+pad when ``component_designator`` is set, so a
+    multi-connector SOURCE (P on J2 pad 1, N on J3 pad 1) is not treated as
+    a shorted pair.
     """
-    p_keys = {pin.pad_designator.upper() for pin in p_spec.pins}
-    n_keys = {pin.pad_designator.upper() for pin in n_spec.pins}
+    p_keys = {_terminal_pin_overlap_key(pin) for pin in p_spec.pins}
+    n_keys = {_terminal_pin_overlap_key(pin) for pin in n_spec.pins}
     overlap = p_keys & n_keys
     if not overlap:
         return p_spec, n_spec
@@ -1703,7 +1725,7 @@ def _arbitrate_overlapping_terminals(
     if p_tier < n_tier:
         kept = tuple(
             pin for pin in n_spec.pins
-            if pin.pad_designator.upper() not in overlap
+            if _terminal_pin_overlap_key(pin) not in overlap
         )
         result.warnings.append(
             f"{role_diag}: P/N pin overlap on {overlap_text} "
@@ -1727,7 +1749,7 @@ def _arbitrate_overlapping_terminals(
     if n_tier < p_tier:
         kept = tuple(
             pin for pin in p_spec.pins
-            if pin.pad_designator.upper() not in overlap
+            if _terminal_pin_overlap_key(pin) not in overlap
         )
         result.warnings.append(
             f"{role_diag}: P/N pin overlap on {overlap_text} "

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -577,6 +577,32 @@ def _designator_candidates(
     return candidates
 
 
+# Local-net match quality (lower = better). Used to discard ambiguous
+# alias-only hits when a stronger name-level or PCB-confirmed match exists
+# (shared bare aliases across hierarchy levels are common in multi-channel
+# netlists).
+_LOCAL_NET_TIER_DIRECT = -1   # direct PCB net name or pin override
+_LOCAL_NET_TIER_PCB = 0       # netlist row lists the pad's PCB net name
+_LOCAL_NET_TIER_NAME = 1      # match on compiled net.name (exact/channel)
+_LOCAL_NET_TIER_ALIAS = 2     # match on a netlist alias only
+
+
+def _channel_token_after_prefix(label: str, prefix: str) -> str | None:
+    """If ``label`` is ``prefix`` + ``.``/``_`` + token, return the token."""
+    if not label.startswith(prefix) or len(label) <= len(prefix):
+        return None
+    sep = label[len(prefix)]
+    if sep not in "._":
+        return None
+    token = label[len(prefix) + 1:]
+    return token or None
+
+
+def _designator_has_channel_token(designator: str, token: str) -> bool:
+    """True when ``designator`` ends with ``.token`` or ``_token``."""
+    return designator.endswith("." + token) or designator.endswith("_" + token)
+
+
 def _local_net_label_matches(
     label: str | None,
     local_net_name: str,
@@ -584,9 +610,11 @@ def _local_net_label_matches(
 ) -> bool:
     """True when ``label`` names the same local net class as ``local_net_name``.
 
-    Channel-mangled aliases (``S00A_SL8M7``, ``S00A.4``) are accepted only
-    when an instance designator in ``des_candidates`` carries the same
-    channel token.
+    Channel-mangled aliases (``S00A_SL8M7``, ``S00A.4``, ``VIN_1``) are
+    accepted when an instance designator in ``des_candidates`` carries the
+    same channel *token*, regardless of whether the netlist used ``.`` or
+    ``_`` as the separator (Altium's channel designator format and net
+    annotation can disagree: designator ``R1.1`` vs net ``VIN_1``).
     """
     if not label:
         return False
@@ -594,14 +622,11 @@ def _local_net_label_matches(
     lu = label.upper()
     if lu == ln:
         return True
-    if lu.startswith(ln + "."):
-        channel = lu[len(ln) + 1:]
-        if channel and any(d.endswith("." + channel) for d in des_candidates):
-            return True
-    if lu.startswith(ln + "_"):
-        channel = lu[len(ln) + 1:]
-        if channel and any(d.endswith("_" + channel) for d in des_candidates):
-            return True
+    channel = _channel_token_after_prefix(lu, ln)
+    if channel and any(
+        _designator_has_channel_token(d, channel) for d in des_candidates
+    ):
+        return True
     return False
 
 
@@ -748,13 +773,19 @@ class InstanceLocalNetResolver:
             )
             routed = pads_by.get(pcb_index, {})
             if routed:
-                local_pins = _resolve_local_net_pins(
+                pcb_net_by_pin = {
+                    pin_key: self.proj.nets[pad.net_index].name.upper()
+                    for pin_key, pad in routed.items()
+                    if pad.net_index != NO_NET
+                }
+                local_pins, _tier = _resolve_local_net_pins(
                     self.proj.compiled_netlist,
                     lookup_des,
                     schdoc,
                     local_name,
                     routed_pin_keys=set(routed),
                     pcb_designator=pcb.designator,
+                    pcb_net_by_pin=pcb_net_by_pin or None,
                 )
                 wanted = {p.upper() for p in local_pins}
                 for pin_key, pad in routed.items():
@@ -860,29 +891,53 @@ def _resolve_local_net_pins(
     *,
     routed_pin_keys: set[str] | None = None,
     pcb_designator: str | None = None,
-) -> list[str]:
-    """Return pin designators on ``sch_designator`` for a local sheet net name.
+    pcb_net_by_pin: dict[str, str] | None = None,
+) -> tuple[list[str], int]:
+    """Return ``(pin designators, match_tier)`` for a local sheet net name.
 
     ``pcb_designator`` is the placed instance's (possibly channel-flattened)
     designator, e.g. ``J3_SL8M3``. In a repeated ("multi-channel") sheet the
     compiled netlist keys both terminals and mangled net-label aliases by that
     flattened form, whereas ``sch_designator`` is the base schematic designator
     (``J3``); terminal and alias matching accept either.
+
+    When several netlist nets share a bare local alias, only the strongest
+    match tier is kept:
+
+    * :data:`_LOCAL_NET_TIER_PCB` — the pad's PCB net name itself is a
+      channel form of the local label (``VIN_1`` for local ``VIN``);
+    * :data:`_LOCAL_NET_TIER_NAME` — ``net.name`` matches the local label
+      (exact or channel-token);
+    * :data:`_LOCAL_NET_TIER_ALIAS` — only an alias matched.
+
+    ``pcb_net_by_pin`` maps upper-cased pin designators to upper-cased PCB
+    net names for the PCB-confirmed tier.
     """
     if netlist is None:
-        return []
+        return [], _LOCAL_NET_TIER_ALIAS
     des_candidates = _designator_candidates(sch_designator, pcb_designator)
 
-    pins: list[str] = []
-    seen: set[str] = set()
+    # (tier, pin) candidates; lower tier wins.
+    scored: list[tuple[int, str]] = []
     unscoped_used = False
     for net in netlist.nets:
-        names = [net.name, *getattr(net, "aliases", ())]
-        if not any(_local_net_label_matches(n, local_net_name, des_candidates) for n in names):
+        aliases = list(getattr(net, "aliases", ()) or ())
+        names = [net.name, *aliases]
+        name_match = _local_net_label_matches(
+            net.name, local_net_name, des_candidates,
+        )
+        alias_match = any(
+            _local_net_label_matches(a, local_net_name, des_candidates)
+            for a in aliases
+        )
+        if not name_match and not alias_match:
             continue
         net_sheets = list(getattr(net, "source_sheets", ()) or ())
         if not _sheet_name_matches(schdoc_name, net_sheets):
             continue
+        base_tier = (
+            _LOCAL_NET_TIER_NAME if name_match else _LOCAL_NET_TIER_ALIAS
+        )
         for term in net.terminals:
             if term.designator.upper() not in des_candidates:
                 continue
@@ -890,18 +945,40 @@ def _resolve_local_net_pins(
             key = pin.upper()
             if routed_pin_keys is not None and key not in routed_pin_keys:
                 continue
-            if key not in seen:
-                seen.add(key)
-                pins.append(pin)
-                if schdoc_name and not net_sheets:
-                    unscoped_used = True
+            tier = base_tier
+            if pcb_net_by_pin is not None:
+                pcb_n = pcb_net_by_pin.get(key)
+                # PCB-confirmed only when the physical net name itself is a
+                # channel form of the requested local label (VIN_1 / VIN.1 for
+                # local VIN). Being listed on the row is not enough — every
+                # terminal's primary name is on its own row, so that would
+                # promote alias-only hits to the top tier and erase ranking.
+                if pcb_n and _local_net_label_matches(
+                    pcb_n, local_net_name, des_candidates,
+                ):
+                    tier = _LOCAL_NET_TIER_PCB
+            scored.append((tier, pin))
+            if schdoc_name and not net_sheets:
+                unscoped_used = True
     if unscoped_used:
         log.debug(
             "Local net %r on %s resolved via net(s) lacking sheet provenance; "
             "match scoped by routed pins only.",
             local_net_name, sch_designator,
         )
-    return pins
+    if not scored:
+        return [], _LOCAL_NET_TIER_ALIAS
+    best = min(t for t, _ in scored)
+    pins: list[str] = []
+    seen: set[str] = set()
+    for tier, pin in scored:
+        if tier != best:
+            continue
+        key = pin.upper()
+        if key not in seen:
+            seen.add(key)
+            pins.append(pin)
+    return pins, best
 
 
 def _terminal_layer_for_pad(pad: RawPad, enabled_layers: list[int]) -> int:
@@ -974,7 +1051,7 @@ def _resolve_terminal(
     net_remap: dict[int, int] | None = None,
     sch_lookup_designator: str | None = None,
     schdoc_name: str | None = None,
-) -> tuple[TerminalSpec | None, list[str]]:
+) -> tuple[TerminalSpec | None, list[str], int]:
     """Resolve a terminal to its participating pads.
 
     ``pcb_index`` indexes :attr:`ExtractedProject.pcb_components` — one
@@ -987,17 +1064,21 @@ def _resolve_terminal(
     equivalence classes are *not* consulted here — those belong to the
     solver's net graph, not terminal pin selection.
 
-    Returns ``(spec, errors)``. If ``errors`` is non-empty, ``spec`` is ``None``.
+    Returns ``(spec, errors, match_tier)``. If ``errors`` is non-empty,
+    ``spec`` is ``None``. ``match_tier`` is a :data:`_LOCAL_NET_TIER_*`
+    constant used by :func:`_resolve_two_terminal` to arbitrate overlapping
+    P/N pin sets.
     """
     errors: list[str] = []
     resolved_via_local = False
+    match_tier = _LOCAL_NET_TIER_DIRECT
     designator = proj.pcb_components[pcb_index].designator
     component_pads = _pads_by_component_all(proj).get(pcb_index, [])
     if not component_pads:
         errors.append(
             f"{role_diagnostic}: component {designator!r} has no pads on the PCB"
         )
-        return None, errors
+        return None, errors, match_tier
 
     if override_pins:
         wanted = {pin.upper() for pin in override_pins}
@@ -1009,13 +1090,13 @@ def _resolve_terminal(
                 f"{sorted(missing)}"
             )
         if not matched:
-            return None, errors
+            return None, errors, match_tier
     else:
         if not net_name:
             errors.append(
                 f"{role_diagnostic}: neither a net nor pin overrides supplied"
             )
-            return None, errors
+            return None, errors, match_tier
         net_indices = _net_indices_by_name(proj, net_name)
         matched: list[RawPad] = []
         if net_indices:
@@ -1038,13 +1119,19 @@ def _resolve_terminal(
                 for p in component_pads
                 if p.net_index != NO_NET
             }
-            local_pins = _resolve_local_net_pins(
+            pcb_net_by_pin = {
+                p.designator.upper(): proj.nets[p.net_index].name.upper()
+                for p in component_pads
+                if p.net_index != NO_NET
+            }
+            local_pins, local_tier = _resolve_local_net_pins(
                 proj.compiled_netlist,
                 sch_lookup_designator,
                 schdoc_name or "",
                 net_name,
                 routed_pin_keys=routed_pin_keys or None,
                 pcb_designator=designator,
+                pcb_net_by_pin=pcb_net_by_pin or None,
             )
             if local_pins:
                 wanted_pins = {pin.upper() for pin in local_pins}
@@ -1055,6 +1142,7 @@ def _resolve_terminal(
                 ]
                 if matched:
                     resolved_via_local = True
+                    match_tier = local_tier
                     if warnings is not None:
                         pcb_net_names = sorted({
                             proj.nets[p.net_index].name
@@ -1083,6 +1171,10 @@ def _resolve_terminal(
             )
             if alias_matched:
                 matched = alias_matched
+                # Alias fallback already requires the pad's PCB net on the
+                # netlist row — equivalent to the PCB-confirmed local tier.
+                match_tier = _LOCAL_NET_TIER_PCB
+                resolved_via_local = True
                 if warnings is not None:
                     pcb_net_names = sorted({
                         proj.nets[p.net_index].name
@@ -1138,7 +1230,7 @@ def _resolve_terminal(
                 f"PCB and could not be resolved as a local schematic net."
                 f"{hint}{local_hint}"
             )
-            return None, errors
+            return None, errors, match_tier
 
         if not matched:
             # List the nets that this component's pads actually sit on, so the
@@ -1156,7 +1248,7 @@ def _resolve_terminal(
                 f"{net_name!r}. {designator}'s pads connect to: {pads_listing}"
                 f" (could be due a series part not setup with PDN_ROLE: SERIES)"
             )
-            return None, errors
+            return None, errors, match_tier
 
     pins = tuple(
         TerminalPin(
@@ -1170,7 +1262,7 @@ def _resolve_terminal(
     )
     return TerminalSpec(
         pins=pins, requested_net=net_name, resolved_via_local=resolved_via_local,
-    ), errors
+    ), errors, match_tier
 
 
 def _find_pcb_instances(proj: ExtractedProject, sch_designator: str) -> list[int]:
@@ -1554,7 +1646,7 @@ def _resolve_two_terminal(
     if p_net is None and p_pins is None or n_net is None and n_pins is None:
         return None
 
-    p_spec, p_err = _resolve_terminal(
+    p_spec, p_err, p_tier = _resolve_terminal(
         proj, pcb_index, p_net, p_pins, enabled_layers,
         f"{role_diag} P-terminal",
         warnings=result.warnings,
@@ -1562,7 +1654,7 @@ def _resolve_two_terminal(
         sch_lookup_designator=sch_lookup_designator,
         schdoc_name=schdoc_name,
     )
-    n_spec, n_err = _resolve_terminal(
+    n_spec, n_err, n_tier = _resolve_terminal(
         proj, pcb_index, n_net, n_pins, enabled_layers,
         f"{role_diag} N-terminal",
         warnings=result.warnings,
@@ -1574,7 +1666,94 @@ def _resolve_two_terminal(
     result.errors.extend(n_err)
     if p_spec is None or n_spec is None:
         return None
+
+    p_spec, n_spec = _arbitrate_overlapping_terminals(
+        p_spec, n_spec, p_tier, n_tier, role_diag, result,
+    )
+    if p_spec is None or n_spec is None:
+        return None
     return p_spec, n_spec
+
+
+def _arbitrate_overlapping_terminals(
+    p_spec: TerminalSpec,
+    n_spec: TerminalSpec,
+    p_tier: int,
+    n_tier: int,
+    role_diag: str,
+    result: AnnotationResult,
+) -> tuple[TerminalSpec | None, TerminalSpec | None]:
+    """Drop shared pins from the weaker terminal; error when tiers are equal.
+
+    Ambiguous local-net aliases can make a SERIES P-terminal claim both pads
+    of a two-pin part (shorting the series element). Prefer the higher-quality
+    match tier; when tiers tie, require explicit ``PDN_*_PINS`` overrides.
+    """
+    p_keys = {pin.pad_designator.upper() for pin in p_spec.pins}
+    n_keys = {pin.pad_designator.upper() for pin in n_spec.pins}
+    overlap = p_keys & n_keys
+    if not overlap:
+        return p_spec, n_spec
+
+    overlap_text = ", ".join(sorted(overlap))
+
+    def _label(spec: TerminalSpec) -> str:
+        return spec.requested_net or "?"
+
+    if p_tier < n_tier:
+        kept = tuple(
+            pin for pin in n_spec.pins
+            if pin.pad_designator.upper() not in overlap
+        )
+        result.warnings.append(
+            f"{role_diag}: P/N pin overlap on {overlap_text} "
+            f"(P={_label(p_spec)!r} tier={p_tier}, "
+            f"N={_label(n_spec)!r} tier={n_tier}); "
+            f"kept on P-terminal, dropped from N-terminal"
+        )
+        if not kept:
+            result.errors.append(
+                f"{role_diag}: N-terminal empty after removing overlapping "
+                f"pins {sorted(overlap)}; set PDN_P_PINS / PDN_N_PINS to "
+                f"disambiguate"
+            )
+            return p_spec, None
+        return p_spec, TerminalSpec(
+            pins=kept,
+            requested_net=n_spec.requested_net,
+            resolved_via_local=n_spec.resolved_via_local,
+        )
+
+    if n_tier < p_tier:
+        kept = tuple(
+            pin for pin in p_spec.pins
+            if pin.pad_designator.upper() not in overlap
+        )
+        result.warnings.append(
+            f"{role_diag}: P/N pin overlap on {overlap_text} "
+            f"(P={_label(p_spec)!r} tier={p_tier}, "
+            f"N={_label(n_spec)!r} tier={n_tier}); "
+            f"kept on N-terminal, dropped from P-terminal"
+        )
+        if not kept:
+            result.errors.append(
+                f"{role_diag}: P-terminal empty after removing overlapping "
+                f"pins {sorted(overlap)}; set PDN_P_PINS / PDN_N_PINS to "
+                f"disambiguate"
+            )
+            return None, n_spec
+        return TerminalSpec(
+            pins=kept,
+            requested_net=p_spec.requested_net,
+            resolved_via_local=p_spec.resolved_via_local,
+        ), n_spec
+
+    result.errors.append(
+        f"{role_diag}: P and N terminals share pin(s) {sorted(overlap)} "
+        f"(P={_label(p_spec)!r}, N={_label(n_spec)!r}). "
+        f"Set PDN_P_PINS / PDN_N_PINS to disambiguate"
+    )
+    return None, None
 
 
 def _terminal_mode(params: dict[str, str], idx: int | None,
@@ -1650,7 +1829,7 @@ def _resolve_single_terminal(
     """
     net = _ci_get(params, net_key)
     pins = _split_pin_list(_ci_get(params, pins_key))
-    spec, errs = _resolve_terminal(
+    spec, errs, _tier = _resolve_terminal(
         proj, pcb_index, net, pins, enabled_layers,
         f"{role_diag} terminal", warnings=result.warnings, net_remap=net_remap,
         sch_lookup_designator=sch_lookup_designator,

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1673,6 +1673,29 @@ def test_arbitrate_overlapping_terminals_equal_tier_errors():
     assert any("PDN_P_PINS" in e for e in result.errors)
 
 
+def test_arbitrate_overlapping_terminals_ignores_same_pad_on_other_parts():
+    """Banana-jack style: pad '1' on J2 vs pad '1' on J3 is not an overlap."""
+    p = TerminalSpec(
+        pins=(TerminalPin(
+            "1", 1, 0, Pt2D(0, 0), component_designator="J2",
+        ),),
+        requested_net="+5V",
+    )
+    n = TerminalSpec(
+        pins=(TerminalPin(
+            "1", 1, 1, Pt2D(10, 0), component_designator="J3",
+        ),),
+        requested_net="GND",
+    )
+    result = AnnotationResult()
+    p2, n2 = _arbitrate_overlapping_terminals(
+        p, n, _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_ALIAS, "SOURCE on J2", result,
+    )
+    assert p2 is p and n2 is n
+    assert not result.errors
+    assert not result.warnings
+
+
 def _regulator_proj_with_source(**extra_regulator_params):
     """SOURCE J1 @5V + REGULATOR U2 on +5V→+3V3 with two pads each side."""
     reg_params = {

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -23,11 +23,16 @@ from fypa.altium.annotations import (
     SourceSpec,
     TerminalPin,
     TerminalSpec,
+    _LOCAL_NET_TIER_ALIAS,
+    _LOCAL_NET_TIER_NAME,
+    _LOCAL_NET_TIER_PCB,
+    _arbitrate_overlapping_terminals,
     _collect_supply_voltages_by_net,
     _iter_pdn_parameter_sources,
     _iter_series_bridge_pairs,
     _union_series_bridge_net_indices,
     _lookup_inferred_vin,
+    _local_net_label_matches,
     _require_value,
     _resolve_local_net_pins,
     _resolve_terminal,
@@ -369,7 +374,7 @@ def test_resolve_local_net_pins_finds_alias_on_sheet():
             terminals=[_FakeTerminal("U1", "14"), _FakeTerminal("C1", "1")],
         ),
     ])
-    pins = _resolve_local_net_pins(netlist, "U1", "Power.SchDoc", "+3V3")
+    pins, _tier = _resolve_local_net_pins(netlist, "U1", "Power.SchDoc", "+3V3")
     assert pins == ["14"]
 
 
@@ -393,7 +398,7 @@ def test_resolve_local_net_pins_matches_multichannel_mangled_alias():
             ],
         ),
     ])
-    pins = _resolve_local_net_pins(
+    pins, _tier = _resolve_local_net_pins(
         netlist, "J3", "SL8_Module.SchDoc", "S00A",
         pcb_designator="J3_SL8M7",
     )
@@ -412,7 +417,7 @@ def test_resolve_local_net_pins_mangled_alias_is_channel_scoped():
             terminals=[_FakeTerminal("J3_SL8M7", "29")],
         ),
     ])
-    pins = _resolve_local_net_pins(
+    pins, _tier = _resolve_local_net_pins(
         netlist, "J3", "SL8_Module.SchDoc", "S00A",
         pcb_designator="J3_SL8M7",
     )
@@ -457,12 +462,12 @@ def test_resolve_terminal_local_net_per_channel_instance():
         compiled_netlist=netlist,
     )
     warnings: list[str] = []
-    spec0, err0 = _resolve_terminal(
+    spec0, err0, _t0 = _resolve_terminal(
         proj, 0, "+3V3", None, [1], "SINK P",
         warnings=warnings,
         sch_lookup_designator="U1", schdoc_name="Child.SchDoc",
     )
-    spec1, err1 = _resolve_terminal(
+    spec1, err1, _t1 = _resolve_terminal(
         proj, 1, "+3V3", None, [1], "SINK P",
         warnings=warnings,
         sch_lookup_designator="U1", schdoc_name="Child.SchDoc",
@@ -1033,7 +1038,7 @@ def test_resolve_local_net_pins_dot_channel_alias():
             ],
         ),
     ])
-    pins = _resolve_local_net_pins(
+    pins, _tier = _resolve_local_net_pins(
         netlist, "J3", "Child.SchDoc", "S00A",
         pcb_designator="J3.4",
     )
@@ -1049,7 +1054,7 @@ def test_resolve_local_net_pins_dot_channel_alias_scoped():
             terminals=[_FakeTerminal("J3.4", "29")],
         ),
     ])
-    pins = _resolve_local_net_pins(
+    pins, _tier = _resolve_local_net_pins(
         netlist, "J3", "Child.SchDoc", "S00A",
         pcb_designator="J3.4",
     )
@@ -1143,7 +1148,7 @@ def test_variant_alias_pattern_via_pad_netlist():
         pads=(_pad(0, "1", 0, 0), _pad(0, "2", 1, 1)),
         compiled_netlist=netlist,
     )
-    spec, errors = _resolve_terminal(
+    spec, errors, _tier = _resolve_terminal(
         proj, 0, "MDI.TD_P", None, [1], "SERIES P",
         sch_lookup_designator="R1", schdoc_name="eth.schdoc",
     )
@@ -1188,9 +1193,9 @@ def test_alias_fallback_no_cross_channel_family_leak():
     )
     with patch(
         "fypa.altium.annotations._resolve_local_net_pins",
-        return_value=[],
+        return_value=([], 2),
     ):
-        spec, errors = _resolve_terminal(
+        spec, errors, _tier = _resolve_terminal(
             proj, 0, "+3V3", None, [1], "SINK P",
             sch_lookup_designator="U1", schdoc_name="child2.schdoc",
         )
@@ -1224,9 +1229,9 @@ def test_alias_fallback_flattened_terminal_designator():
     )
     with patch(
         "fypa.altium.annotations._resolve_local_net_pins",
-        return_value=[],
+        return_value=([], 2),
     ):
-        spec, errors = _resolve_terminal(
+        spec, errors, _tier = _resolve_terminal(
             proj, 0, "S00A", None, [1], "SINK P",
             sch_lookup_designator="J3", schdoc_name="Child.SchDoc",
         )
@@ -1434,7 +1439,7 @@ def test_resolve_terminal_no_double_suffix_on_qualified_net():
         pads=(_pad(0, "2", 0, 0),),
         compiled_netlist=None,
     )
-    spec, errors = _resolve_terminal(
+    spec, errors, _tier = _resolve_terminal(
         proj, 0, "VCC_EFUSE.4", None, [1], "SERIES N",
     )
     assert not errors
@@ -1456,7 +1461,7 @@ def test_resolve_terminal_degraded_suffix_guess_warns():
         compiled_netlist=None,
     )
     warnings: list[str] = []
-    spec, errors = _resolve_terminal(
+    spec, errors, _tier = _resolve_terminal(
         proj, 0, "VCC_EFUSE", None, [1], "SERIES N", warnings=warnings,
     )
     assert not errors
@@ -1496,7 +1501,7 @@ def test_local_fallback_skips_no_net_pad():
         ),
         compiled_netlist=netlist,
     )
-    spec, errors = _resolve_terminal(
+    spec, errors, _tier = _resolve_terminal(
         proj, 0, "+3V3", None, [1], "SINK P",
         sch_lookup_designator="U1", schdoc_name="Power.SchDoc",
     )
@@ -1505,6 +1510,167 @@ def test_local_fallback_skips_no_net_pad():
     assert len(spec.pins) == 1
     assert spec.pins[0].pad_designator == "2"
     assert spec.pins[0].net_index == 1
+
+
+def test_local_net_label_matches_separator_agnostic_channel_token():
+    """Net VIN_1 must match local VIN on designator R1.1 (._ separators differ)."""
+    assert _local_net_label_matches("VIN_1", "VIN", {"R1", "R1.1"})
+    assert _local_net_label_matches("VIN.1", "VIN", {"R1", "R1_1"})
+    assert not _local_net_label_matches("VIN_L.1", "VIN", {"R1", "R1.1"})
+    assert _local_net_label_matches("VIN_L.1", "VIN_L", {"R1", "R1.1"})
+
+
+def test_resolve_local_net_pins_prefers_name_over_shared_alias():
+    """Two nets sharing bare alias VIN: keep only the channel name-level match.
+
+    Models the multi-channel case where both sides of a SERIES element carry
+    the same local alias in the compiled netlist. The P label VIN must resolve
+    to pin 2 (net VIN_1) and not also claim pin 1 (net VIN_L.1).
+    """
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="VIN_1",
+            aliases=["VIN", "VIN.1"],
+            source_sheets=["Supply.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "2")],
+        ),
+        _FakeNet(
+            name="VIN_L.1",
+            aliases=["VIN", "VIN.1", "VIN.2"],
+            source_sheets=["Supply.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "1")],
+        ),
+    ])
+    pins, tier = _resolve_local_net_pins(
+        netlist, "R1", "Supply.SchDoc", "VIN",
+        pcb_designator="R1.1",
+        routed_pin_keys={"1", "2"},
+    )
+    assert pins == ["2"]
+    assert tier == _LOCAL_NET_TIER_NAME
+
+    n_pins, n_tier = _resolve_local_net_pins(
+        netlist, "R1", "Supply.SchDoc", "VIN_L",
+        pcb_designator="R1.1",
+        routed_pin_keys={"1", "2"},
+    )
+    assert n_pins == ["1"]
+    assert n_tier == _LOCAL_NET_TIER_NAME
+
+
+def test_resolve_local_net_pins_pcb_confirmed_beats_name():
+    """When PCB net confirms a row, prefer that tier over bare name matches."""
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="OTHER",
+            aliases=["VIN"],
+            source_sheets=["Supply.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "2")],
+        ),
+        _FakeNet(
+            name="VIN_1",
+            aliases=["VIN"],
+            source_sheets=["Supply.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "1")],
+        ),
+    ])
+    pins, tier = _resolve_local_net_pins(
+        netlist, "R1", "Supply.SchDoc", "VIN",
+        pcb_designator="R1.1",
+        routed_pin_keys={"1", "2"},
+        pcb_net_by_pin={"1": "VIN_1", "2": "VOUT"},
+    )
+    # Pin 1 is PCB-confirmed (VIN_1 on the row); pin 2 is alias-only → drop it.
+    assert pins == ["1"]
+    assert tier == _LOCAL_NET_TIER_PCB
+
+
+def test_series_shared_alias_resolves_disjoint_p_n():
+    """SERIES with local VIN / VIN_L must not short both pads of a 2-pin part."""
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="VIN_1",
+            aliases=["VIN", "VIN.1"],
+            source_sheets=["Supply.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "2")],
+        ),
+        _FakeNet(
+            name="VIN_L.1",
+            aliases=["VIN", "VIN.1"],
+            source_sheets=["Supply.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "1")],
+        ),
+    ])
+    proj = _minimal_proj(
+        nets=(RawNet("VIN_1"), RawNet("VIN_L.1")),
+        pcb_components=(
+            RawPcbComponent(
+                designator="R1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1005R", source_designator="R1",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN_R": "10m",
+                    "PDN_P_NET": "VIN",
+                    "PDN_N_NET": "VIN_L",
+                },
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1, 0),  # VIN_L.1
+            _pad(0, "2", 0, 1),  # VIN_1
+        ),
+        compiled_netlist=netlist,
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    series = [d for d in result.directives if isinstance(d, ResistorSpec)]
+    assert len(series) == 1
+    r = series[0]
+    p_nets = {p.net_index for p in r.p.pins}
+    n_nets = {p.net_index for p in r.n.pins}
+    assert p_nets == {0}
+    assert n_nets == {1}
+    assert p_nets.isdisjoint(n_nets)
+
+
+def test_arbitrate_overlapping_terminals_drops_weaker_side():
+    p = TerminalSpec(
+        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),
+              TerminalPin("2", 1, 1, Pt2D(1, 0))),
+        requested_net="VIN",
+        resolved_via_local=True,
+    )
+    n = TerminalSpec(
+        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),),
+        requested_net="VIN_L",
+        resolved_via_local=True,
+    )
+    result = AnnotationResult()
+    p2, n2 = _arbitrate_overlapping_terminals(
+        p, n, _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_NAME, "SERIES on R1.1", result,
+    )
+    assert p2 is not None and n2 is not None
+    assert {pin.pad_designator for pin in p2.pins} == {"2"}
+    assert {pin.pad_designator for pin in n2.pins} == {"1"}
+    assert any("overlap" in w for w in result.warnings)
+    assert not result.errors
+
+
+def test_arbitrate_overlapping_terminals_equal_tier_errors():
+    p = TerminalSpec(
+        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),),
+        requested_net="VIN",
+    )
+    n = TerminalSpec(
+        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),),
+        requested_net="VIN_L",
+    )
+    result = AnnotationResult()
+    p2, n2 = _arbitrate_overlapping_terminals(
+        p, n, _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_ALIAS, "SERIES on R1", result,
+    )
+    assert p2 is None and n2 is None
+    assert any("PDN_P_PINS" in e for e in result.errors)
 
 
 def _regulator_proj_with_source(**extra_regulator_params):


### PR DESCRIPTION
## Summary
- Rank local-net matches (PCB-confirmed > `net.name` > alias-only) so a SERIES P-terminal cannot claim both pads when the compiled netlist shares a bare local alias across hierarchy levels.
- Match channel tokens separator-agnostically (`VIN_1` vs designator `R1.1`).
- Add a P/N pin-overlap guard that keeps the stronger tier or asks for `PDN_P_PINS` / `PDN_N_PINS` when tiers tie.
- Document the failure mode in the local-net troubleshooting table.

Upstream netlist alias collisions are tracked separately in wavenumber-eng/altium_monkey#27; this PR is the FYPA defensive fix.

## Test plan
- [x] `pytest tests/test_annotations.py` (new shared-alias / arbitration cases)
- [ ] Load a multi-channel project with SERIES on local labels that share aliases; confirm P/N pads stay disjoint
- [ ] Optional: pin-override workaround (`PDN_P_PINS` / `PDN_N_PINS`) still works
