### PR TITLE
Add sheet-symbol PDN overrides and multi-instance SMPS Vin inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,8 @@ ExampleDesigns/Sandbox/*
 # would re-leak exactly what it removes. Run it before each commit.
 sanitize_sandbox.ps1
 wiring.json
-scripts/test-*.ps1
+# Local override for test-combined (team config is on team/local branch)
+scripts/test-combined.json
+# Fork-local team config (team/test-combined.json is tracked on team/local only)
+team/*
+!team/test-combined.json

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ sanitize_sandbox.ps1
 wiring.json
 # Local override for test-combined (team config is on team/local branch)
 scripts/test-combined.json
+scripts/py314.local.json
 # Fork-local team config (team/test-combined.json is tracked on team/local only)
 team/*
 !team/test-combined.json

--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ net via pin connectivity (not via `ChannelDesignatorFormatString`). See
 Different values per placement use sheet-symbol parameters
 `PDN_<Designator>_*` (e.g. `PDN_J1_I`) — see
 [Per-instance overrides on sheet symbols](docs/user-guide/01-sources-and-sinks.md#per-instance-overrides-on-sheet-symbols).
+The same overrides apply when the shared role/nets live only on the PCB
+(Blanket / ECO) and the per-instance value is on the sheet symbol.
 
 ### Mixed-role parts (a source and a sink on one component)
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,9 @@ On **repeated schematic sheets** (Altium `REPEAT`), `PDN_*_NET` may use
 the local child-sheet net label; FYPA maps each PCB instance to its slot
 net via pin connectivity (not via `ChannelDesignatorFormatString`). See
 [User guide — Local net names](docs/user-guide/01-sources-and-sinks.md#local-net-names-hierarchical--reused-sheets).
+Different values per placement use sheet-symbol parameters
+`PDN_<Designator>_*` (e.g. `PDN_J1_I`) — see
+[Per-instance overrides on sheet symbols](docs/user-guide/01-sources-and-sinks.md#per-instance-overrides-on-sheet-symbols).
 
 ### Mixed-role parts (a source and a sink on one component)
 

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -1,0 +1,50 @@
+# Fork workflow (team/local)
+
+This fork keeps upstream-ready work separate from local team tooling.
+
+## Branches
+
+| Branch | Purpose |
+|--------|---------|
+| `main` | Tracks upstream; use as the base for upstream pull requests |
+| `team/local` | Shared fork config (combined-test branch list, etc.) |
+
+Daily development can use `team/local` or feature branches. **Do not merge `team/local` into branches you open upstream.**
+
+## Combined local test
+
+`scripts/test-combined.ps1` builds a throwaway branch, merges configured feature branches, runs topology tests and FYPA, then returns to your previous branch. Run it from **any** branch — config is read from `team/local` via `git show` when the file is not in your working tree.
+
+Config lives in `team/test-combined.json` on the `team/local` branch:
+
+```json
+{
+  "baseBranch": "main",
+  "testBranch": "test/combined",
+  "deleteTestBranchFirst": true,
+  "extraFeatureBranches": ["feature/example-a", "fix/example-b"]
+}
+```
+
+- `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate).
+- By default, `baseBranch` and `extraFeatureBranches` are **fetched from `origin`** and merged via `origin/<branch>`. Use `--local-only` to use local branches only.
+- Override any field on the command line, e.g. `-DeleteTestBranchFirst:$false`.
+
+```powershell
+pwsh scripts/test-combined.ps1
+pwsh scripts/test-combined.ps1 --local-only
+```
+
+Resolution order: `scripts/test-combined.json` (local override) → `team/test-combined.json` → `team/local:team/test-combined.json` → example file.
+
+For a one-off local config, copy `scripts/test-combined.example.json` to `scripts/test-combined.json` (gitignored).
+
+## Upstream pull requests
+
+Create the PR branch from upstream, not from `team/local`:
+
+```powershell
+git fetch upstream
+git checkout -b feature/my-fix upstream/main
+git cherry-pick <commit>   # feature commits only
+```

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -14,7 +14,7 @@ Daily development can use `team/local` or feature branches. **Do not merge `team
 
 ## Combined test (`test/combined`)
 
-Feature branches listed in `team/test-combined.json` on `team/local` are merged **once** into the shared `test/combined` branch and pushed to GitHub. Machines only fetch and check out that tip — they do not merge at Altium/FYPA start.
+Feature branches listed in `team/test-combined.json` on `team/local` are merged into the shared `test/combined` branch and pushed to GitHub. Machines only fetch and check out that tip — they do not merge at Altium/FYPA start.
 
 Config on `team/local`:
 
@@ -27,53 +27,54 @@ Config on `team/local`:
 }
 ```
 
-### Maintain (rebuild + publish)
+### Maintain (update + publish)
 
-Uses **origin tips only** (unpushed local commits are ignored). Missing remotes abort.
+Uses **origin tips only**. Prefer **incremental** updates (default): check out `origin/test/combined` and merge only extras not already in that tip. That keeps prior conflict resolutions.
 
 ```powershell
-pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+pwsh scripts/maintain-test-combined.ps1 -Push          # incremental
+pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push # clean recreate from main
+pwsh scripts/maintain-test-combined.ps1 -Abort         # escape stuck merge
 ```
 
-Omit `-Push` to rebuild locally while resolving merge conflicts, then push when clean.
+Omit `-Push` while resolving conflicts locally, then `-Push` when clean.
 
-On conflict, only `.gitignore` and `FYPA.code-workspace` auto-resolve with `--ours`; other conflicts stop the script.
+**Conflicts:** only `.gitignore` / `FYPA.code-workspace` auto-resolve. On a real conflict the script stays on `test/combined` — do not `git switch` away. Either finish (`git add` + `git commit`, then `-Push`) or run `-Abort` to hard-reset to `origin/test/combined` and return to your previous branch.
 
-Config resolution for maintain: `scripts/test-combined.json` (gitignored override) → `team/test-combined.json` → `team/local:team/test-combined.json` → example file.
+Use `-Rebuild` only when `main` moved a lot, extras were removed/reordered, or the tip is broken. Expect to resolve the same conflicts again.
+
+Config resolution: `scripts/test-combined.json` (gitignored) → `team/test-combined.json` → `team/local:team/test-combined.json` → example file.
 
 ### GitHub Action (fork only)
 
-`.github/workflows/maintain-test-combined.yml` lives **only on `team/local`** — never commit it to `main` or to branches destined for an upstream PR.
+`.github/workflows/maintain-test-combined.yml` lives **only on `team/local`** — never commit it to `main` or upstream PR branches.
 
-Triggers: `workflow_dispatch` (use `--ref team/local`) and pushes to `team/local` that touch `team/test-combined.json`. The job runs maintain with `-Rebuild -Push`.
+Triggers: `workflow_dispatch` (`--ref team/local`) and pushes to `team/local` that touch `team/test-combined.json`.
 
 ### Launch (no merge)
 
 ```powershell
 pwsh scripts/test-combined.ps1
-pwsh scripts/test-combined.ps1 -SkipTests
 pwsh scripts/test-combined.ps1 -SkipTests -PrjPcb path\to\Board.PrjPcb
 ```
 
-Checks out `origin/test/combined`, optionally runs topology pytest, then FYPA. `-Rebuild` is not supported here — use maintain.
+Checks out `origin/test/combined` only. `-Rebuild` is not supported — use maintain.
 
-Altium bootstrap (`Run_FYPA.ps1`) calls `scripts/launch-combined-gui.ps1` after clone/`uv sync`: fetch + hard-reset to `origin/test/combined`, then `Launch_GUI.py`.
+Altium (`Run_FYPA.ps1`) calls `scripts/launch-combined-gui.ps1`.
 
 ### Typical flow
 
 1. Push the feature branch to `origin`.
 2. Add it to `team/test-combined.json` on `team/local` and push `team/local`.
-3. Run maintain (or let the Action rebuild) so `origin/test/combined` updates.
-4. On any machine: Altium → Run FYPA → fetch + checkout — done.
+3. `pwsh scripts/maintain-test-combined.ps1 -Push` (incremental).
+4. On any machine: Altium / `test-combined.ps1` → `origin/test/combined`.
 
 Prefer clean feature branches in the JSON (not pre-merged `*-combined` stacks).
 
 ## Upstream pull requests
 
-Create the PR branch from upstream, not from `team/local`:
-
 ```powershell
 git fetch upstream
 git checkout -b feature/my-fix upstream/main
-git cherry-pick <commit>   # feature commits only
+git cherry-pick <commit>
 ```

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -7,15 +7,16 @@ This fork keeps upstream-ready work separate from local team tooling.
 | Branch | Purpose |
 |--------|---------|
 | `main` | Tracks upstream; use as the base for upstream pull requests |
-| `team/local` | Shared fork config (combined-test branch list, etc.) |
+| `team/local` | Shared fork config (combined-test branch list, GH Action for maintain) |
+| `test/combined` | Published integration tip built from the JSON list (force-pushed) |
 
 Daily development can use `team/local` or feature branches. **Do not merge `team/local` into branches you open upstream.**
 
-## Combined local test
+## Combined test (`test/combined`)
 
-`scripts/test-combined.ps1` builds a throwaway branch, merges configured feature branches, optionally runs topology tests and FYPA, then returns to your previous branch. Run it from **any** branch — config is read from `team/local` via `git show` when the file is not in your working tree.
+Feature branches listed in `team/test-combined.json` on `team/local` are merged **once** into the shared `test/combined` branch and pushed to GitHub. Machines only fetch and check out that tip — they do not merge at Altium/FYPA start.
 
-Config lives in `team/test-combined.json` on the `team/local` branch:
+Config on `team/local`:
 
 ```json
 {
@@ -26,22 +27,46 @@ Config lives in `team/test-combined.json` on the `team/local` branch:
 }
 ```
 
-- `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate). Only applies when the branch is rebuilt, not when it is reused.
-- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`**. Each input tip is resolved so **local work is never dropped**: if the local branch is ahead of or diverged from `origin/<branch>`, the local tip is used; if local is behind, `origin/<branch>` is used; branches that exist only locally or only on the remote are accepted either way. If fetch fails (offline), the same resolution runs against existing refs. Use `-LocalOnly` to skip fetch and use local branches only.
-- When the existing `testBranch` tip has a matching stamp (input SHAs + config identity stored as a git note), the branch is **reused** instead of rebuilt. Pass `-Rebuild` to force a clean recreate.
-- Topology pytest runs by default. Pass `-SkipTests` to skip them (the Altium launcher always passes `-SkipTests`).
-- Override any field on the command line, e.g. `-DeleteTestBranchFirst:$false`.
+### Maintain (rebuild + publish)
+
+Uses **origin tips only** (unpushed local commits are ignored). Missing remotes abort.
+
+```powershell
+pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+```
+
+Omit `-Push` to rebuild locally while resolving merge conflicts, then push when clean.
+
+On conflict, only `.gitignore` and `FYPA.code-workspace` auto-resolve with `--ours`; other conflicts stop the script.
+
+Config resolution for maintain: `scripts/test-combined.json` (gitignored override) → `team/test-combined.json` → `team/local:team/test-combined.json` → example file.
+
+### GitHub Action (fork only)
+
+`.github/workflows/maintain-test-combined.yml` lives **only on `team/local`** — never commit it to `main` or to branches destined for an upstream PR.
+
+Triggers: `workflow_dispatch` (use `--ref team/local`) and pushes to `team/local` that touch `team/test-combined.json`. The job runs maintain with `-Rebuild -Push`.
+
+### Launch (no merge)
 
 ```powershell
 pwsh scripts/test-combined.ps1
-pwsh scripts/test-combined.ps1 -LocalOnly
-pwsh scripts/test-combined.ps1 -Rebuild
 pwsh scripts/test-combined.ps1 -SkipTests
+pwsh scripts/test-combined.ps1 -SkipTests -PrjPcb path\to\Board.PrjPcb
 ```
 
-Resolution order: `scripts/test-combined.json` (local override) → `team/test-combined.json` → `team/local:team/test-combined.json` → example file.
+Checks out `origin/test/combined`, optionally runs topology pytest, then FYPA. `-Rebuild` is not supported here — use maintain.
 
-For a one-off local config, copy `scripts/test-combined.example.json` to `scripts/test-combined.json` (gitignored).
+Altium bootstrap (`Run_FYPA.ps1`) calls `scripts/launch-combined-gui.ps1` after clone/`uv sync`: fetch + hard-reset to `origin/test/combined`, then `Launch_GUI.py`.
+
+### Typical flow
+
+1. Push the feature branch to `origin`.
+2. Add it to `team/test-combined.json` on `team/local` and push `team/local`.
+3. Run maintain (or let the Action rebuild) so `origin/test/combined` updates.
+4. On any machine: Altium → Run FYPA → fetch + checkout — done.
+
+Prefer clean feature branches in the JSON (not pre-merged `*-combined` stacks).
 
 ## Upstream pull requests
 

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -27,7 +27,7 @@ Config lives in `team/test-combined.json` on the `team/local` branch:
 ```
 
 - `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate). Only applies when the branch is rebuilt, not when it is reused.
-- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`** and merged via `origin/<branch>`. If fetch fails (offline), local refs are used instead. Use `--local-only` to skip fetch entirely.
+- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`**. Each input tip is resolved so **local work is never dropped**: if the local branch is ahead of or diverged from `origin/<branch>`, the local tip is used; if local is behind, `origin/<branch>` is used; branches that exist only locally or only on the remote are accepted either way. If fetch fails (offline), the same resolution runs against existing refs. Use `--local-only` to skip fetch and use local branches only.
 - When the existing `testBranch` tip has a matching stamp (input SHAs + config identity stored as a git note), the branch is **reused** instead of rebuilt. Pass `-Rebuild` to force a clean recreate.
 - Topology pytest runs by default. Pass `-SkipTests` to skip them (the Altium launcher always passes `-SkipTests`).
 - Override any field on the command line, e.g. `-DeleteTestBranchFirst:$false`.

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -27,14 +27,14 @@ Config lives in `team/test-combined.json` on the `team/local` branch:
 ```
 
 - `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate). Only applies when the branch is rebuilt, not when it is reused.
-- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`**. Each input tip is resolved so **local work is never dropped**: if the local branch is ahead of or diverged from `origin/<branch>`, the local tip is used; if local is behind, `origin/<branch>` is used; branches that exist only locally or only on the remote are accepted either way. If fetch fails (offline), the same resolution runs against existing refs. Use `--local-only` to skip fetch and use local branches only.
+- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`**. Each input tip is resolved so **local work is never dropped**: if the local branch is ahead of or diverged from `origin/<branch>`, the local tip is used; if local is behind, `origin/<branch>` is used; branches that exist only locally or only on the remote are accepted either way. If fetch fails (offline), the same resolution runs against existing refs. Use `-LocalOnly` to skip fetch and use local branches only.
 - When the existing `testBranch` tip has a matching stamp (input SHAs + config identity stored as a git note), the branch is **reused** instead of rebuilt. Pass `-Rebuild` to force a clean recreate.
 - Topology pytest runs by default. Pass `-SkipTests` to skip them (the Altium launcher always passes `-SkipTests`).
 - Override any field on the command line, e.g. `-DeleteTestBranchFirst:$false`.
 
 ```powershell
 pwsh scripts/test-combined.ps1
-pwsh scripts/test-combined.ps1 --local-only
+pwsh scripts/test-combined.ps1 -LocalOnly
 pwsh scripts/test-combined.ps1 -Rebuild
 pwsh scripts/test-combined.ps1 -SkipTests
 ```

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -13,7 +13,7 @@ Daily development can use `team/local` or feature branches. **Do not merge `team
 
 ## Combined local test
 
-`scripts/test-combined.ps1` builds a throwaway branch, merges configured feature branches, runs topology tests and FYPA, then returns to your previous branch. Run it from **any** branch — config is read from `team/local` via `git show` when the file is not in your working tree.
+`scripts/test-combined.ps1` builds a throwaway branch, merges configured feature branches, optionally runs topology tests and FYPA, then returns to your previous branch. Run it from **any** branch — config is read from `team/local` via `git show` when the file is not in your working tree.
 
 Config lives in `team/test-combined.json` on the `team/local` branch:
 
@@ -26,13 +26,17 @@ Config lives in `team/test-combined.json` on the `team/local` branch:
 }
 ```
 
-- `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate).
-- By default, `baseBranch` and `extraFeatureBranches` are **fetched from `origin`** and merged via `origin/<branch>`. Use `--local-only` to use local branches only.
+- `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate). Only applies when the branch is rebuilt, not when it is reused.
+- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`** and merged via `origin/<branch>`. If fetch fails (offline), local refs are used instead. Use `--local-only` to skip fetch entirely.
+- When the existing `testBranch` tip has a matching stamp (input SHAs + config identity stored as a git note), the branch is **reused** instead of rebuilt. Pass `-Rebuild` to force a clean recreate.
+- Topology pytest runs by default. Pass `-SkipTests` to skip them (the Altium launcher always passes `-SkipTests`).
 - Override any field on the command line, e.g. `-DeleteTestBranchFirst:$false`.
 
 ```powershell
 pwsh scripts/test-combined.ps1
 pwsh scripts/test-combined.ps1 --local-only
+pwsh scripts/test-combined.ps1 -Rebuild
+pwsh scripts/test-combined.ps1 -SkipTests
 ```
 
 Resolution order: `scripts/test-combined.json` (local override) → `team/test-combined.json` → `team/local:team/test-combined.json` → example file.

--- a/docs/user-guide/01-sources-and-sinks.md
+++ b/docs/user-guide/01-sources-and-sinks.md
@@ -328,6 +328,63 @@ The same parameters on every instance; FYPA resolves `VCC_EFUSE` to
 `resolved local net 'VCC_EFUSE' via schematic pins ['2'] → PCB net(s) VCC_EFUSE.4`
 is expected and not an error.
 
+#### Per-instance overrides on sheet symbols
+
+When the **same** child sheet is placed more than once and you need a
+**different** current (or voltage / resistance) per placement, put the
+shared role and nets on the child component and override the value on
+each **sheet symbol**:
+
+On `Port.SchDoc`, component `J1`:
+
+| Parameter    | Value   |
+|--------------|---------|
+| `PDN_ROLE`   | `SINK`  |
+| `PDN_I`      | `500mA` |
+| `PDN_P_NET`  | `VBUS`  |
+| `PDN_N_NET`  | `GND`   |
+
+(`PDN_I` on the child is an optional default; each sheet symbol may
+override it.)
+
+On the parent sheet, sheet symbol `CON-A` (file `Port.SchDoc`):
+
+| Parameter   | Value |
+|-------------|-------|
+| `PDN_J1_I`  | `1.5A` |
+
+On sheet symbol `CON-B`:
+
+| Parameter   | Value |
+|-------------|-------|
+| `PDN_J1_I`  | `3A`   |
+
+FYPA binds each override to the PCB instance whose `SOURCEUNIQUEID` path
+contains that sheet symbol's UniqueID (`J1.1`, `J1.2`, …). When
+`SOURCEUNIQUEID` is empty, FYPA falls back to matching sheet-symbol names
+against `SOURCEHIERARCHICALPATH` segments. Only segments that equal a sheet
+symbol name are considered; a leading name is kept when it parents a deeper
+matched symbol (nested sheets), otherwise a root-like leading collision is
+ignored (e.g. a symbol named `main` under path `main\CON-A`). If several
+symbols share a matched name, only one is used (sorted by UniqueID) and a
+warning is emitted — prefer UniqueID binding or unique sheet-symbol names.
+Deeper symbols in a nested UniqueID hierarchy win when both set the same key.
+
+| Form | Meaning |
+|------|---------|
+| `PDN_<Des>_<Key>` | Override for logical designator (e.g. `PDN_J1_I`) |
+| `PDN_<Des>_<n>_<Key>` | Override for indexed PDN channel `n` on that part |
+| `PDN_<Des>_<Key>.N` | REPEAT slot `N` when one sheet symbol expands to several channels |
+
+`<Key>` is any normal PDN suffix (`I`, `V`, `R`, `ROLE`, `P_NET`, …). The
+designator segment must contain a digit (`J1`, `U12`, `U12A`) so ordinary
+keys like `PDN_P_NET` are not misread as overrides.
+
+You can also place a **full** directive on the sheet symbol alone
+(`PDN_J1_ROLE`, `PDN_J1_I`, nets) with no `PDN_*` on the child component.
+A sheet-symbol `PDN_<Des>_ROLE` may also override the child's role for
+that placement only.
+
 #### PCB-only parameters (Blanket / ECO)
 
 When `PDN_*` parameters are pushed to the PCB only (Blanket rule or ECO),

--- a/docs/user-guide/01-sources-and-sinks.md
+++ b/docs/user-guide/01-sources-and-sinks.md
@@ -390,7 +390,9 @@ the **PCB** (Blanket / ECO) and the per-instance value is on the sheet
 symbol — e.g. PCB has `PDN_ROLE=REGULATOR` and nets, sheet symbol has
 `PDN_U1_V=5V`. FYPA merges those into one directive per placement (it does
 not create a second source when both PCB-ECO and a full sheet-symbol
-directive target the same instance).
+directive target the same instance). Different `PDN_<Des>_V` values on
+repeated regulator sheets also feed SMPS Vin inference under the
+instance-expanded output nets (see [Section 4](04-regulators.md)).
 
 A *partial coverage* warning (`PDN covers … (sheet symbol) … but not …`)
 is issued only when FYPA synthesises at least one full sheet-symbol-only

--- a/docs/user-guide/01-sources-and-sinks.md
+++ b/docs/user-guide/01-sources-and-sinks.md
@@ -385,11 +385,28 @@ You can also place a **full** directive on the sheet symbol alone
 A sheet-symbol `PDN_<Des>_ROLE` may also override the child's role for
 that placement only.
 
+Sheet overrides also apply when the shared `PDN_*` parameters live only on
+the **PCB** (Blanket / ECO) and the per-instance value is on the sheet
+symbol — e.g. PCB has `PDN_ROLE=REGULATOR` and nets, sheet symbol has
+`PDN_U1_V=5V`. FYPA merges those into one directive per placement (it does
+not create a second source when both PCB-ECO and a full sheet-symbol
+directive target the same instance).
+
+A *partial coverage* warning (`PDN covers … (sheet symbol) … but not …`)
+is issued only when FYPA synthesises at least one full sheet-symbol-only
+directive and another placement of the same designator still has neither
+PCB-ECO/`PDN_ROLE` nor a complete sheet-symbol directive. Covered
+placements are labelled `(sheet symbol)` or `(PCB-ECO)` in the message.
+Value-only overrides on an ECO'd placement do not trigger that warning for
+bare siblings.
+
 #### PCB-only parameters (Blanket / ECO)
 
 When `PDN_*` parameters are pushed to the PCB only (Blanket rule or ECO),
 FYPA infers the originating schematic sheet from pad ↔ netlist
 connectivity so local-net resolution stays scoped to that instance.
+Combine with sheet-symbol `PDN_<Des>_*` overrides as above when values
+must differ per placement.
 
 #### Troubleshooting local nets
 

--- a/docs/user-guide/04-regulators.md
+++ b/docs/user-guide/04-regulators.md
@@ -94,8 +94,11 @@ When `PDN_GAIN` is omitted, set `PDN_REGULATOR_TYPE`:
 
 For `SMPS`, **Vin_nom** is inferred from an upstream `SOURCE` or
 `REGULATOR` whose output is declared on the same net name as
-`PDN_IN_P_NET` (exact name match — SERIES bridge groups are not used to
-expand Vin lookup or terminal pin resolution). Set
+`PDN_IN_P_NET` (exact / instance-expanded names — undirected bridge groups
+are not used to expand Vin lookup). Multi-channel child sheets that share
+a local switch node name (`LX`) publish per-instance PCB nets (`LX.1`,
+`LX.2`) and filter inductors annotated as `SERIES` (`LX` → `VDD_OUT`)
+propagate voltage onto the instance rails (`VDD_5V0`, `VDD_12V`). Set
 `PDN_REGULATOR_EFFICIENCY` to the datasheet value (default `1.0` = ideal).
 
 Example — 3.3 V buck from a 5 V `SOURCE`:

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -3066,6 +3066,94 @@ def _expanded_supply_net_names(
     return (local_u,)
 
 
+def _primary_supply_net_name(
+    proj: ExtractedProject,
+    local_name: str,
+    pcb_index: int,
+) -> str | None:
+    """One canonical label per placement (avoids alias cross-products)."""
+    names = _expanded_supply_net_names(proj, local_name, pcb_index)
+    if not names:
+        return None
+    local_u = local_name.strip().upper()
+    suffix = _channel_suffix_from_pcb_designator(
+        proj.pcb_components[pcb_index].designator,
+    )
+    if suffix:
+        slotted = f"{local_u}.{suffix}"
+        if slotted in names:
+            return slotted
+    return names[0]
+
+
+def _iter_series_supply_flow_edges(
+    parameter_sources: list[PdnParameterSource],
+    proj: ExtractedProject,
+) -> Iterator[tuple[str, str]]:
+    """Directed SERIES power-flow edges ``(upstream_P, downstream_N)``.
+
+    Covers explicit ``P_NET``/``N_NET`` and single-channel 2-pin autoinfer via
+    :func:`_iter_series_bridge_pairs`, expanding each side to one primary
+    instance label so multi-channel locals do not fan out into a cross-product.
+    """
+    for pcb_idx, p_net, n_net in _iter_series_bridge_pairs(
+        parameter_sources, proj,
+    ):
+        up = _primary_supply_net_name(proj, p_net, pcb_idx)
+        dn = _primary_supply_net_name(proj, n_net, pcb_idx)
+        if up is None or dn is None or up == dn:
+            continue
+        yield up, dn
+    # Sch-only SERIES (no PCB instance yet): keep bare names for unit tests.
+    for comp in parameter_sources:
+        if _pcb_indices_for_source(comp, proj):
+            continue
+        indices = _series_channel_indices(comp)
+        for idx in indices:
+            p_net = _ci_get(comp.parameters, _channel_key("P_NET", idx))
+            n_net = _ci_get(comp.parameters, _channel_key("N_NET", idx))
+            if not p_net or not n_net:
+                continue
+            up = p_net.strip().upper()
+            dn = n_net.strip().upper()
+            if up != dn:
+                yield up, dn
+
+
+def _propagate_series_supply_voltages(
+    supply_map: dict[str, float],
+    parameter_sources: list[PdnParameterSource],
+    proj: ExtractedProject,
+) -> None:
+    """Copy unique voltages along SERIES P→N until fixpoint (in-place).
+
+    Multi-hop chains (``LX.2 → VDD_12V → VDD_12V_S``) resolve regardless of
+    SERIES directive order. Conflicting voltages on one downstream net are
+    dropped (ambiguous).
+    """
+    edges = list(_iter_series_supply_flow_edges(parameter_sources, proj))
+    if not edges:
+        return
+    ambiguous: set[str] = set()
+    changed = True
+    while changed:
+        changed = False
+        for up, dn in edges:
+            if dn in ambiguous:
+                continue
+            v = supply_map.get(up)
+            if v is None:
+                continue
+            existing = supply_map.get(dn)
+            if existing is None:
+                supply_map[dn] = v
+                changed = True
+            elif existing != v:
+                supply_map.pop(dn, None)
+                ambiguous.add(dn)
+                changed = True
+
+
 def _collect_supply_voltages_by_net(
     parameter_sources: list[PdnParameterSource],
     proj: ExtractedProject,
@@ -3081,7 +3169,8 @@ def _collect_supply_voltages_by_net(
 
     When placements exist, each instance expands local OUT / P net names
     (e.g. ``LX`` → ``LX.2``) so multi-channel regulators with different
-    ``PDN_V`` do not collide on the shared child-sheet label.
+    ``PDN_V`` do not collide on the shared child-sheet label. Unique voltages
+    then propagate along directed SERIES edges to fixpoint.
     """
     raw: dict[str, set[float]] = {}
 
@@ -3140,27 +3229,7 @@ def _collect_supply_voltages_by_net(
         if len(voltages) == 1:
             out[net] = next(iter(voltages))
     if proj is not None:
-        # Copy unique voltages across SERIES P→N (e.g. LX.2 → VDD_12V through
-        # a filter inductor) so exact Vin lookup finds the rail without a walk.
-        for comp in parameter_sources:
-            for idx in _series_channel_indices(comp):
-                p_net = _ci_get(comp.parameters, _channel_key("P_NET", idx))
-                n_net = _ci_get(comp.parameters, _channel_key("N_NET", idx))
-                if not p_net or not n_net:
-                    continue
-                for pcb_idx in _pcb_indices_for_source(comp, proj):
-                    for up in _expanded_supply_net_names(proj, p_net, pcb_idx):
-                        v = out.get(up)
-                        if v is None:
-                            continue
-                        for dn in _expanded_supply_net_names(proj, n_net, pcb_idx):
-                            if dn == up:
-                                continue
-                            existing = out.get(dn)
-                            if existing is None:
-                                out[dn] = v
-                            elif existing != v:
-                                out.pop(dn, None)
+        _propagate_series_supply_voltages(out, parameter_sources, proj)
     return out
 
 

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -3086,38 +3086,69 @@ def _primary_supply_net_name(
     return names[0]
 
 
+def _supply_net_lookup_aliases(
+    proj: ExtractedProject | None,
+    local_name: str | None,
+    pcb_index: int | None,
+) -> tuple[str, ...]:
+    """Net names to try for Vin lookup (instance expansions, then bare label)."""
+    if local_name is None or not str(local_name).strip():
+        return ()
+    raw = local_name.strip().upper()
+    if proj is None or pcb_index is None:
+        return (raw,)
+    seen: list[str] = []
+    for name in _expanded_supply_net_names(proj, raw, pcb_index):
+        if name not in seen:
+            seen.append(name)
+    if raw not in seen:
+        seen.append(raw)
+    return tuple(seen)
+
+
 def _iter_series_supply_flow_edges(
     parameter_sources: list[PdnParameterSource],
     proj: ExtractedProject,
-) -> Iterator[tuple[str, str]]:
-    """Directed SERIES power-flow edges ``(upstream_P, downstream_N)``.
+) -> Iterator[tuple[bool, str, str]]:
+    """SERIES supply-flow edges as ``(directed, net_a, net_b)``.
 
-    Covers explicit ``P_NET``/``N_NET`` and single-channel 2-pin autoinfer via
-    :func:`_iter_series_bridge_pairs`, expanding each side to one primary
-    instance label so multi-channel locals do not fan out into a cross-product.
+    Explicit ``P_NET``/``N_NET`` yield directed ``(True, upstream_P, downstream_N)``.
+    Single-channel 2-pin autoinfer (pad order is not power-flow) yields
+    undirected ``(False, net_a, net_b)`` so voltage can copy either way.
+    Each side is expanded to one primary instance label (no alias cross-product).
     """
-    for pcb_idx, p_net, n_net in _iter_series_bridge_pairs(
-        parameter_sources, proj,
-    ):
-        up = _primary_supply_net_name(proj, p_net, pcb_idx)
-        dn = _primary_supply_net_name(proj, n_net, pcb_idx)
-        if up is None or dn is None or up == dn:
-            continue
-        yield up, dn
-    # Sch-only SERIES (no PCB instance yet): keep bare names for unit tests.
     for comp in parameter_sources:
-        if _pcb_indices_for_source(comp, proj):
-            continue
         indices = _series_channel_indices(comp)
+        if not indices:
+            continue
+        pcb_indices = _pcb_indices_for_source(comp, proj)
+        if not pcb_indices:
+            for idx in indices:
+                p_net = _ci_get(comp.parameters, _channel_key("P_NET", idx))
+                n_net = _ci_get(comp.parameters, _channel_key("N_NET", idx))
+                if not p_net or not n_net:
+                    continue
+                up = p_net.strip().upper()
+                dn = n_net.strip().upper()
+                if up != dn:
+                    yield True, up, dn
+            continue
         for idx in indices:
-            p_net = _ci_get(comp.parameters, _channel_key("P_NET", idx))
-            n_net = _ci_get(comp.parameters, _channel_key("N_NET", idx))
-            if not p_net or not n_net:
-                continue
-            up = p_net.strip().upper()
-            dn = n_net.strip().upper()
-            if up != dn:
-                yield up, dn
+            explicit = (
+                _ci_get(comp.parameters, _channel_key("P_NET", idx)) is not None
+                and _ci_get(comp.parameters, _channel_key("N_NET", idx)) is not None
+            )
+            for pcb_idx in pcb_indices:
+                pair = _resolve_series_channel_nets(
+                    comp, proj, idx, pcb_idx, indices,
+                )
+                if pair is None:
+                    continue
+                a = _primary_supply_net_name(proj, pair[0], pcb_idx)
+                b = _primary_supply_net_name(proj, pair[1], pcb_idx)
+                if a is None or b is None or a == b:
+                    continue
+                yield explicit, a, b
 
 
 def _propagate_series_supply_voltages(
@@ -3125,11 +3156,12 @@ def _propagate_series_supply_voltages(
     parameter_sources: list[PdnParameterSource],
     proj: ExtractedProject,
 ) -> None:
-    """Copy unique voltages along SERIES P→N until fixpoint (in-place).
+    """Copy unique voltages along SERIES edges until fixpoint (in-place).
 
-    Multi-hop chains (``LX.2 → VDD_12V → VDD_12V_S``) resolve regardless of
-    SERIES directive order. Conflicting voltages on one downstream net are
-    dropped (ambiguous).
+    Directed edges copy P→N. Undirected autoinfer edges copy whichever side
+    already has a unique voltage onto the other (pad order is not power-flow).
+    Multi-hop chains resolve regardless of SERIES directive order. Conflicting
+    directed voltages on one downstream net are dropped (ambiguous).
     """
     edges = list(_iter_series_supply_flow_edges(parameter_sources, proj))
     if not edges:
@@ -3138,20 +3170,33 @@ def _propagate_series_supply_voltages(
     changed = True
     while changed:
         changed = False
-        for up, dn in edges:
-            if dn in ambiguous:
-                continue
-            v = supply_map.get(up)
-            if v is None:
-                continue
-            existing = supply_map.get(dn)
-            if existing is None:
-                supply_map[dn] = v
-                changed = True
-            elif existing != v:
-                supply_map.pop(dn, None)
-                ambiguous.add(dn)
-                changed = True
+        for directed, a, b in edges:
+            if directed:
+                up, dn = a, b
+                if dn in ambiguous:
+                    continue
+                v = supply_map.get(up)
+                if v is None:
+                    continue
+                existing = supply_map.get(dn)
+                if existing is None:
+                    supply_map[dn] = v
+                    changed = True
+                elif existing != v:
+                    supply_map.pop(dn, None)
+                    ambiguous.add(dn)
+                    changed = True
+            else:
+                if a in ambiguous or b in ambiguous:
+                    continue
+                va = supply_map.get(a)
+                vb = supply_map.get(b)
+                if va is not None and vb is None:
+                    supply_map[b] = va
+                    changed = True
+                elif vb is not None and va is None:
+                    supply_map[a] = vb
+                    changed = True
 
 
 def _collect_supply_voltages_by_net(
@@ -3170,7 +3215,7 @@ def _collect_supply_voltages_by_net(
     When placements exist, each instance expands local OUT / P net names
     (e.g. ``LX`` → ``LX.2``) so multi-channel regulators with different
     ``PDN_V`` do not collide on the shared child-sheet label. Unique voltages
-    then propagate along directed SERIES edges to fixpoint.
+    then propagate along SERIES edges to fixpoint.
     """
     raw: dict[str, set[float]] = {}
 
@@ -3437,6 +3482,7 @@ def _resolve_regulator_gain(
     series_graph: _SeriesVinGraph | None = None,
     proj: ExtractedProject | None = None,
     net_remap: dict[int, int] | None = None,
+    pcb_index: int | None = None,
 ) -> tuple[float, str | None, float, bool] | None:
     """Return ``(gain, regulator_type, efficiency, adaptive_gain_eligible)``."""
     gain_key = _channel_key("GAIN", idx)
@@ -3505,12 +3551,20 @@ def _resolve_regulator_gain(
         return None
 
     lookup_net = (
-        _canonical_supply_net_name(proj, in_p_net, net_remap)
+        _canonical_supply_net_name(proj, in_p_net, net_remap, pcb_index=pcb_index)
         if proj is not None and in_p_net else in_p_net
     )
     vin, vin_failure, vin_hops = _lookup_inferred_vin(
         lookup_net, supply_map, graph=series_graph,
     )
+    if (vin is None or vin <= 0) and proj is not None:
+        for name in _supply_net_lookup_aliases(proj, in_p_net, pcb_index):
+            cand, fail, hops = _lookup_inferred_vin(
+                name, supply_map, graph=series_graph,
+            )
+            if cand is not None and cand > 0:
+                vin, vin_failure, vin_hops = cand, fail, hops
+                break
     in_key = _channel_key("IN_P_NET", idx)
     if vin is None or vin <= 0:
         if vin_failure == "ambiguous":
@@ -3621,6 +3675,8 @@ def _parse_regulator(comp, proj, enabled_layers, result,
             resolved = _resolve_regulator_gain(
                 params, idx, v, in_p_net,
                 supply_map, value_diag, result,
+                series_graph=series_graph, proj=proj, net_remap=net_remap,
+                pcb_index=pcb_idx,
             ) if v is not None else None
             if v is None or resolved is None:
                 continue

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -3123,15 +3123,7 @@ def _iter_series_supply_flow_edges(
             continue
         pcb_indices = _pcb_indices_for_source(comp, proj)
         if not pcb_indices:
-            for idx in indices:
-                p_net = _ci_get(comp.parameters, _channel_key("P_NET", idx))
-                n_net = _ci_get(comp.parameters, _channel_key("N_NET", idx))
-                if not p_net or not n_net:
-                    continue
-                up = p_net.strip().upper()
-                dn = n_net.strip().upper()
-                if up != dn:
-                    yield True, up, dn
+            # Unplaced / DNI SERIES must not invent global Vin edges.
             continue
         for idx in indices:
             explicit = (

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -3143,13 +3143,7 @@ def _collect_supply_voltages_by_net(
         # Copy unique voltages across SERIES P→N (e.g. LX.2 → VDD_12V through
         # a filter inductor) so exact Vin lookup finds the rail without a walk.
         for comp in parameter_sources:
-            part_role_raw = _ci_get(comp.parameters, ROLE_KEY)
-            if part_role_raw is None:
-                continue
-            part_role = part_role_raw.strip().upper()
-            for idx in _discover_channel_indices(comp.parameters, "R"):
-                if _effective_role(comp.parameters, idx, part_role) not in _RESISTOR_LIKE_ROLES:
-                    continue
+            for idx in _series_channel_indices(comp):
                 p_net = _ci_get(comp.parameters, _channel_key("P_NET", idx))
                 n_net = _ci_get(comp.parameters, _channel_key("N_NET", idx))
                 if not p_net or not n_net:

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -1010,7 +1010,9 @@ def _expand_sheet_bound_parameter_sources(
 
     Each clone carries that placement's merged parameters (child + sheet
     overrides), including a possible per-instance ``PDN_ROLE``. Sources that
-    already pin ``pcb_index`` (PCB-ECO / sheet-symbol-only) are left as-is.
+    already pin ``pcb_index`` (PCB-ECO / sheet-symbol-only) stay single-
+    placement, but still receive sheet-symbol overrides so keys like
+    ``PDN_U17_V`` fill ``PDN_V`` for channel discovery.
 
     Only the first schematic source per logical designator is expanded; later
     duplicates (same designator in another SchDoc) are skipped with the same
@@ -1022,7 +1024,10 @@ def _expand_sheet_bound_parameter_sources(
     expanded_logical: set[str] = set()
     for comp in sources:
         if comp.pcb_index is not None:
-            out.append(comp)
+            params = _instance_pdn_params(
+                comp, proj, comp.pcb_index, result=result,
+            )
+            out.append(replace(comp, parameters=params))
             continue
         if not _bound_sheet_symbols_for_designator(proj, comp.lookup_designator):
             out.append(comp)
@@ -1375,12 +1380,17 @@ def _iter_pdn_parameter_sources(
 
     Also synthesises per-placement sources when ``PDN_<Des>_*`` overrides on
     sheet symbols fully define a directive and the child component itself
-    carries no ``PDN_ROLE``. When only some PCB placements of such a
-    designator get a complete sheet-only directive, a warning is recorded
-    if ``result`` is provided.
+    carries no ``PDN_ROLE``. When a PCB placement already has a PCB-ECO
+    source, sheet-symbol-only synthesis skips that ``pcb_index`` (overrides
+    are merged later in :func:`_expand_sheet_bound_parameter_sources`) so the
+    same placement is not parsed twice. When at least one sheet-only source
+    is synthesised and some sibling placement is still uncovered (PCB-ECO
+    placements count as covered), a warning is recorded if ``result`` is
+    provided.
     """
     sources: list[PdnParameterSource] = []
     sch_with_role: set[str] = set()
+    occupied_pcb_indices: set[int] = set()
 
     for comp in proj.sch_components:
         if not _is_pdn_annotated(comp.parameters):
@@ -1419,6 +1429,7 @@ def _iter_pdn_parameter_sources(
             pcb_index=idx,
             sch_lookup_designator=lookup_des,
         ))
+        occupied_pcb_indices.add(idx)
 
     # Sheet-symbol-only directives (child has no PDN_ROLE).
     override_designators: set[str] = set()
@@ -1433,8 +1444,13 @@ def _iter_pdn_parameter_sources(
         pcb_indices = _find_pcb_instances(proj, des)
         if not pcb_indices:
             continue
-        covered: list[int] = []
+        sheet_only_covered: list[int] = []
+        pcb_eco_for_des = occupied_pcb_indices & set(pcb_indices)
         for pcb_idx in pcb_indices:
+            if pcb_idx in occupied_pcb_indices:
+                # PCB-ECO already owns this placement; sheet overrides merge
+                # in expand — do not synthesise a second source.
+                continue
             overrides = _overrides_from_sheet_symbols(proj, pcb_idx, des)
             if not overrides:
                 continue
@@ -1463,27 +1479,37 @@ def _iter_pdn_parameter_sources(
                 pcb_index=pcb_idx,
                 sch_lookup_designator=des,
             ))
-            covered.append(pcb_idx)
-        if (
-            result is not None
-            and covered
-            and len(covered) < len(pcb_indices)
-        ):
-            covered_set = set(covered)
-            covered_names = ", ".join(
-                proj.pcb_components[i].designator for i in covered
-            )
-            missing_names = ", ".join(
-                proj.pcb_components[i].designator
-                for i in pcb_indices if i not in covered_set
-            )
-            _append_warning_once(
-                result,
-                f"{des}: sheet-symbol-only PDN directive covers "
-                f"{covered_names} but not {missing_names} — add "
-                f"PDN_{des}_ROLE (and value/nets) on those sheet symbols "
-                f"or annotate the child component",
-            )
+            occupied_pcb_indices.add(pcb_idx)
+            sheet_only_covered.append(pcb_idx)
+        # Warn only when at least one sheet-only source was synthesised and
+        # some sibling placement is still uncovered (PCB-ECO counts as
+        # covered so mixed ECO + sheet-only does not false-alarm).
+        if result is not None and sheet_only_covered:
+            covered_set = set(sheet_only_covered) | pcb_eco_for_des
+            if len(covered_set) < len(pcb_indices):
+                def _names(indices: set[int] | list[int]) -> str:
+                    return ", ".join(
+                        proj.pcb_components[i].designator
+                        for i in sorted(indices)
+                    )
+
+                covered_parts: list[str] = [
+                    f"{_names(sheet_only_covered)} (sheet symbol)",
+                ]
+                if pcb_eco_for_des:
+                    covered_parts.append(
+                        f"{_names(pcb_eco_for_des)} (PCB-ECO)",
+                    )
+                missing_names = _names(
+                    [i for i in pcb_indices if i not in covered_set],
+                )
+                _append_warning_once(
+                    result,
+                    f"{des}: PDN covers {' and '.join(covered_parts)} "
+                    f"but not {missing_names} — add "
+                    f"PDN_{des}_ROLE (and value/nets) on those sheet symbols "
+                    f"or annotate the child component / PCB",
+                )
     return sources
 
 

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -3033,6 +3033,39 @@ def _parse_resistance(comp, proj, enabled_layers, result,
     return specs
 
 
+
+def _expanded_supply_net_names(
+    proj: ExtractedProject,
+    local_name: str,
+    pcb_index: int,
+) -> tuple[str, ...]:
+    """PCB / local labels for a supply net on one placement.
+
+    Starts from :meth:`InstanceLocalNetResolver.expand_net_names`, then adds a
+    channel-suffixed candidate (``LX`` + designator ``U1.2`` → ``LX.2``) when
+    that net exists on the PCB — needed when the compiled netlist is missing
+    and pin-driven expansion cannot run.
+    """
+    if not local_name or not str(local_name).strip():
+        return ()
+    local_u = local_name.strip().upper()
+    names: list[str] = list(
+        _instance_resolver(proj).expand_net_names(local_u, pcb_index=pcb_index),
+    )
+    pcb = proj.pcb_components[pcb_index]
+    suffix = _channel_suffix_from_pcb_designator(pcb.designator)
+    if suffix:
+        slotted = f"{local_u}.{suffix}"
+        if _net_indices_by_name(proj, slotted) and slotted not in names:
+            names.append(slotted)
+    # Prefer instance-specific labels when present so multi-channel locals
+    # (shared ``LX``) do not collapse to one ambiguous supply-map key.
+    preferred = tuple(n for n in names if n != local_u)
+    if preferred:
+        return preferred
+    return (local_u,)
+
+
 def _collect_supply_voltages_by_net(
     parameter_sources: list[PdnParameterSource],
     proj: ExtractedProject,
@@ -3045,6 +3078,10 @@ def _collect_supply_voltages_by_net(
     :func:`_collect_series_upstream_map`, and the ``IN_P_NET`` a regulator is
     looked up by are all keyed the same way. Without that, any design the
     loader's net-merge pre-pass renamed a rail in would find no Vin at all.
+
+    When placements exist, each instance expands local OUT / P net names
+    (e.g. ``LX`` → ``LX.2``) so multi-channel regulators with different
+    ``PDN_V`` do not collide on the shared child-sheet label.
     """
     raw: dict[str, set[float]] = {}
 
@@ -3061,6 +3098,18 @@ def _collect_supply_voltages_by_net(
         } or {_canonical_supply_net_name(proj, net, net_remap)}
         for key in keys:
             raw.setdefault(key, set()).add(float(voltage))
+
+    def _register_local(comp: PdnParameterSource, local_net: str | None,
+                        voltage: float) -> None:
+        if local_net is None or not str(local_net).strip():
+            return
+        pcb_indices = _pcb_indices_for_source(comp, proj)
+        if not pcb_indices:
+            _register(local_net, voltage, [])
+            return
+        for pcb_idx in pcb_indices:
+            for name in _expanded_supply_net_names(proj, local_net, pcb_idx):
+                _register(name, voltage, [pcb_idx])
 
     for comp in parameter_sources:
         part_role = _part_role_default(comp.parameters)
@@ -3082,14 +3131,42 @@ def _collect_supply_voltages_by_net(
             if eff == "SOURCE":
                 p_net = _ci_get(comp.parameters, _channel_key("P_NET", idx))
                 single_net = _ci_get(comp.parameters, _channel_key("NET", idx))
-                _register(p_net or single_net, v, pcb_indices)
+                _register_local(comp, p_net or single_net, v)
             else:  # REGULATOR
                 out_net = _ci_get(comp.parameters, _channel_key("OUT_P_NET", idx))
-                _register(out_net, v, pcb_indices)
+                _register_local(comp, out_net, v)
     out: dict[str, float] = {}
     for net, voltages in raw.items():
         if len(voltages) == 1:
             out[net] = next(iter(voltages))
+    if proj is not None:
+        # Copy unique voltages across SERIES P→N (e.g. LX.2 → VDD_12V through
+        # a filter inductor) so exact Vin lookup finds the rail without a walk.
+        for comp in parameter_sources:
+            part_role_raw = _ci_get(comp.parameters, ROLE_KEY)
+            if part_role_raw is None:
+                continue
+            part_role = part_role_raw.strip().upper()
+            for idx in _discover_channel_indices(comp.parameters, "R"):
+                if _effective_role(comp.parameters, idx, part_role) not in _RESISTOR_LIKE_ROLES:
+                    continue
+                p_net = _ci_get(comp.parameters, _channel_key("P_NET", idx))
+                n_net = _ci_get(comp.parameters, _channel_key("N_NET", idx))
+                if not p_net or not n_net:
+                    continue
+                for pcb_idx in _pcb_indices_for_source(comp, proj):
+                    for up in _expanded_supply_net_names(proj, p_net, pcb_idx):
+                        v = out.get(up)
+                        if v is None:
+                            continue
+                        for dn in _expanded_supply_net_names(proj, n_net, pcb_idx):
+                            if dn == up:
+                                continue
+                            existing = out.get(dn)
+                            if existing is None:
+                                out[dn] = v
+                            elif existing != v:
+                                out.pop(dn, None)
     return out
 
 
@@ -3222,7 +3299,6 @@ def _collect_series_upstream_map(
 # (fuse, ORing FET, filter, sense resistor); anything longer is far more likely
 # to be a sense/bleed path stitched into a chain than a power path.
 _SERIES_VIN_MAX_HOPS: int = 8
-
 
 def _lookup_inferred_vin(
     in_p_net: str | None,

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -3265,9 +3265,11 @@ def _collect_supply_voltages_by_net(
     for net, voltages in raw.items():
         if len(voltages) == 1:
             out[net] = next(iter(voltages))
+    declared: frozenset[str] = frozenset()
     if proj is not None:
+        declared = frozenset(out.keys())
         _propagate_series_supply_voltages(out, parameter_sources, proj)
-    return out
+    return out, declared
 
 
 def _canonical_supply_net_name(
@@ -3475,6 +3477,7 @@ def _resolve_regulator_gain(
     proj: ExtractedProject | None = None,
     net_remap: dict[int, int] | None = None,
     pcb_index: int | None = None,
+    declared_supply: frozenset[str] | None = None,
 ) -> tuple[float, str | None, float, bool] | None:
     """Return ``(gain, regulator_type, efficiency, adaptive_gain_eligible)``."""
     gain_key = _channel_key("GAIN", idx)
@@ -3542,21 +3545,39 @@ def _resolve_regulator_gain(
         )
         return None
 
+    lookup_map = (
+        {k: v for k, v in supply_map.items() if k in declared_supply}
+        if declared_supply is not None else supply_map
+    )
     lookup_net = (
         _canonical_supply_net_name(proj, in_p_net, net_remap, pcb_index=pcb_index)
         if proj is not None and in_p_net else in_p_net
     )
     vin, vin_failure, vin_hops = _lookup_inferred_vin(
-        lookup_net, supply_map, graph=series_graph,
+        lookup_net, lookup_map, graph=series_graph,
     )
     if (vin is None or vin <= 0) and proj is not None:
         for name in _supply_net_lookup_aliases(proj, in_p_net, pcb_index):
             cand, fail, hops = _lookup_inferred_vin(
-                name, supply_map, graph=series_graph,
+                name, lookup_map, graph=series_graph,
             )
             if cand is not None and cand > 0:
                 vin, vin_failure, vin_hops = cand, fail, hops
                 break
+    if vin is None or vin <= 0:
+        fb_vin, fb_fail, fb_hops = _lookup_inferred_vin(
+            lookup_net, supply_map, graph=None,
+        )
+        if fb_vin is not None and fb_vin > 0:
+            vin, vin_failure, vin_hops = fb_vin, fb_fail, fb_hops
+        elif (vin is None or vin <= 0) and proj is not None:
+            for name in _supply_net_lookup_aliases(proj, in_p_net, pcb_index):
+                fb_vin, fb_fail, fb_hops = _lookup_inferred_vin(
+                    name, supply_map, graph=None,
+                )
+                if fb_vin is not None and fb_vin > 0:
+                    vin, vin_failure, vin_hops = fb_vin, fb_fail, fb_hops
+                    break
     in_key = _channel_key("IN_P_NET", idx)
     if vin is None or vin <= 0:
         if vin_failure == "ambiguous":
@@ -3608,7 +3629,7 @@ def _resolve_regulator_gain(
 
 def _parse_regulator(comp, proj, enabled_layers, result,
                      net_remap=None, supply_map=None, only_indices=None,
-                     series_graph=None):
+                     series_graph=None, declared_supply=None):
     role_diag_base = f"REGULATOR on {comp.designator}"
     discovery = _discovery_pdn_params(comp, proj)
     if _has_single_net_params(discovery, only_indices):
@@ -3668,7 +3689,7 @@ def _parse_regulator(comp, proj, enabled_layers, result,
                 params, idx, v, in_p_net,
                 supply_map, value_diag, result,
                 series_graph=series_graph, proj=proj, net_remap=net_remap,
-                pcb_index=pcb_idx,
+                pcb_index=pcb_idx, declared_supply=declared_supply,
             ) if v is not None else None
             if v is None or resolved is None:
                 continue
@@ -4038,13 +4059,16 @@ def parse_annotations(proj: ExtractedProject,
         proj, parameter_sources, result,
     )
 
-    supply_map = _collect_supply_voltages_by_net(
+    supply_map, declared_supply = _collect_supply_voltages_by_net(
         parameter_sources, proj, net_remap=net_remap,
     )
     series_graph = _collect_series_upstream_map(
         parameter_sources, proj, net_remap=net_remap,
         skip_designators=skip_set,
     )
+    for net in series_graph.ambiguous:
+        if net not in declared_supply:
+            supply_map.pop(net, None)
 
     for comp in parameter_sources:
         if comp.designator.upper() in skip_set:
@@ -4096,18 +4120,29 @@ def parse_annotations(proj: ExtractedProject,
             # the role-appropriate "missing PDN_V / PDN_I / …" diagnostic.
             if not role:
                 continue
-            specs = _PARSER_BY_ROLE[role](comp, proj, enabled_layers, result,
-                                          net_remap=net_remap,
-                                          supply_map=supply_map,
-                                          series_graph=series_graph)
+            parser_kw = dict(
+                net_remap=net_remap,
+                supply_map=supply_map,
+                series_graph=series_graph,
+            )
+            if role == "REGULATOR":
+                parser_kw["declared_supply"] = declared_supply
+            specs = _PARSER_BY_ROLE[role](
+                comp, proj, enabled_layers, result, **parser_kw,
+            )
             result.directives.extend(specs)
         else:
             for chan_role, idxs in channel_roles.items():
-                specs = _PARSER_BY_ROLE[chan_role](
-                    comp, proj, enabled_layers, result,
+                parser_kw = dict(
                     net_remap=net_remap,
-                    supply_map=supply_map, only_indices=idxs,
+                    supply_map=supply_map,
+                    only_indices=idxs,
                     series_graph=series_graph,
+                )
+                if chan_role == "REGULATOR":
+                    parser_kw["declared_supply"] = declared_supply
+                specs = _PARSER_BY_ROLE[chan_role](
+                    comp, proj, enabled_layers, result, **parser_kw,
                 )
                 # Every parser returns a list — empty if the directive failed
                 # to resolve, one element per resolved channel otherwise.

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -110,6 +110,13 @@ one of SOURCE / SINK / SERIES / REGULATOR. (A SOURCE and a SINK on the same
 channels on **different** nets; a genuine input→output converter is better
 modelled with a single REGULATOR channel.)
 
+On **repeated schematic sheets** (Altium ``REPEAT``), ``PDN_*_NET`` may use
+the local child-sheet net label; FYPA maps each PCB instance to its slot
+net via pin connectivity (not via ``ChannelDesignatorFormatString``). See
+the user guide. Sheet-symbol parameters ``PDN_<Designator>_*`` (e.g.
+``PDN_J1_I``) override values per placement — see
+:func:`_overrides_from_sheet_symbols`.
+
 Auto-inference for 2-pin SERIES
 --------------------------------
 For a SERIES directive on a 2-pin component (inductor DCR, 0Ω jumper,
@@ -153,6 +160,7 @@ from fypa.altium.extract import (
     NO_NET,
     Pt2D,
     RawPad,
+    RawSchSheetSymbol,
 )
 from fypa.altium_geometry import _pad_polygon
 
@@ -169,6 +177,15 @@ MULTI_LAYER_PAD_LAYER_ID: int = 74
 # independent channels on one part. Index `None` is the legacy unindexed
 # form; integer indices are additional channels.
 _INDEXED_KEY_RE = re.compile(r"^PDN(\d+)?_(.+)$", re.IGNORECASE)
+
+# Sheet-symbol per-instance override: ``PDN_<Des>_<Key>``, optional indexed
+# channel ``PDN_<Des>_<n>_<Key>``, optional REPEAT slot ``….N``.
+# Designator must contain a digit (``J1``, ``U12A``) so ``PDN_P_NET`` /
+# ``PDN_OUT_P_NET`` stay ordinary component keys.
+_SHEET_OVERRIDE_KEY_RE = re.compile(
+    r"^PDN_([A-Za-z]*\d[A-Za-z0-9]*)_(?:(\d+)_)?(.+?)(?:\.(\d+))?$",
+    re.IGNORECASE,
+)
 
 # Roles that produce a Resistor lumped element (a series resistance between
 # two nets).
@@ -674,6 +691,495 @@ def _channel_suffix_from_pcb_designator(pcb_designator: str) -> str | None:
     return suffix if suffix.isdigit() else None
 
 
+def _source_unique_id_segments(uid_path: str) -> list[str]:
+    """Split PCB ``SOURCEUNIQUEID`` into UniqueID segments (upper-cased)."""
+    if not uid_path:
+        return []
+    normalised = uid_path.replace("/", "\\")
+    return [s.upper() for s in normalised.split("\\") if s.strip()]
+
+
+def _parse_sheet_override_key(
+    name: str,
+) -> tuple[str, int | None, str, int | None] | None:
+    """Parse ``PDN_<Des>[_n]_<Key>[.slot]`` → (des, channel, suffix, slot).
+
+    Returns ``None`` for ordinary component keys (``PDN_I``, ``PDN1_I``,
+    ``PDN_P_NET``, …).
+    """
+    m = _SHEET_OVERRIDE_KEY_RE.match(str(name).strip())
+    if m is None:
+        return None
+    des = m.group(1).upper()
+    ch_raw, suffix, slot_raw = m.group(2), m.group(3), m.group(4)
+    channel = int(ch_raw) if ch_raw else None
+    slot = int(slot_raw) if slot_raw else None
+    return des, channel, suffix.upper(), slot
+
+
+def _sheet_symbol_bind_key(sym: RawSchSheetSymbol) -> str:
+    """Stable identity for a sheet symbol (UniqueID, else sheet_name)."""
+    return (sym.unique_id or "").upper() or f"name:{(sym.sheet_name or '').upper()}"
+
+
+def _schdoc_basename(name: str) -> str:
+    """Case-folded filename of a schematic path (``Port.SchDoc``)."""
+    return Path(name or "").name.lower()
+
+
+def _hierpath_matchable_segments(
+    path: str,
+    symbols: tuple[RawSchSheetSymbol, ...] | list[RawSchSheetSymbol],
+) -> list[str]:
+    """``SOURCEHIERARCHICALPATH`` segments used for sheet-symbol name matching.
+
+    Only segments that equal a sheet-symbol ``sheet_name`` are candidates.
+    A leading candidate is kept when it is the only match, or when it can be
+    the parent of a deeper matched symbol (``child_filename`` ↔ later
+    ``parent_schdoc``). A leading name that is not such a parent is dropped
+    so a root document segment that happens to equal a sheet-symbol name
+    (e.g. ``main`` in ``main\\\\CON-A``) does not bind.
+    """
+    parts = [
+        p.strip().upper()
+        for p in path.replace("/", "\\").split("\\") if p.strip()
+    ]
+    if not parts:
+        return []
+    by_name: dict[str, list[RawSchSheetSymbol]] = {}
+    for sym in symbols:
+        name = (sym.sheet_name or "").strip().upper()
+        if name:
+            by_name.setdefault(name, []).append(sym)
+    hits: list[tuple[int, str]] = [
+        (i, part) for i, part in enumerate(parts) if part in by_name
+    ]
+    if not hits:
+        return []
+    kept: list[str] = []
+    for j, (_idx, part) in enumerate(hits):
+        if j == len(hits) - 1:
+            kept.append(part)
+            continue
+        later_syms = [
+            s for _i, later_name in hits[j + 1:] for s in by_name[later_name]
+        ]
+        if any(
+            _schdoc_basename(later.parent_schdoc)
+            == _schdoc_basename(cand.child_filename)
+            for cand in by_name[part]
+            for later in later_syms
+        ):
+            kept.append(part)
+    out: list[str] = []
+    seen: set[str] = set()
+    for part in kept:
+        if part in seen:
+            continue
+        seen.add(part)
+        out.append(part)
+    return out
+
+
+def _hierpath_symbols_by_name(
+    symbols: tuple[RawSchSheetSymbol, ...] | list[RawSchSheetSymbol],
+    matchable: list[str],
+) -> dict[str, list[RawSchSheetSymbol]]:
+    """Group sheet symbols whose ``sheet_name`` appears in ``matchable``."""
+    order = {part: i for i, part in enumerate(matchable)}
+    by_name: dict[str, list[RawSchSheetSymbol]] = {}
+    for sym in symbols:
+        name = (sym.sheet_name or "").strip().upper()
+        if not name or name not in order:
+            continue
+        by_name.setdefault(name, []).append(sym)
+    return by_name
+
+
+def _pick_hierpath_symbol(
+    group: list[RawSchSheetSymbol],
+) -> RawSchSheetSymbol:
+    """Deterministic winner among same-named hierpath candidates."""
+    return sorted(
+        group,
+        key=lambda s: (
+            (s.unique_id or "").upper(),
+            (s.parent_schdoc or "").upper(),
+        ),
+    )[0]
+
+
+def _hierpath_ambiguous_loser_keys(proj: ExtractedProject) -> set[str]:
+    """Bind keys of symbols discarded when several share a hierpath name."""
+    symbols = getattr(proj, "sch_sheet_symbols", ()) or ()
+    losers: set[str] = set()
+    for pcb in proj.pcb_components:
+        if _source_unique_id_segments(pcb.source_unique_id):
+            continue
+        path = pcb.source_hierarchical_path or ""
+        matchable = _hierpath_matchable_segments(path, symbols)
+        if not matchable:
+            continue
+        by_name = _hierpath_symbols_by_name(symbols, matchable)
+        for group in by_name.values():
+            if len(group) < 2:
+                continue
+            winner = _pick_hierpath_symbol(group)
+            win_key = _sheet_symbol_bind_key(winner)
+            for sym in group:
+                key = _sheet_symbol_bind_key(sym)
+                if key != win_key:
+                    losers.add(key)
+    return losers
+
+
+def _sheet_symbols_for_pcb(
+    proj: ExtractedProject, pcb_index: int,
+) -> list[RawSchSheetSymbol]:
+    """Sheet symbols bound to this PCB placement.
+
+    Primary: UniqueID segments in ``SOURCEUNIQUEID`` (shallow→deep).
+    Fallback when that path is empty: ``SOURCEHIERARCHICALPATH`` segments
+    that match sheet-symbol names (see :func:`_hierpath_matchable_segments`).
+    When several symbols share a matched name, only the first in a
+    deterministic order (UniqueID, then parent sheet) is kept — see
+    :func:`_warn_ambiguous_hierpath_sheet_symbols`.
+    """
+    pcb = proj.pcb_components[pcb_index]
+    symbols = getattr(proj, "sch_sheet_symbols", ()) or ()
+    segments = _source_unique_id_segments(pcb.source_unique_id)
+    if segments:
+        order = {seg: i for i, seg in enumerate(segments)}
+        matched = [
+            sym for sym in symbols
+            if sym.unique_id and sym.unique_id.upper() in order
+        ]
+        matched.sort(key=lambda s: order[s.unique_id.upper()])
+        return matched
+
+    path = pcb.source_hierarchical_path or ""
+    matchable = _hierpath_matchable_segments(path, symbols)
+    if not matchable:
+        return []
+    order = {part: i for i, part in enumerate(matchable)}
+    by_name = _hierpath_symbols_by_name(symbols, matchable)
+    matched = []
+    for name in sorted(by_name, key=lambda n: order[n]):
+        matched.append(_pick_hierpath_symbol(by_name[name]))
+    return matched
+
+
+def _bound_sheet_symbols_for_designator(
+    proj: ExtractedProject, logical_designator: str,
+) -> list[RawSchSheetSymbol]:
+    """Sheet symbols that bind to at least one PCB placement of ``designator``."""
+    target = logical_designator.upper()
+    seen: set[str] = set()
+    out: list[RawSchSheetSymbol] = []
+    for i, pcb in enumerate(proj.pcb_components):
+        lookup = (pcb.source_designator or pcb.designator).upper()
+        if lookup != target:
+            continue
+        for sym in _sheet_symbols_for_pcb(proj, i):
+            key = _sheet_symbol_bind_key(sym)
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(sym)
+    return out
+
+
+def _overrides_from_sheet_symbols(
+    proj: ExtractedProject,
+    pcb_index: int,
+    logical_designator: str,
+    result: AnnotationResult | None = None,
+) -> dict[str, str]:
+    """Map normal ``PDN_*`` keys ← sheet-symbol overrides for one placement.
+
+    Deeper sheet symbols in ``SOURCEUNIQUEID`` overwrite shallower ones for
+    the same key. REPEAT-qualified keys (``.N``) apply only when the PCB
+    designator's numeric channel suffix matches ``N``. When a slot-qualified
+    key cannot be matched because the designator has no numeric suffix,
+    a warning is recorded (once per key) if ``result`` is provided.
+    """
+    target = logical_designator.upper()
+    pcb = proj.pcb_components[pcb_index]
+    slot_str = _channel_suffix_from_pcb_designator(pcb.designator)
+    slot = int(slot_str) if slot_str is not None else None
+    out: dict[str, str] = {}
+    for sym in _sheet_symbols_for_pcb(proj, pcb_index):
+        for raw_key, raw_val in (sym.parameters or {}).items():
+            parsed = _parse_sheet_override_key(raw_key)
+            if parsed is None:
+                continue
+            des, channel, suffix, rep_slot = parsed
+            if des != target:
+                continue
+            if rep_slot is not None:
+                if slot is None:
+                    if result is not None:
+                        _append_warning_once(
+                            result,
+                            f"sheet symbol {sym.sheet_name!r} "
+                            f"({sym.parent_schdoc}): {raw_key} ignored — "
+                            f"PCB designator {pcb.designator!r} has no "
+                            f"numeric channel suffix (expected e.g. "
+                            f"{des}.{rep_slot})",
+                        )
+                    continue
+                if rep_slot != slot:
+                    continue
+            out[_channel_key(suffix, channel)] = raw_val
+    return out
+
+
+def _instance_pdn_params(
+    comp: PdnParameterSource,
+    proj: ExtractedProject,
+    pcb_index: int,
+    result: AnnotationResult | None = None,
+) -> dict[str, str]:
+    """Child (or PCB-ECO) parameters merged with sheet-symbol overrides."""
+    merged = dict(comp.parameters)
+    if getattr(proj, "sch_sheet_symbols", None):
+        overrides = _overrides_from_sheet_symbols(
+            proj, pcb_index, comp.lookup_designator, result=result,
+        )
+        merged.update(overrides)
+        _strip_stale_cross_role_values(merged, overrides)
+    return merged
+
+
+def _strip_stale_cross_role_values(
+    params: dict[str, str],
+    overrides: dict[str, str],
+) -> None:
+    """Drop params illegal for the new role when an override sets ``PDN[_n]_ROLE``.
+
+    Clears other roles' value keys (e.g. leftover ``PDN_I`` after a switch to
+    SOURCE) and REGULATOR-only terminals / options when leaving REGULATOR.
+    SOURCE and REGULATOR both allow ``V``.
+    """
+    role_channels: set[int | None] = set()
+    for key in overrides:
+        m = _INDEXED_KEY_RE.match(str(key).strip())
+        if m is None or m.group(2).upper() != "ROLE":
+            continue
+        role_channels.add(int(m.group(1)) if m.group(1) else None)
+    if not role_channels:
+        return
+    part_role = _part_role_default(params)
+    for idx in role_channels:
+        eff = _effective_role(params, idx, part_role)
+        if eff not in _KNOWN_SUFFIXES_BY_ROLE:
+            continue
+        allowed = _KNOWN_SUFFIXES_BY_ROLE[eff] | {"ROLE"}
+        for key in list(params):
+            m = _INDEXED_KEY_RE.match(str(key).strip())
+            if m is None:
+                continue
+            key_idx = int(m.group(1)) if m.group(1) else None
+            if key_idx != idx:
+                continue
+            if m.group(2).upper() not in allowed:
+                params.pop(key, None)
+
+
+def _discovery_pdn_params(
+    comp: PdnParameterSource,
+    proj: ExtractedProject,
+) -> dict[str, str]:
+    """Parameters used for role / channel discovery.
+
+    Sheet-bound placements are expanded to per-PCB sources in
+    :func:`_expand_sheet_bound_parameter_sources` with overrides already
+    merged, so discovery must not union keys across sibling instances
+    (that would invent indexed channels on placements that never set them).
+    """
+    _ = proj
+    return dict(comp.parameters)
+
+
+def _expand_sheet_bound_parameter_sources(
+    proj: ExtractedProject,
+    sources: list[PdnParameterSource],
+    result: AnnotationResult,
+) -> list[PdnParameterSource]:
+    """Clone sheet-bound logical sources into one source per PCB placement.
+
+    Each clone carries that placement's merged parameters (child + sheet
+    overrides), including a possible per-instance ``PDN_ROLE``. Sources that
+    already pin ``pcb_index`` (PCB-ECO / sheet-symbol-only) are left as-is.
+
+    Only the first schematic source per logical designator is expanded; later
+    duplicates (same designator in another SchDoc) are skipped with the same
+    warning as the non-sheet path, so expand cannot multiply directives.
+    """
+    if not getattr(proj, "sch_sheet_symbols", None):
+        return sources
+    out: list[PdnParameterSource] = []
+    expanded_logical: set[str] = set()
+    for comp in sources:
+        if comp.pcb_index is not None:
+            out.append(comp)
+            continue
+        if not _bound_sheet_symbols_for_designator(proj, comp.lookup_designator):
+            out.append(comp)
+            continue
+        key = comp.lookup_designator.upper()
+        if key in expanded_logical:
+            _append_warning_once(
+                result,
+                f"{comp.designator}: appears in multiple schdocs with "
+                f"PDN_ROLE — only the first occurrence is used",
+            )
+            continue
+        indices = _find_pcb_instances(proj, comp.lookup_designator)
+        if not indices:
+            out.append(comp)
+            continue
+        expanded_logical.add(key)
+        for pcb_idx in indices:
+            params = _instance_pdn_params(comp, proj, pcb_idx, result=result)
+            out.append(replace(comp, parameters=params, pcb_index=pcb_idx))
+    return out
+
+
+def _sibling_pcb_count(proj: ExtractedProject, logical_designator: str) -> int:
+    """How many PCB placements share this schematic designator."""
+    return len(_find_pcb_instances(proj, logical_designator))
+
+
+def _sch_component_for_designator(
+    proj: ExtractedProject, designator: str, child_filename: str,
+):
+    """Best-effort schematic component row for ``designator`` on a child sheet."""
+    des_u = designator.upper()
+    child_base = Path(child_filename).name.lower() if child_filename else ""
+    fallback = None
+    for sc in proj.sch_components:
+        if sc.designator.upper() != des_u:
+            continue
+        if child_base and Path(sc.schdoc_name).name.lower() == child_base:
+            return sc
+        if fallback is None:
+            fallback = sc
+    return fallback
+
+
+def _append_error_once(result: AnnotationResult, msg: str) -> None:
+    if msg not in result.errors:
+        result.errors.append(msg)
+
+
+def _append_warning_once(result: AnnotationResult, msg: str) -> None:
+    if msg not in result.warnings:
+        result.warnings.append(msg)
+
+
+def _warn_orphan_sheet_overrides(
+    proj: ExtractedProject, result: AnnotationResult,
+) -> None:
+    """Warn when sheet-symbol ``PDN_<Des>_*`` keys match no PCB placement.
+
+    Binding is the same as parse time: UniqueID in ``SOURCEUNIQUEID``, or
+    ``sheet_name`` in ``SOURCEHIERARCHICALPATH`` when the UniqueID path is empty.
+    Symbols discarded only as same-name hierpath losers skip the *unbound*
+    warning (covered by :func:`_warn_ambiguous_hierpath_sheet_symbols`) but
+    still warn when their designator targets no PCB component.
+    """
+    bound_keys: set[str] = set()
+    for i in range(len(proj.pcb_components)):
+        for sym in _sheet_symbols_for_pcb(proj, i):
+            bound_keys.add(_sheet_symbol_bind_key(sym))
+    ambiguous_losers = _hierpath_ambiguous_loser_keys(proj)
+    logical_on_pcb = {
+        (pcb.source_designator or pcb.designator).upper()
+        for pcb in proj.pcb_components
+    }
+    for sym in getattr(proj, "sch_sheet_symbols", ()) or ():
+        bind_key = _sheet_symbol_bind_key(sym)
+        is_ambig_loser = bind_key in ambiguous_losers
+        missing_bind_keys: list[str] = []
+        missing_des_keys: dict[str, list[str]] = {}
+        for raw_key in (sym.parameters or ()):
+            parsed = _parse_sheet_override_key(raw_key)
+            if parsed is None:
+                continue
+            des, _ch, _suf, _slot = parsed
+            if bind_key not in bound_keys:
+                if is_ambig_loser:
+                    # Unbound is explained by the ambiguous-name warning; still
+                    # flag designators that match no PCB component.
+                    if des not in logical_on_pcb:
+                        missing_des_keys.setdefault(des, []).append(raw_key)
+                else:
+                    missing_bind_keys.append(raw_key)
+                continue
+            if des not in logical_on_pcb:
+                missing_des_keys.setdefault(des, []).append(raw_key)
+        if not missing_bind_keys and not missing_des_keys:
+            continue
+        label = (
+            f"sheet symbol {sym.sheet_name!r} "
+            f"({sym.parent_schdoc} → {sym.child_filename})"
+        )
+        if missing_bind_keys:
+            keys = ", ".join(repr(k) for k in missing_bind_keys)
+            uid = sym.unique_id or "(none)"
+            result.warnings.append(
+                f"{label}: {keys} — not bound to any PCB placement "
+                f"(UniqueID {uid!r} not on SOURCEUNIQUEID, and sheet_name "
+                f"not on an empty-UID SOURCEHIERARCHICALPATH)"
+            )
+        for des, keys_list in missing_des_keys.items():
+            keys = ", ".join(repr(k) for k in keys_list)
+            result.warnings.append(
+                f"{label}: {keys} — no PCB component with "
+                f"source designator {des!r}"
+            )
+
+
+def _warn_ambiguous_hierpath_sheet_symbols(
+    proj: ExtractedProject, result: AnnotationResult,
+) -> None:
+    """Warn when hierpath fallback matches multiple symbols with the same name.
+
+    Binding keeps only the first symbol per name (UniqueID, then parent sheet);
+    others are ignored — prefer UniqueID paths or unique sheet names.
+    """
+    symbols = getattr(proj, "sch_sheet_symbols", ()) or ()
+    if not symbols:
+        return
+    for pcb in proj.pcb_components:
+        if _source_unique_id_segments(pcb.source_unique_id):
+            continue
+        matchable = _hierpath_matchable_segments(
+            pcb.source_hierarchical_path or "", symbols,
+        )
+        if not matchable:
+            continue
+        by_name = _hierpath_symbols_by_name(symbols, matchable)
+        for name, group in by_name.items():
+            if len(group) < 2:
+                continue
+            winner = _pick_hierpath_symbol(group)
+            chosen = winner.unique_id or winner.sheet_name
+            ignored = ", ".join(
+                repr(s.unique_id or s.sheet_name)
+                for s in group if _sheet_symbol_bind_key(s)
+                != _sheet_symbol_bind_key(winner)
+            )
+            _append_warning_once(
+                result,
+                f"PCB {pcb.designator!r}: SOURCEHIERARCHICALPATH matches "
+                f"{len(group)} sheet symbols named {name!r} — using "
+                f"{chosen!r}, ignoring {ignored}. Prefer SOURCEUNIQUEID "
+                f"binding or unique sheet-symbol names.",
+            )
+
+
 def _degraded_pcb_net_candidates(
     local_net_name: str,
     pcb_designator: str,
@@ -861,8 +1367,18 @@ def _instance_resolver(proj: ExtractedProject) -> InstanceLocalNetResolver:
     return entry[1]
 
 
-def _iter_pdn_parameter_sources(proj: ExtractedProject) -> list[PdnParameterSource]:
-    """Schematic PDN directives plus PCB-only directives (Blanket ECO path)."""
+def _iter_pdn_parameter_sources(
+    proj: ExtractedProject,
+    result: AnnotationResult | None = None,
+) -> list[PdnParameterSource]:
+    """Schematic PDN directives plus PCB-only directives (Blanket ECO path).
+
+    Also synthesises per-placement sources when ``PDN_<Des>_*`` overrides on
+    sheet symbols fully define a directive and the child component itself
+    carries no ``PDN_ROLE``. When only some PCB placements of such a
+    designator get a complete sheet-only directive, a warning is recorded
+    if ``result`` is provided.
+    """
     sources: list[PdnParameterSource] = []
     sch_with_role: set[str] = set()
 
@@ -903,6 +1419,71 @@ def _iter_pdn_parameter_sources(proj: ExtractedProject) -> list[PdnParameterSour
             pcb_index=idx,
             sch_lookup_designator=lookup_des,
         ))
+
+    # Sheet-symbol-only directives (child has no PDN_ROLE).
+    override_designators: set[str] = set()
+    for sym in getattr(proj, "sch_sheet_symbols", ()) or ():
+        for raw_key in (sym.parameters or ()):
+            parsed = _parse_sheet_override_key(raw_key)
+            if parsed is not None:
+                override_designators.add(parsed[0])
+    for des in sorted(override_designators):
+        if des in sch_with_role:
+            continue
+        pcb_indices = _find_pcb_instances(proj, des)
+        if not pcb_indices:
+            continue
+        covered: list[int] = []
+        for pcb_idx in pcb_indices:
+            overrides = _overrides_from_sheet_symbols(proj, pcb_idx, des)
+            if not overrides:
+                continue
+            child_fn = ""
+            for sym in reversed(_sheet_symbols_for_pcb(proj, pcb_idx)):
+                for k in (sym.parameters or ()):
+                    parsed = _parse_sheet_override_key(k)
+                    if parsed is not None and parsed[0] == des:
+                        child_fn = sym.child_filename
+                        break
+                if child_fn:
+                    break
+            sch = _sch_component_for_designator(proj, des, child_fn)
+            base = dict(sch.parameters) if sch is not None else {}
+            merged = {**base, **overrides}
+            _strip_stale_cross_role_values(merged, overrides)
+            if not _is_pdn_annotated(merged):
+                continue
+            sources.append(PdnParameterSource(
+                designator=des,
+                schdoc_name=(
+                    sch.schdoc_name if sch is not None
+                    else (Path(child_fn).name if child_fn else "")
+                ),
+                parameters=merged,
+                pcb_index=pcb_idx,
+                sch_lookup_designator=des,
+            ))
+            covered.append(pcb_idx)
+        if (
+            result is not None
+            and covered
+            and len(covered) < len(pcb_indices)
+        ):
+            covered_set = set(covered)
+            covered_names = ", ".join(
+                proj.pcb_components[i].designator for i in covered
+            )
+            missing_names = ", ".join(
+                proj.pcb_components[i].designator
+                for i in pcb_indices if i not in covered_set
+            )
+            _append_warning_once(
+                result,
+                f"{des}: sheet-symbol-only PDN directive covers "
+                f"{covered_names} but not {missing_names} — add "
+                f"PDN_{des}_ROLE (and value/nets) on those sheet symbols "
+                f"or annotate the child component",
+            )
     return sources
 
 
@@ -1797,12 +2378,15 @@ class AnnotationResult:
 def _require_value(params: dict[str, str], key: str, role_diag: str, result: AnnotationResult) -> float | None:
     raw = _ci_get(params, key)
     if raw is None:
-        result.errors.append(f"{role_diag}: missing required parameter {key}")
+        _append_error_once(result, f"{role_diag}: missing required parameter {key}")
         return None
     try:
         return parse_si_value(raw)
     except ValueError as e:
-        result.errors.append(f"{role_diag}: {key}={raw!r} — {e}{_PARSE_VALUE_HINT}")
+        _append_error_once(
+            result,
+            f"{role_diag}: {key}={raw!r} — {e}{_PARSE_VALUE_HINT}",
+        )
         return None
 
 
@@ -1817,7 +2401,10 @@ def _optional_value(params: dict[str, str], key: str, role_diag: str,
     try:
         return parse_si_value(raw)
     except ValueError as e:
-        result.errors.append(f"{role_diag}: {key}={raw!r} — {e}{_PARSE_VALUE_HINT}")
+        _append_error_once(
+            result,
+            f"{role_diag}: {key}={raw!r} — {e}{_PARSE_VALUE_HINT}",
+        )
         return None
 
 
@@ -1835,16 +2422,25 @@ def _resolve_two_terminal(
     net_remap: dict[int, int] | None = None,
     sch_lookup_designator: str | None = None,
     schdoc_name: str | None = None,
+    param_diag: str | None = None,
 ) -> tuple[TerminalSpec, TerminalSpec] | None:
+    # ``param_diag`` prefixes missing-parameter errors (logical designator
+    # when expanding multi-channel PCB instances); pad-resolution errors keep
+    # ``role_diag`` (often the physical instance label).
+    missing_diag = param_diag or role_diag
     p_net = _ci_get(params, p_net_key)
     n_net = _ci_get(params, n_net_key)
     p_pins = _split_pin_list(_ci_get(params, p_pins_key))
     n_pins = _split_pin_list(_ci_get(params, n_pins_key))
 
     if p_net is None and p_pins is None:
-        result.errors.append(f"{role_diag}: missing {p_net_key} (or {p_pins_key})")
+        _append_error_once(
+            result, f"{missing_diag}: missing {p_net_key} (or {p_pins_key})",
+        )
     if n_net is None and n_pins is None:
-        result.errors.append(f"{role_diag}: missing {n_net_key} (or {n_pins_key})")
+        _append_error_once(
+            result, f"{missing_diag}: missing {n_net_key} (or {n_pins_key})",
+        )
     if p_net is None and p_pins is None or n_net is None and n_pins is None:
         return None
 
@@ -1864,8 +2460,8 @@ def _resolve_two_terminal(
         sch_lookup_designator=sch_lookup_designator,
         schdoc_name=schdoc_name,
     )
-    result.errors.extend(p_err)
-    result.errors.extend(n_err)
+    for err in (*p_err, *n_err):
+        _append_error_once(result, err)
     if p_spec is None or n_spec is None:
         return None
     if p_err or n_err:
@@ -2046,15 +2642,16 @@ def _terminal_mode(params: dict[str, str], idx: int | None,
         )
         if _ci_get(params, pins_key) is not None:
             msg += f" For a two-terminal check use {p_pins_key}, not {pins_key}."
-        result.errors.append(msg)
+        _append_error_once(result, msg)
         return None
     if has_single:
         return "single"
     if has_two:
         return "two"
-    result.errors.append(
+    _append_error_once(
+        result,
         f"{role_diag}: no terminal net specified — set {p_net_key} and "
-        f"{n_net_key}, or {net_key} for a single-net (point-to-point) check"
+        f"{n_net_key}, or {net_key} for a single-net (point-to-point) check",
     )
     return None
 
@@ -2087,7 +2684,8 @@ def _resolve_single_terminal(
         sch_lookup_designator=sch_lookup_designator,
         schdoc_name=schdoc_name,
     )
-    result.errors.extend(errs)
+    for err in errs:
+        _append_error_once(result, err)
     return spec
 
 
@@ -2119,14 +2717,16 @@ def _parse_source(comp, proj, enabled_layers, result,
     # ``only_indices`` (from the per-channel role dispatcher) restricts this
     # parser to the channels whose effective role is SOURCE; when ``None`` the
     # whole part is SOURCE and channels are discovered here.
+    discovery = _discovery_pdn_params(comp, proj)
     if only_indices is not None:
         indices = list(only_indices)
     else:
-        indices = _discover_channel_indices(comp.parameters, "V")
+        indices = _discover_channel_indices(discovery, "V")
         if not indices:
-            result.errors.append(
-                f"SOURCE on {comp.designator}: missing PDN_V "
-                f"(or PDN<n>_V for an indexed channel)"
+            _append_error_once(
+                result,
+                f"SOURCE on {comp.lookup_designator}: missing PDN_V "
+                f"(or PDN<n>_V for an indexed channel)",
             )
             return []
     pcb_indices = _pcb_indices_for_source(comp, proj)
@@ -2143,23 +2743,29 @@ def _parse_source(comp, proj, enabled_layers, result,
             f"{len(pcb_indices)} multi-channel PCB instances ({names})"
         )
     specs: list[SourceSpec] = []
+    multi = _sibling_pcb_count(proj, comp.lookup_designator) > 1
+    logical = comp.lookup_designator
     for idx in indices:
-        role_diag = f"SOURCE on {_channel_label(comp.designator, idx)}"
-        v = _require_value(comp.parameters, _channel_key("V", idx), role_diag, result)
-        if v is None:
-            continue
-        mode = _terminal_mode(comp.parameters, idx, role_diag, result)
-        if mode is None:
-            continue
+        role_diag = f"SOURCE on {_channel_label(logical, idx)}"
         for pcb_idx in pcb_indices:
+            params = _instance_pdn_params(comp, proj, pcb_idx, result=result)
             pcb_des = proj.pcb_components[pcb_idx].designator
             inst_diag = (
                 f"SOURCE on {_channel_label(pcb_des, idx)}"
-                if len(pcb_indices) > 1 else role_diag
+                if multi else role_diag
             )
+            # Shared missing/invalid values: report on the logical designator
+            # once instead of once per expanded PCB instance.
+            value_diag = role_diag if multi else inst_diag
+            v = _require_value(params, _channel_key("V", idx), value_diag, result)
+            if v is None:
+                continue
+            mode = _terminal_mode(params, idx, value_diag, result)
+            if mode is None:
+                continue
             if mode == "single":
                 p = _resolve_single_terminal(
-                    proj, pcb_idx, comp.parameters,
+                    proj, pcb_idx, params,
                     _channel_key("NET", idx), _channel_key("PINS", idx),
                     enabled_layers, inst_diag, result,
                     net_remap=net_remap,
@@ -2174,13 +2780,14 @@ def _parse_source(comp, proj, enabled_layers, result,
                 ))
                 continue
             pair = _resolve_two_terminal(
-                proj, pcb_idx, comp.parameters,
+                proj, pcb_idx, params,
                 _channel_key("P_NET", idx), _channel_key("N_NET", idx),
                 _channel_key("P_PINS", idx), _channel_key("N_PINS", idx),
                 enabled_layers, inst_diag, result,
                 net_remap=net_remap,
                 sch_lookup_designator=comp.lookup_designator,
                 schdoc_name=comp.schdoc_name,
+                param_diag=value_diag,
             )
             if pair is None:
                 continue
@@ -2196,14 +2803,16 @@ def _parse_sink(comp, proj, enabled_layers, result,
                 series_graph=None):
     # ``only_indices`` restricts this parser to the part's SINK-role channels;
     # see _parse_source.
+    discovery = _discovery_pdn_params(comp, proj)
     if only_indices is not None:
         indices = list(only_indices)
     else:
-        indices = _discover_channel_indices(comp.parameters, "I")
+        indices = _discover_channel_indices(discovery, "I")
         if not indices:
-            result.errors.append(
-                f"SINK on {comp.designator}: missing PDN_I "
-                f"(or PDN<n>_I for an indexed channel)"
+            _append_error_once(
+                result,
+                f"SINK on {comp.lookup_designator}: missing PDN_I "
+                f"(or PDN<n>_I for an indexed channel)",
             )
             return []
     pcb_indices = _pcb_indices_for_source(comp, proj)
@@ -2220,26 +2829,30 @@ def _parse_sink(comp, proj, enabled_layers, result,
             f"{len(pcb_indices)} multi-channel PCB instances ({names})"
         )
     specs: list[SinkSpec] = []
+    multi = _sibling_pcb_count(proj, comp.lookup_designator) > 1
+    logical = comp.lookup_designator
     for idx in indices:
-        role_diag = f"SINK on {_channel_label(comp.designator, idx)}"
-        i = _require_value(comp.parameters, _channel_key("I", idx), role_diag, result)
-        if i is None:
-            continue
-        mode = _terminal_mode(comp.parameters, idx, role_diag, result)
-        if mode is None:
-            continue
-        min_v = _optional_value(
-            comp.parameters, _channel_key("MIN_V", idx), role_diag, result,
-        )
+        role_diag = f"SINK on {_channel_label(logical, idx)}"
         for pcb_idx in pcb_indices:
+            params = _instance_pdn_params(comp, proj, pcb_idx, result=result)
             pcb_des = proj.pcb_components[pcb_idx].designator
             inst_diag = (
                 f"SINK on {_channel_label(pcb_des, idx)}"
-                if len(pcb_indices) > 1 else role_diag
+                if multi else role_diag
+            )
+            value_diag = role_diag if multi else inst_diag
+            i = _require_value(params, _channel_key("I", idx), value_diag, result)
+            if i is None:
+                continue
+            mode = _terminal_mode(params, idx, value_diag, result)
+            if mode is None:
+                continue
+            min_v = _optional_value(
+                params, _channel_key("MIN_V", idx), value_diag, result,
             )
             if mode == "single":
                 p = _resolve_single_terminal(
-                    proj, pcb_idx, comp.parameters,
+                    proj, pcb_idx, params,
                     _channel_key("NET", idx), _channel_key("PINS", idx),
                     enabled_layers, inst_diag, result,
                     net_remap=net_remap,
@@ -2255,13 +2868,14 @@ def _parse_sink(comp, proj, enabled_layers, result,
                 ))
                 continue
             pair = _resolve_two_terminal(
-                proj, pcb_idx, comp.parameters,
+                proj, pcb_idx, params,
                 _channel_key("P_NET", idx), _channel_key("N_NET", idx),
                 _channel_key("P_PINS", idx), _channel_key("N_PINS", idx),
                 enabled_layers, inst_diag, result,
                 net_remap=net_remap,
                 sch_lookup_designator=comp.lookup_designator,
                 schdoc_name=comp.schdoc_name,
+                param_diag=value_diag,
             )
             if pair is None:
                 continue
@@ -2281,7 +2895,8 @@ def _parse_resistance(comp, proj, enabled_layers, result,
     # SERIES regardless of the part-wide PDN_ROLE.
     role_raw = "SERIES"
     role_diag_base = f"{role_raw} on {comp.designator}"
-    if _has_single_net_params(comp.parameters, only_indices):
+    discovery = _discovery_pdn_params(comp, proj)
+    if _has_single_net_params(discovery, only_indices):
         result.errors.append(
             f"{role_diag_base}: PDN_NET is only valid on SOURCE/SINK — a "
             f"SERIES directive bridges two nets, use PDN_P_NET and PDN_N_NET"
@@ -2290,11 +2905,12 @@ def _parse_resistance(comp, proj, enabled_layers, result,
     if only_indices is not None:
         indices = list(only_indices)
     else:
-        indices = _discover_channel_indices(comp.parameters, "R")
+        indices = _discover_channel_indices(discovery, "R")
         if not indices:
-            result.errors.append(
-                f"{role_diag_base}: missing PDN_R "
-                f"(or PDN<n>_R for an indexed channel)"
+            _append_error_once(
+                result,
+                f"SERIES on {comp.lookup_designator}: missing PDN_R "
+                f"(or PDN<n>_R for an indexed channel)",
             )
             return []
 
@@ -2313,36 +2929,43 @@ def _parse_resistance(comp, proj, enabled_layers, result,
         )
 
     specs: list[ResistorSpec] = []
+    multi = _sibling_pcb_count(proj, comp.lookup_designator) > 1
+    logical = comp.lookup_designator
     for idx in indices:
-        role_diag = f"{role_raw} on {_channel_label(comp.designator, idx)}"
-        r = _require_value(
-            comp.parameters, _channel_key("R", idx), role_diag, result,
-        )
-        if r is None:
-            continue
-        if r <= 0:
-            result.errors.append(
-                f"{role_diag}: {_channel_key('R', idx)} must be positive, got {r}"
-            )
-            continue
+        role_diag = f"{role_raw} on {_channel_label(logical, idx)}"
         for pcb_idx in pcb_indices:
+            params = _instance_pdn_params(comp, proj, pcb_idx, result=result)
             pcb_des = proj.pcb_components[pcb_idx].designator
             inst_diag = (
                 f"{role_raw} on {_channel_label(pcb_des, idx)}"
-                if len(pcb_indices) > 1 else role_diag
+                if multi else role_diag
             )
+            value_diag = role_diag if multi else inst_diag
+            r = _require_value(
+                params, _channel_key("R", idx), value_diag, result,
+            )
+            if r is None:
+                continue
+            if r <= 0:
+                _append_error_once(
+                    result,
+                    f"{value_diag}: {_channel_key('R', idx)} must be positive, "
+                    f"got {r}",
+                )
+                continue
             given = any(
-                _ci_get(comp.parameters, _channel_key(k, idx)) is not None
+                _ci_get(params, _channel_key(k, idx)) is not None
                 for k in ("P_NET", "N_NET", "P_PINS", "N_PINS")
             )
-            params = dict(comp.parameters)
+            resolve_params = dict(params)
             if not given:
                 if len(indices) > 1:
-                    result.errors.append(
-                        f"{inst_diag}: multi-channel SERIES requires explicit "
+                    _append_error_once(
+                        result,
+                        f"{value_diag}: multi-channel SERIES requires explicit "
                         f"{_channel_key('P_NET', idx)} / {_channel_key('N_NET', idx)} "
                         f"or {_channel_key('P_PINS', idx)} / "
-                        f"{_channel_key('N_PINS', idx)} per channel"
+                        f"{_channel_key('N_PINS', idx)} per channel",
                     )
                     continue
                 inferred = _autoinfer_2pin_nets(proj, pcb_idx)
@@ -2357,8 +2980,8 @@ def _parse_resistance(comp, proj, enabled_layers, result,
                         f"{_channel_key('N_PINS', idx)})"
                     )
                     continue
-                params[_channel_key("P_NET", idx)] = inferred[0]
-                params[_channel_key("N_NET", idx)] = inferred[1]
+                resolve_params[_channel_key("P_NET", idx)] = inferred[0]
+                resolve_params[_channel_key("N_NET", idx)] = inferred[1]
                 result.warnings.append(
                     f"{inst_diag}: auto-inferred "
                     f"{_channel_key('P_NET', idx)}={inferred[0]!r}, "
@@ -2366,13 +2989,14 @@ def _parse_resistance(comp, proj, enabled_layers, result,
                     f"from 2-pin connectivity"
                 )
             pair = _resolve_two_terminal(
-                proj, pcb_idx, params,
+                proj, pcb_idx, resolve_params,
                 _channel_key("P_NET", idx), _channel_key("N_NET", idx),
                 _channel_key("P_PINS", idx), _channel_key("N_PINS", idx),
                 enabled_layers, inst_diag, result,
                 net_remap=net_remap,
                 sch_lookup_designator=comp.lookup_designator,
                 schdoc_name=comp.schdoc_name,
+                param_diag=value_diag,
             )
             if pair is None:
                 continue
@@ -2775,7 +3399,8 @@ def _parse_regulator(comp, proj, enabled_layers, result,
                      net_remap=None, supply_map=None, only_indices=None,
                      series_graph=None):
     role_diag_base = f"REGULATOR on {comp.designator}"
-    if _has_single_net_params(comp.parameters, only_indices):
+    discovery = _discovery_pdn_params(comp, proj)
+    if _has_single_net_params(discovery, only_indices):
         result.errors.append(
             f"{role_diag_base}: PDN_NET is only valid on SOURCE/SINK — a "
             f"REGULATOR has four terminals, use PDN_OUT_P_NET / PDN_OUT_N_NET "
@@ -2785,11 +3410,12 @@ def _parse_regulator(comp, proj, enabled_layers, result,
     if only_indices is not None:
         indices = list(only_indices)
     else:
-        indices = _discover_channel_indices(comp.parameters, "V")
+        indices = _discover_channel_indices(discovery, "V")
         if not indices:
-            result.errors.append(
-                f"REGULATOR on {comp.designator}: missing PDN_V "
-                f"(or PDN<n>_V for an indexed channel)"
+            _append_error_once(
+                result,
+                f"REGULATOR on {comp.lookup_designator}: missing PDN_V "
+                f"(or PDN<n>_V for an indexed channel)",
             )
             return []
 
@@ -2811,56 +3437,61 @@ def _parse_regulator(comp, proj, enabled_layers, result,
         supply_map = {}
 
     specs: list[RegulatorSpec] = []
+    multi = _sibling_pcb_count(proj, comp.lookup_designator) > 1
+    logical = comp.lookup_designator
     for idx in indices:
-        role_diag = f"REGULATOR on {_channel_label(comp.designator, idx)}"
-        v = _require_value(
-            comp.parameters, _channel_key("V", idx), role_diag, result,
-        )
-        in_p_net = _ci_get(comp.parameters, _channel_key("IN_P_NET", idx))
-        resolved = _resolve_regulator_gain(
-            comp.parameters, idx, v, in_p_net,
-            supply_map, role_diag, result,
-            series_graph=series_graph, proj=proj, net_remap=net_remap,
-        ) if v is not None else None
-        if v is None or resolved is None:
-            continue
-        g, reg_type, eff, adaptive = resolved
-        q_key = _channel_key("QUIESCENT", idx)
-        if _ci_get(comp.parameters, q_key) is None:
-            quiescent = 0.0
-        else:
-            iq_raw = _optional_value(comp.parameters, q_key, role_diag, result)
-            if iq_raw is None:
-                # Present but unparseable — error already recorded; skip the
-                # spec rather than building it with a silent quiescent=0.
-                continue
-            if iq_raw < 0:
-                result.errors.append(f"{role_diag}: {q_key} must be >= 0")
-                continue
-            quiescent = iq_raw
+        role_diag = f"REGULATOR on {_channel_label(logical, idx)}"
         for pcb_idx in pcb_indices:
+            params = _instance_pdn_params(comp, proj, pcb_idx, result=result)
             pcb_des = proj.pcb_components[pcb_idx].designator
             inst_diag = (
                 f"REGULATOR on {_channel_label(pcb_des, idx)}"
-                if len(pcb_indices) > 1 else role_diag
+                if multi else role_diag
             )
+            value_diag = role_diag if multi else inst_diag
+            v = _require_value(
+                params, _channel_key("V", idx), value_diag, result,
+            )
+            in_p_net = _ci_get(params, _channel_key("IN_P_NET", idx))
+            resolved = _resolve_regulator_gain(
+                params, idx, v, in_p_net,
+                supply_map, value_diag, result,
+            ) if v is not None else None
+            if v is None or resolved is None:
+                continue
+            g, reg_type, eff, adaptive = resolved
+            q_key = _channel_key("QUIESCENT", idx)
+            if _ci_get(params, q_key) is None:
+                quiescent = 0.0
+            else:
+                iq_raw = _optional_value(params, q_key, value_diag, result)
+                if iq_raw is None:
+                    continue
+                if iq_raw < 0:
+                    _append_error_once(
+                        result, f"{value_diag}: {q_key} must be >= 0",
+                    )
+                    continue
+                quiescent = iq_raw
             out = _resolve_two_terminal(
-                proj, pcb_idx, comp.parameters,
+                proj, pcb_idx, params,
                 _channel_key("OUT_P_NET", idx), _channel_key("OUT_N_NET", idx),
                 _channel_key("OUT_P_PINS", idx), _channel_key("OUT_N_PINS", idx),
                 enabled_layers, f"{inst_diag} OUT", result,
                 net_remap=net_remap,
                 sch_lookup_designator=comp.lookup_designator,
                 schdoc_name=comp.schdoc_name,
+                param_diag=f"{value_diag} OUT",
             )
             in_ = _resolve_two_terminal(
-                proj, pcb_idx, comp.parameters,
+                proj, pcb_idx, params,
                 _channel_key("IN_P_NET", idx), _channel_key("IN_N_NET", idx),
                 _channel_key("IN_P_PINS", idx), _channel_key("IN_N_PINS", idx),
                 enabled_layers, f"{inst_diag} IN", result,
                 net_remap=net_remap,
                 sch_lookup_designator=comp.lookup_designator,
                 schdoc_name=comp.schdoc_name,
+                param_diag=f"{value_diag} IN",
             )
             if out is None or in_ is None:
                 continue
@@ -3044,20 +3675,23 @@ def _warn_unknown_pdn_params(
         ch = f"#{idx}" if idx is not None else ""
         if suffix_u == "PIN":
             suggest = _channel_key("P_PINS", idx)
-            result.warnings.append(
+            _append_warning_once(
+                result,
                 f"{diag}{ch}: unknown parameter {key!r} — did you mean "
-                f"{suggest}?"
+                f"{suggest}?",
             )
             continue
         if suffix_u.startswith("OUT_") and eff_role in ("SOURCE", "SINK"):
-            result.warnings.append(
+            _append_warning_once(
+                result,
                 f"{diag}{ch}: {key!r} is a REGULATOR parameter — did you mean "
                 f"to set the channel's role to REGULATOR "
-                f"({_channel_key('ROLE', idx)}=REGULATOR)?"
+                f"({_channel_key('ROLE', idx)}=REGULATOR)?",
             )
             continue
-        result.warnings.append(
-            f"{diag}{ch}: unknown PDN parameter {key!r} (ignored)"
+        _append_warning_once(
+            result,
+            f"{diag}{ch}: unknown PDN parameter {key!r} (ignored)",
         )
 
 
@@ -3184,7 +3818,12 @@ def parse_annotations(proj: ExtractedProject,
                 f"directive ignored"
             )
 
-    parameter_sources = _iter_pdn_parameter_sources(proj)
+    parameter_sources = _iter_pdn_parameter_sources(proj, result=result)
+    _warn_orphan_sheet_overrides(proj, result)
+    _warn_ambiguous_hierpath_sheet_symbols(proj, result)
+    parameter_sources = _expand_sheet_bound_parameter_sources(
+        proj, parameter_sources, result,
+    )
 
     supply_map = _collect_supply_voltages_by_net(
         parameter_sources, proj, net_remap=net_remap,
@@ -3197,9 +3836,10 @@ def parse_annotations(proj: ExtractedProject,
     for comp in parameter_sources:
         if comp.designator.upper() in skip_set:
             continue  # Absorbed by net-merge pre-pass — see fypa.altium.loader.
-        role_raw = _ci_get(comp.parameters, ROLE_KEY)
+        discovery = _discovery_pdn_params(comp, proj)
+        role_raw = _ci_get(discovery, ROLE_KEY)
         if role_raw is None:
-            if not _has_indexed_role_params(comp.parameters):
+            if not _has_indexed_role_params(discovery):
                 continue
             role = ""
         else:
@@ -3224,7 +3864,11 @@ def parse_annotations(proj: ExtractedProject,
         if comp.pcb_index is None:
             seen_designators.add(key)
 
-        _warn_unknown_pdn_params(comp, role, result)
+        _warn_unknown_pdn_params(
+            replace(comp, parameters=discovery) if discovery != comp.parameters
+            else comp,
+            role, result,
+        )
 
         # Split the part's channels by effective role (part-wide PDN_ROLE, or
         # a per-channel PDN<n>_ROLE override) and dispatch each group to its
@@ -3232,7 +3876,7 @@ def parse_annotations(proj: ExtractedProject,
         # and multi-channel same-role parts behave exactly as before; a mixed
         # part (source + sink on one component) yields one group per role.
         channel_roles = _resolve_channel_roles(
-            comp.parameters, role, comp.designator, result,
+            discovery, role, comp.designator, result,
         )
         if not channel_roles:
             # No resolvable channels — call the part-role parser so it emits

--- a/fypa/altium/extract.py
+++ b/fypa/altium/extract.py
@@ -355,6 +355,14 @@ class RawPcbComponent:
     # schematic→PCB ECO; carries Blanket/Parameter-Set directives among others).
     parameters: dict[str, str] = field(default_factory=dict)
     unique_id: str = ""
+    # Hierarchy path of UniqueIDs from root sheet symbol(s) down to the
+    # schematic component (PCB ``SOURCEUNIQUEID``, e.g. ``\XOZXOXGE\QJGQOCLZ``).
+    # Primary key for binding sheet-symbol ``PDN_<Des>_*`` overrides.
+    source_unique_id: str = ""
+    # Human-readable hierarchy (PCB ``SOURCEHIERARCHICALPATH``), e.g.
+    # ``main\CON-AUX``. Used as fallback when ``source_unique_id`` is empty:
+    # sheet-symbol ``sheet_name`` is matched against path segments.
+    source_hierarchical_path: str = ""
 
 
 @dataclass(frozen=True, slots=True)
@@ -404,6 +412,21 @@ class RawSchComponent:
 
 
 @dataclass(frozen=True, slots=True)
+class RawSchSheetSymbol:
+    """One hierarchical sheet symbol placement (parent sheet → child SchDoc).
+
+    Carries optional ``PDN_<Designator>_*`` parameters that override child
+    component PDN directives for PCB instances whose ``SOURCEUNIQUEID`` path
+    contains this symbol's :attr:`unique_id`.
+    """
+    parent_schdoc: str        # filename of the sheet that hosts the symbol
+    sheet_name: str           # display name (may be ``REPEAT(...)``)
+    child_filename: str       # referenced child schematic filename
+    unique_id: str            # Altium UniqueID of the sheet symbol
+    parameters: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
 class ExtractedProject:
     prjpcb_path: Path
     pcbdoc_path: Path           # which .PcbDoc was actually loaded (multi-PCB projects)
@@ -418,6 +441,9 @@ class ExtractedProject:
     nets: tuple[RawNet, ...]
     stackup: tuple[RawStackupLayer, ...]
     sch_components: tuple[RawSchComponent, ...]
+    # Sheet symbols across all SchDocs (for per-instance PDN overrides).
+    # Empty default so older callers / Gerber extracts keep working.
+    sch_sheet_symbols: tuple[RawSchSheetSymbol, ...] = ()
     # Compiled schematic netlist (multi-sheet aware). Used to translate local
     # sheet net names in PDN_*_NET parameters to per-instance PCB connectivity.
     compiled_netlist: Any | None = None
@@ -980,6 +1006,7 @@ def _extract_pcb_components(pcb, ox_mm: float, oy_mm: float,
         # skip it. A dropped component only loses its designator overlay /
         # any PDN annotations it carried; the copper geometry is unaffected.
         try:
+            rr = getattr(c, "raw_record", None) or {}
             out.append(RawPcbComponent(
                 designator=str(c.designator),
                 center=Pt2D(parse_mil_string(c.x) - ox_mm,
@@ -988,10 +1015,13 @@ def _extract_pcb_components(pcb, ox_mm: float, oy_mm: float,
                 layer_name=str(c.layer),
                 footprint=str(c.footprint),
                 source_designator=str(
-                    c.raw_record.get("SOURCEDESIGNATOR", "") or ""),
+                    rr.get("SOURCEDESIGNATOR", "") or ""),
                 parameters=_normalise_pcb_parameters(
                     getattr(c, "parameters", None)),
                 unique_id=str(getattr(c, "unique_id", "") or ""),
+                source_unique_id=str(rr.get("SOURCEUNIQUEID", "") or ""),
+                source_hierarchical_path=str(
+                    rr.get("SOURCEHIERARCHICALPATH", "") or ""),
             ))
         except Exception as exc:
             desig = getattr(c, "designator", "?")
@@ -1353,6 +1383,121 @@ def _extract_sch_components(design) -> tuple[RawSchComponent, ...]:
     return tuple(out)
 
 
+def _parameters_from_sch_children(children) -> dict[str, str]:
+    """Collect ``AltiumSchParameter`` name→text from a parent object's children."""
+    parameters: dict[str, str] = {}
+    for child in children or ():
+        if type(child).__name__ != "AltiumSchParameter":
+            continue
+        name = getattr(child, "name", None)
+        if not name:
+            continue
+        parameters[str(name).strip()] = str(getattr(child, "text", ""))
+    return parameters
+
+
+def _parameters_owned_by_index(schdoc, owner_index: int) -> dict[str, str]:
+    """Parameters on ``schdoc.parameters`` whose ``owner_index`` matches.
+
+    altium_monkey attaches sheet-symbol parameters this way (OwnerIndex →
+    sheet symbol ``index_in_sheet``). They are *not* placed on
+    ``symbol.children`` — that list only holds entries / name / filename.
+    """
+    parameters: dict[str, str] = {}
+    for param in getattr(schdoc, "parameters", ()) or ():
+        if getattr(param, "owner_index", None) != owner_index:
+            continue
+        name = getattr(param, "name", None)
+        if not name:
+            continue
+        parameters[str(name).strip()] = str(getattr(param, "text", "") or "")
+    return parameters
+
+
+# Sheet-symbol PDN overrides are ``PDN_<DesignatorWithDigit>_*`` (e.g.
+# ``PDN_J1_I``, ``PDN_U12A_I``). BOM / library params on the same symbol
+# are dropped.
+_PDN_SHEET_OVERRIDE_NAME_RE = re.compile(
+    r"^PDN_[A-Za-z]*\d[A-Za-z0-9]*_", re.IGNORECASE,
+)
+
+
+def _filter_sheet_pdn_parameters(parameters: dict[str, str]) -> dict[str, str]:
+    """Keep only designator-targeted ``PDN_<Des>_*`` sheet-symbol keys."""
+    return {
+        k: v for k, v in parameters.items()
+        if _PDN_SHEET_OVERRIDE_NAME_RE.match(str(k).strip())
+    }
+
+
+def _extract_sch_sheet_symbol(
+    info, parent_schdoc: str, schdoc=None,
+) -> RawSchSheetSymbol | None:
+    """Extract one sheet symbol's identity + parameters."""
+    record = getattr(info, "record", None)
+    if record is None:
+        return None
+    unique_id = str(getattr(info, "unique_id", "") or "").strip()
+    if not unique_id:
+        unique_id = str(getattr(record, "unique_id", "") or "").strip()
+    child_filename = str(getattr(info, "file_name", "") or "").strip()
+    if not child_filename:
+        return None
+    sheet_name = str(getattr(info, "designator", "") or "").strip()
+    # Children rarely carry parameters for sheet symbols; OwnerIndex on the
+    # schdoc's flat parameter list is the authoritative path.
+    parameters = _parameters_from_sch_children(getattr(record, "children", ()))
+    owner_index = getattr(record, "index_in_sheet", None)
+    if schdoc is not None and owner_index is not None:
+        parameters.update(_parameters_owned_by_index(schdoc, owner_index))
+    parameters = _filter_sheet_pdn_parameters(parameters)
+    return RawSchSheetSymbol(
+        parent_schdoc=parent_schdoc,
+        sheet_name=sheet_name,
+        child_filename=child_filename,
+        unique_id=unique_id,
+        parameters=parameters,
+    )
+
+
+def _sheet_symbol_info_wrapper(record):
+    """Adapt a bare ``AltiumSchSheetSymbol`` to the info-wrapper interface."""
+    class _Info:
+        def __init__(self, rec):
+            self.record = rec
+
+        @property
+        def designator(self):
+            sn = getattr(self.record, "sheet_name", None)
+            return getattr(sn, "text", "") if sn is not None else ""
+
+        @property
+        def file_name(self):
+            fn = getattr(self.record, "file_name", None)
+            return getattr(fn, "text", "") if fn is not None else ""
+
+        @property
+        def unique_id(self):
+            return getattr(self.record, "unique_id", "") or ""
+
+    return _Info(record)
+
+
+def _extract_sch_sheet_symbols(design) -> tuple[RawSchSheetSymbol, ...]:
+    out: list[RawSchSheetSymbol] = []
+    for sd in design.schdocs:
+        parent_name = sd.filepath.name if getattr(sd, "filepath", None) else ""
+        getter = getattr(sd, "get_sheet_symbols", None)
+        symbols = getter() if callable(getter) else getattr(sd, "sheet_symbols", ())
+        for info in symbols or ():
+            if type(info).__name__ == "AltiumSchSheetSymbol":
+                info = _sheet_symbol_info_wrapper(info)
+            rec = _extract_sch_sheet_symbol(info, parent_name, schdoc=sd)
+            if rec is not None:
+                out.append(rec)
+    return tuple(out)
+
+
 # --- public entry -------------------------------------------------------------
 
 def list_pcbdoc_paths(prjpcb_path: str | Path) -> list[Path]:
@@ -1503,6 +1648,7 @@ def extract_project(prjpcb_path: str | Path,
         nets=_extract_nets(pcb),
         stackup=_extract_stackup(pcb),
         sch_components=_extract_sch_components(design),
+        sch_sheet_symbols=_extract_sch_sheet_symbols(design),
         compiled_netlist=compiled_netlist,
         physical_sheet_names=physical_sheet_names,
         board_origin_mm=Pt2D(ox_mm, oy_mm),
@@ -1540,6 +1686,7 @@ def _summarise(proj: ExtractedProject) -> str:
         f"  nets         : {len(proj.nets):>6}\n"
         f"  stackup rows : {len(proj.stackup):>6}\n"
         f"  sch_components: {len(proj.sch_components):>6}\n"
+        f"  sch_sheet_symbols: {len(proj.sch_sheet_symbols):>6}\n"
         f"  enabled copper layers (Top->Bottom): {enabled_str}\n"
     )
 

--- a/scripts/launch-combined-gui.ps1
+++ b/scripts/launch-combined-gui.ps1
@@ -1,0 +1,122 @@
+<#
+.SYNOPSIS
+    Check out origin/test/combined and launch the GUI (Altium bootstrap path).
+
+.DESCRIPTION
+    Used by Run_FYPA.ps1 after clone/uv sync. Fetches the shared combined branch,
+    hard-resets to the remote tip, and runs Launch_GUI.py (or FYPA.py gui).
+
+    Does not merge feature branches. Maintain the shared branch with:
+      pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+
+.PARAMETER PrjPcb
+    Path to the focused .PrjPcb.
+
+.PARAMETER LaunchGui
+    Absolute path to Launch_GUI.py (outside the disposable clone). Optional.
+
+.PARAMETER Remote
+    Remote name. Default: origin
+
+.PARAMETER TestBranch
+    Combined branch name. Default: test/combined
+
+.PARAMETER RepoRoot
+    FYPA repo root. Default: parent of scripts/.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $PrjPcb,
+
+    [string] $LaunchGui,
+
+    [string] $Remote = "origin",
+
+    [string] $TestBranch = "test/combined",
+
+    [string] $RepoRoot
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $RepoRoot) {
+    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+}
+else {
+    $RepoRoot = (Resolve-Path -LiteralPath $RepoRoot).Path
+}
+Set-Location $RepoRoot
+
+if (-not (Test-Path -LiteralPath (Join-Path $RepoRoot 'FYPA.py'))) {
+    throw "FYPA.py not found in $RepoRoot"
+}
+
+if (-not (Test-Path -LiteralPath $PrjPcb)) {
+    throw "PrjPcb not found: $PrjPcb"
+}
+$PrjPcbPath = (Resolve-Path -LiteralPath $PrjPcb).Path
+
+function Invoke-GitLogged {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs
+    )
+    Write-Host (">> git {0}" -f ($GitArgs -join ' ')) -ForegroundColor DarkGray
+    & git.exe @GitArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($GitArgs -join ' ') failed (exit $LASTEXITCODE)"
+    }
+}
+
+$RemoteRef = "$Remote/$TestBranch"
+Write-Host "==> Fetch $Remote $TestBranch"
+& git.exe fetch $Remote $TestBranch 2>&1 | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning "git fetch $Remote $TestBranch failed; trying existing $RemoteRef"
+}
+
+& git.exe rev-parse --verify "$RemoteRef^{commit}" 2>$null | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    throw @"
+$RemoteRef not found.
+Publish the shared branch first (on a maintainer machine or via the team/local Action):
+
+  pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+"@
+}
+
+$Tip = ([string](& git.exe rev-parse --verify "$RemoteRef^{commit}")).Trim()
+Write-Host "==> Checkout $TestBranch @ $Tip"
+Invoke-GitLogged @('checkout', '-B', $TestBranch, $RemoteRef)
+Invoke-GitLogged @('reset', '--hard', $RemoteRef)
+
+Write-Host "==> uv sync (on $TestBranch)"
+& uv sync
+if ($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+    $venvPython = Join-Path $RepoRoot '.venv\Scripts\python.exe'
+    if (Test-Path -LiteralPath $venvPython) {
+        Write-Warning "uv sync failed; reusing existing .venv"
+    }
+    else {
+        throw "uv sync failed (exit $LASTEXITCODE)"
+    }
+}
+
+Write-Host "==> Launch GUI"
+$env:PYTHONUNBUFFERED = '1'
+if ($LaunchGui -and (Test-Path -LiteralPath $LaunchGui)) {
+    Write-Host "    Using Launch_GUI.py (File > Import style, GUI first)"
+    & uv run --extra spacemouse python $LaunchGui $PrjPcbPath
+}
+else {
+    if ($LaunchGui) {
+        Write-Warning "Launch_GUI.py missing at $LaunchGui — falling back to FYPA.py gui"
+    }
+    & uv run --extra spacemouse FYPA.py gui $PrjPcbPath
+}
+
+if ($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}

--- a/scripts/maintain-test-combined.ps1
+++ b/scripts/maintain-test-combined.ps1
@@ -4,8 +4,13 @@
 
 .DESCRIPTION
     Reads team/test-combined.json (team/local by default), fetches base + extras
-    from origin, recreates the disposable test branch using remote tips only,
+    from origin, updates the disposable test branch using remote tips only,
     and optionally force-pushes with lease.
+
+    Default (no -Rebuild): if origin/test/combined exists, check it out and
+    merge only extras whose tips are not already ancestors of HEAD
+    (incremental — keeps prior conflict resolutions). Pass -Rebuild for a
+    clean recreate from baseBranch (expect conflicts again).
 
     Local unpushed commits are never merged — tips are always origin/<branch>.
     Missing remote extras abort the run.
@@ -26,20 +31,34 @@
     Remote name. Default: origin
 
 .PARAMETER Rebuild
-    Force recreate even when the stamp on the existing local test branch matches.
+    Delete/recreate from baseBranch even when a published tip exists.
+    Prefer incremental updates without this switch.
+
+.PARAMETER Abort
+    Abort a stuck merge: hard-reset local test/combined to origin/test/combined
+    (if present), clear merge/rebase state, and check out the starting branch.
+    Does not push.
 
 .PARAMETER Push
-    After a successful rebuild (or reuse), push --force-with-lease to Remote.
+    After a successful update (or reuse), push --force-with-lease to Remote.
 
 .PARAMETER BaseBranch / TestBranch / ExtraFeatureBranches / DeleteTestBranchFirst
     Override individual config fields.
 
 .EXAMPLE
-    pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+    pwsh scripts/maintain-test-combined.ps1 -Push
+
+    Incremental update from origin/test/combined, then publish.
 
 .EXAMPLE
-    pwsh scripts/maintain-test-combined.ps1
-    Build locally without pushing (e.g. to resolve merge conflicts).
+    pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+
+    Clean recreate from main (resolves conflicts from scratch).
+
+.EXAMPLE
+    pwsh scripts/maintain-test-combined.ps1 -Abort
+
+    Escape a mid-merge worktree and return to the previous branch.
 #>
 
 [CmdletBinding()]
@@ -48,6 +67,7 @@ param(
     [string] $TeamConfigRef = "team/local",
     [string] $Remote = "origin",
     [switch] $Rebuild,
+    [switch] $Abort,
     [switch] $Push,
     [string] $BaseBranch,
     [string] $TestBranch,
@@ -119,6 +139,15 @@ function Invoke-GitSoft {
 function Test-GitRef {
     param([string] $Ref)
     & git show-ref --verify --quiet $Ref
+    return $LASTEXITCODE -eq 0
+}
+
+function Test-GitAncestor {
+    param(
+        [string] $Ancestor,
+        [string] $Descendant
+    )
+    & git.exe merge-base --is-ancestor $Ancestor $Descendant 2>$null | Out-Null
     return $LASTEXITCODE -eq 0
 }
 
@@ -397,8 +426,76 @@ function Read-TestCombinedConfig {
     return $Config
 }
 
+function Clear-TestCombinedUpstream {
+    param([string] $Branch)
+    # Creating from origin/main sets upstream to main — confusing ("ahead of main").
+    & git.exe branch --unset-upstream $Branch 2>$null | Out-Null
+}
+
 if (-not (Test-Path "FYPA.py")) {
     throw "FYPA.py not found in $RepoRoot — run this script from the FYPA repo."
+}
+
+$ReturnBranch = Get-CurrentBranch
+if (-not $ReturnBranch) {
+    throw "Could not determine the current branch (detached HEAD?). Check out a branch first."
+}
+
+if ($Abort) {
+    $AbortTestBranch = if ($PSBoundParameters.ContainsKey("TestBranch") -and $TestBranch) {
+        $TestBranch
+    }
+    else {
+        "test/combined"
+    }
+    Write-Host "==> Abort: clear merge/rebase state and reset $AbortTestBranch"
+    $onAbortBranch = ((Get-CurrentBranch) -eq $AbortTestBranch)
+    if ($onAbortBranch) {
+        & git merge --abort 2>$null | Out-Null
+        & git rebase --abort 2>$null | Out-Null
+        & git reset --merge 2>$null | Out-Null
+    }
+    try {
+        Sync-RemoteBranches -RemoteName $Remote -Branches @($AbortTestBranch)
+    }
+    catch {
+        Write-Warning "Fetch $Remote/$AbortTestBranch failed — using existing refs if present."
+    }
+    $RemoteAbortRef = "$Remote/$AbortTestBranch"
+    if (Test-GitRef "refs/remotes/$Remote/$AbortTestBranch") {
+        if ($onAbortBranch) {
+            Invoke-Git @('reset', '--hard', $RemoteAbortRef)
+            Clear-TestCombinedUpstream -Branch $AbortTestBranch
+            Write-Host "==> $AbortTestBranch reset to $RemoteAbortRef"
+            if ($ReturnBranch -ne $AbortTestBranch) {
+                Write-Host "==> Return to $ReturnBranch"
+                Restore-DevBranch -Branch $ReturnBranch
+            }
+        }
+        else {
+            # Update the local branch tip without checking it out (worktree may be dirty).
+            if (Test-GitRef "refs/heads/$AbortTestBranch") {
+                Invoke-Git @('branch', '-f', $AbortTestBranch, $RemoteAbortRef)
+            }
+            else {
+                Invoke-Git @('branch', $AbortTestBranch, $RemoteAbortRef)
+            }
+            Clear-TestCombinedUpstream -Branch $AbortTestBranch
+            Write-Host "==> Local $AbortTestBranch forced to $RemoteAbortRef (no checkout)"
+        }
+    }
+    elseif ($onAbortBranch) {
+        Write-Host "==> No $RemoteAbortRef — checking out $ReturnBranch and deleting local tip"
+        Restore-DevBranch -Branch $ReturnBranch
+        if (Test-GitRef "refs/heads/$AbortTestBranch") {
+            Invoke-Git @('branch', '-D', $AbortTestBranch)
+        }
+    }
+    else {
+        Write-Host "==> No local/remote $AbortTestBranch to reset"
+    }
+    Write-Host "==> Abort done — on $(Get-CurrentBranch)"
+    exit 0
 }
 
 # Soft-fetch team config ref so git show origin/team/local:... works.
@@ -439,11 +536,6 @@ if (-not $TestBranch) { throw "testBranch is empty." }
 
 Write-Host "==> Branch source: $Remote tips only (no local-ahead merge)"
 
-$ReturnBranch = Get-CurrentBranch
-if (-not $ReturnBranch) {
-    throw "Could not determine the current branch (detached HEAD?). Check out a branch first."
-}
-
 Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
 # test/combined may not exist yet on first publish — soft-fetch only.
 try {
@@ -477,6 +569,7 @@ foreach ($ExtraBranch in $ExtraFeatureBranches) {
     $ResolvedExtras.Add(@{
         Branch   = $ExtraTarget.Branch
         MergeRef = $ExtraTarget.MergeRef
+        Sha      = $ExtraTarget.Sha
     })
 }
 
@@ -500,23 +593,34 @@ $DesiredStamp = ConvertTo-NormalizedStamp (Get-InputStamp `
     -BaseSha $BaseSha `
     -ExtraPairs @($ExtraStampPairs))
 
-$TestBranchExists = Test-GitRef "refs/heads/$TestBranch"
-$ExistingTip = if ($TestBranchExists) { Get-RefSha -Ref $TestBranch } else { $null }
-$ExistingStamp = ConvertTo-NormalizedStamp (Get-TestCombinedStamp -Commit $ExistingTip)
+$RemoteTestRef = "$Remote/$TestBranch"
+$HasRemoteTest = Test-GitRef "refs/remotes/$Remote/$TestBranch"
+$RemoteTestSha = if ($HasRemoteTest) { Get-RefSha -Ref $RemoteTestRef } else { $null }
+$RemoteStamp = ConvertTo-NormalizedStamp (Get-TestCombinedStamp -Commit $RemoteTestSha)
+
 $CanReuse = (
     -not $Rebuild -and
-    $TestBranchExists -and
-    $ExistingStamp -and
-    ($ExistingStamp -eq $DesiredStamp)
+    $RemoteStamp -and
+    ($RemoteStamp -eq $DesiredStamp)
 )
 
-if (-not $CanReuse -and $TestBranchExists -and -not $Rebuild) {
-    if (-not $ExistingStamp) {
-        Write-Host "==> No reuse stamp on $TestBranch — will rebuild"
-    }
-    else {
-        Write-Host "==> Stamp mismatch on $TestBranch — will rebuild"
-    }
+$UseIncremental = (
+    -not $Rebuild -and
+    -not $CanReuse -and
+    $HasRemoteTest
+)
+
+if ($CanReuse) {
+    Write-Host "==> Stamp matches $RemoteTestRef — reuse"
+}
+elseif ($UseIncremental) {
+    Write-Host "==> Incremental update from $RemoteTestRef (pass -Rebuild for clean recreate)"
+}
+elseif ($Rebuild) {
+    Write-Host "==> -Rebuild: clean recreate from $BaseRef"
+}
+else {
+    Write-Host "==> No $RemoteTestRef yet — first create from $BaseRef"
 }
 
 $IgnoredPaths = @('.gitignore', 'FYPA.code-workspace')
@@ -531,6 +635,7 @@ if ($BlockingStatus.Count -gt 0) {
     throw @"
 Uncommitted changes detected on '$ReturnBranch'.
 Commit or stash them before running maintain-test-combined.
+To escape a stuck merge: pwsh scripts/maintain-test-combined.ps1 -Abort
 "@
 }
 
@@ -538,22 +643,36 @@ $Returned = $false
 $LeaveOnConflict = $false
 try {
     if ($CanReuse) {
-        Write-Host "==> Reuse $TestBranch (inputs unchanged)"
-        if ((Get-CurrentBranch) -ne $TestBranch) {
-            Invoke-Git @('checkout', $TestBranch)
+        Write-Host "==> Checkout $TestBranch @ $RemoteTestRef"
+        Invoke-Git @('checkout', '-B', $TestBranch, $RemoteTestRef)
+        Invoke-Git @('reset', '--hard', $RemoteTestRef)
+        Clear-TestCombinedUpstream -Branch $TestBranch
+    }
+    elseif ($UseIncremental) {
+        Write-Host "==> Checkout $TestBranch @ $RemoteTestRef"
+        Invoke-Git @('checkout', '-B', $TestBranch, $RemoteTestRef)
+        Invoke-Git @('reset', '--hard', $RemoteTestRef)
+        Clear-TestCombinedUpstream -Branch $TestBranch
+
+        $HeadSha = Get-RefSha -Ref 'HEAD'
+        foreach ($Extra in $ResolvedExtras) {
+            if (Test-GitAncestor -Ancestor $Extra.Sha -Descendant $HeadSha) {
+                Write-Host "==> Skip $($Extra.Branch) (already in $TestBranch)"
+                continue
+            }
+            Write-Host "==> Merge $($Extra.MergeRef) into $TestBranch"
+            Merge-FeatureBranch -MergeRef $Extra.MergeRef -ExtraBranch $Extra.Branch -IgnoredPaths $IgnoredPaths
+            $HeadSha = Get-RefSha -Ref 'HEAD'
+        }
+
+        $NewTip = Get-RefSha -Ref 'HEAD'
+        if ($NewTip) {
+            Set-TestCombinedStamp -Commit $NewTip -Stamp $DesiredStamp
+            Write-Host "==> Stamp written for $TestBranch"
         }
     }
     else {
-        if ($Rebuild) {
-            Write-Host "==> Rebuild requested — recreating $TestBranch"
-        }
-        elseif (-not $TestBranchExists) {
-            Write-Host "==> $TestBranch missing — creating from $BaseRef"
-        }
-        else {
-            Write-Host "==> Inputs changed — recreating $TestBranch from $BaseRef"
-        }
-
+        # Full recreate from base (first publish or -Rebuild).
         if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
             Write-Host "==> Delete $TestBranch"
             if ((Get-CurrentBranch) -eq $TestBranch) {
@@ -571,6 +690,7 @@ try {
             Write-Host "==> Create $TestBranch from $BaseRef"
             Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
         }
+        Clear-TestCombinedUpstream -Branch $TestBranch
 
         foreach ($Extra in $ResolvedExtras) {
             Write-Host "==> Merge $($Extra.MergeRef) into $TestBranch"
@@ -598,17 +718,21 @@ try {
 }
 catch {
     $msg = "$_"
-    if ($msg -match 'Merge conflict' -and (Test-MergeInProgress)) {
+    if ($msg -match 'Merge conflict' -and (
+            (Test-MergeInProgress) -or ((Get-UnmergedPaths).Count -gt 0)
+        )) {
         $LeaveOnConflict = $true
         Write-Host @"
 
-==> Merge conflict — staying on $TestBranch with the conflict in place.
-Resolve, commit, then:
+==> Merge conflict — still on $TestBranch (do not git switch away).
 
-  git notes --ref=test-combined add -f -m '<stamp>' HEAD   # optional
-  git push --force-with-lease $Remote HEAD:refs/heads/$TestBranch
+Finish:
+  git add -u
+  git commit --no-edit
+  pwsh scripts/maintain-test-combined.ps1 -Push
 
-Or re-run: pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+Abort back to published tip + previous branch:
+  pwsh scripts/maintain-test-combined.ps1 -Abort
 "@
     }
     elseif ((Get-CurrentBranch) -ne $ReturnBranch) {

--- a/scripts/maintain-test-combined.ps1
+++ b/scripts/maintain-test-combined.ps1
@@ -444,7 +444,14 @@ if (-not $ReturnBranch) {
     throw "Could not determine the current branch (detached HEAD?). Check out a branch first."
 }
 
-Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches + @($TestBranch))
+Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
+# test/combined may not exist yet on first publish — soft-fetch only.
+try {
+    Sync-RemoteBranches -RemoteName $Remote -Branches @($TestBranch)
+}
+catch {
+    Write-Host "==> $Remote/$TestBranch not fetched yet (ok on first publish)"
+}
 
 $BaseTarget = Resolve-RemoteTip -Branch $BaseBranch -RemoteName $Remote
 if (-not $BaseTarget) {

--- a/scripts/maintain-test-combined.ps1
+++ b/scripts/maintain-test-combined.ps1
@@ -535,6 +535,7 @@ Commit or stash them before running maintain-test-combined.
 }
 
 $Returned = $false
+$LeaveOnConflict = $false
 try {
     if ($CanReuse) {
         Write-Host "==> Reuse $TestBranch (inputs unchanged)"
@@ -596,22 +597,40 @@ try {
     }
 }
 catch {
-    if ((Get-CurrentBranch) -ne $ReturnBranch) {
+    $msg = "$_"
+    if ($msg -match 'Merge conflict' -and (Test-MergeInProgress)) {
+        $LeaveOnConflict = $true
+        Write-Host @"
+
+==> Merge conflict — staying on $TestBranch with the conflict in place.
+Resolve, commit, then:
+
+  git notes --ref=test-combined add -f -m '<stamp>' HEAD   # optional
+  git push --force-with-lease $Remote HEAD:refs/heads/$TestBranch
+
+Or re-run: pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+"@
+    }
+    elseif ((Get-CurrentBranch) -ne $ReturnBranch) {
         & git merge --abort 2>$null | Out-Null
         & git rebase --abort 2>$null | Out-Null
     }
     throw
 }
 finally {
-    $Current = Get-CurrentBranch
-    if ($Current -ne $ReturnBranch) {
-        Write-Host "==> Return to $ReturnBranch"
-        Restore-DevBranch -Branch $ReturnBranch
-        $Returned = $true
+    if (-not $LeaveOnConflict) {
+        $Current = Get-CurrentBranch
+        if ($Current -ne $ReturnBranch) {
+            Write-Host "==> Return to $ReturnBranch"
+            Restore-DevBranch -Branch $ReturnBranch
+            $Returned = $true
+        }
     }
 }
 
-if (-not $Returned) {
-    Write-Host "==> Return to $ReturnBranch"
-    Restore-DevBranch -Branch $ReturnBranch
+if (-not $LeaveOnConflict) {
+    if (-not $Returned) {
+        Write-Host "==> Return to $ReturnBranch"
+        Restore-DevBranch -Branch $ReturnBranch
+    }
 }

--- a/scripts/maintain-test-combined.ps1
+++ b/scripts/maintain-test-combined.ps1
@@ -1,0 +1,610 @@
+<#
+.SYNOPSIS
+    Rebuild origin/test/combined from team/local config and optionally push.
+
+.DESCRIPTION
+    Reads team/test-combined.json (team/local by default), fetches base + extras
+    from origin, recreates the disposable test branch using remote tips only,
+    and optionally force-pushes with lease.
+
+    Local unpushed commits are never merged — tips are always origin/<branch>.
+    Missing remote extras abort the run.
+
+    Config resolution (first match wins):
+      scripts/test-combined.json          local override (gitignored)
+      team/test-combined.json             working tree
+      team/local:team/test-combined.json  from team/local via git show
+      scripts/test-combined.example.json  fallback
+
+.PARAMETER ConfigPath
+    Path or ref:path to a JSON config. Overrides the default search order.
+
+.PARAMETER TeamConfigRef
+    Git ref for team/test-combined.json via git show. Default: team/local
+
+.PARAMETER Remote
+    Remote name. Default: origin
+
+.PARAMETER Rebuild
+    Force recreate even when the stamp on the existing local test branch matches.
+
+.PARAMETER Push
+    After a successful rebuild (or reuse), push --force-with-lease to Remote.
+
+.PARAMETER BaseBranch / TestBranch / ExtraFeatureBranches / DeleteTestBranchFirst
+    Override individual config fields.
+
+.EXAMPLE
+    pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+
+.EXAMPLE
+    pwsh scripts/maintain-test-combined.ps1
+    Build locally without pushing (e.g. to resolve merge conflicts).
+#>
+
+[CmdletBinding()]
+param(
+    [string] $ConfigPath,
+    [string] $TeamConfigRef = "team/local",
+    [string] $Remote = "origin",
+    [switch] $Rebuild,
+    [switch] $Push,
+    [string] $BaseBranch,
+    [string] $TestBranch,
+    [string[]] $ExtraFeatureBranches,
+    [bool] $DeleteTestBranchFirst
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+Set-Location $RepoRoot
+
+function Invoke-GitCore {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs,
+        [switch] $Quiet
+    )
+    if ($GitArgs.Count -eq 0) {
+        throw "Invoke-GitCore: no arguments"
+    }
+
+    $Output = @(& git.exe @GitArgs 2>&1)
+    $ExitCode = $LASTEXITCODE
+
+    if (-not $Quiet) {
+        foreach ($Line in $Output) {
+            if ($Line -is [System.Management.Automation.ErrorRecord]) {
+                Write-Warning $Line.ToString()
+            }
+            else {
+                Write-Host $Line
+            }
+        }
+    }
+
+    $Stdout = @(
+        $Output |
+            Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] } |
+            ForEach-Object { [string] $_ }
+    )
+
+    return @{
+        ExitCode = $ExitCode
+        Output   = $Stdout
+    }
+}
+
+function Invoke-Git {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs
+    )
+    $Result = Invoke-GitCore @GitArgs
+    if ($Result.ExitCode -ne 0) {
+        throw "git $($GitArgs -join ' ') failed (exit $($Result.ExitCode))"
+    }
+    return $Result.Output
+}
+
+function Invoke-GitSoft {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs
+    )
+    return (Invoke-GitCore @GitArgs).ExitCode
+}
+
+function Test-GitRef {
+    param([string] $Ref)
+    & git show-ref --verify --quiet $Ref
+    return $LASTEXITCODE -eq 0
+}
+
+function Get-RefSha {
+    param([string] $Ref)
+    $Sha = ([string] (& git.exe rev-parse --verify "$Ref^{commit}" 2>$null)).Trim()
+    if ($LASTEXITCODE -ne 0 -or -not $Sha) {
+        return $null
+    }
+    return $Sha
+}
+
+function Sync-RemoteBranches {
+    param(
+        [string] $RemoteName,
+        [string[]] $Branches
+    )
+
+    $UniqueBranches = @($Branches | Where-Object { $_ } | Select-Object -Unique)
+    if ($UniqueBranches.Count -eq 0) {
+        return
+    }
+
+    Write-Host "==> Fetch $RemoteName $($UniqueBranches -join ', ')"
+    $Result = Invoke-GitCore -Quiet @(@('fetch', $RemoteName) + $UniqueBranches)
+    if ($Result.ExitCode -ne 0) {
+        $Detail = ($Result.Output -join "`n").Trim()
+        if ($Detail) {
+            throw "git fetch $RemoteName failed (exit $($Result.ExitCode)): $Detail"
+        }
+        throw "git fetch $RemoteName failed (exit $($Result.ExitCode))"
+    }
+}
+
+function Resolve-RemoteTip {
+    param(
+        [string] $Branch,
+        [string] $RemoteName
+    )
+
+    $RemoteRef = "$RemoteName/$Branch"
+    if (-not (Test-GitRef "refs/remotes/$RemoteName/$Branch")) {
+        return $null
+    }
+    $Sha = Get-RefSha -Ref $RemoteRef
+    if (-not $Sha) { return $null }
+    return @{
+        Branch   = $Branch
+        MergeRef = $RemoteRef
+        Sha      = $Sha
+        Source   = 'remote'
+    }
+}
+
+function Get-InputStamp {
+    param(
+        [string] $ConfigIdentity,
+        [string] $BaseName,
+        [string] $BaseSha,
+        [string[]] $ExtraPairs
+    )
+
+    $Parts = [System.Collections.Generic.List[string]]::new()
+    $Parts.Add("config=$ConfigIdentity")
+    $Parts.Add("base=$BaseName=$BaseSha")
+    foreach ($Pair in $ExtraPairs) {
+        if ($Pair) { $Parts.Add("extra=$Pair") }
+    }
+    return ($Parts -join '|')
+}
+
+function Get-TestCombinedStamp {
+    param([string] $Commit)
+    if (-not $Commit) { return $null }
+    $Lines = @(& git.exe notes --ref=test-combined show $Commit 2>$null)
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+    return (($Lines -join "`n").Trim())
+}
+
+function Set-TestCombinedStamp {
+    param(
+        [string] $Commit,
+        [string] $Stamp
+    )
+    $ExitCode = Invoke-GitSoft @(
+        'notes', '--ref=test-combined', 'add', '-f', '-m', $Stamp, $Commit
+    )
+    if ($ExitCode -ne 0) {
+        Write-Warning "Could not write test-combined stamp note on $Commit"
+    }
+}
+
+function ConvertTo-NormalizedStamp {
+    param([string] $Stamp)
+    if (-not $Stamp) { return $null }
+    $Normalized = $Stamp.Trim() -replace "`r`n", "`n" -replace "`r", "`n"
+    if ($Normalized.Contains("`n")) {
+        $Normalized = (($Normalized -split "`n") | ForEach-Object { $_.Trim() } | Where-Object { $_ }) -join '|'
+    }
+    return $Normalized
+}
+
+function Test-MergeInProgress {
+    $MergeHead = & git.exe rev-parse -q --verify MERGE_HEAD 2>$null
+    return [bool] $MergeHead
+}
+
+function Get-UnmergedPaths {
+    $Output = & git.exe diff --name-only --diff-filter=U 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        return @()
+    }
+    return @($Output | Where-Object { $_ })
+}
+
+function Resolve-IgnoredMergeConflicts {
+    param(
+        [string[]] $IgnoredPaths,
+        [ValidateSet('ours', 'theirs')]
+        [string] $Prefer = 'ours'
+    )
+
+    foreach ($Path in (Get-UnmergedPaths)) {
+        if ($Path -in $IgnoredPaths) {
+            Write-Host "==> Auto-resolve merge conflict in $Path ($Prefer)"
+            Invoke-Git @('checkout', "--$Prefer", '--', $Path)
+            Invoke-Git @('add', '--', $Path)
+        }
+    }
+
+    return @(Get-UnmergedPaths)
+}
+
+function Merge-FeatureBranch {
+    param(
+        [string] $MergeRef,
+        [string] $ExtraBranch,
+        [string[]] $IgnoredPaths
+    )
+
+    $MergeMessage = "test: merge $ExtraBranch for combined testing"
+    $ExitCode = Invoke-GitSoft @(
+        'merge', $MergeRef, '--no-edit', '-m', $MergeMessage
+    )
+    if ($ExitCode -eq 0) {
+        return
+    }
+
+    if (-not (Test-MergeInProgress)) {
+        throw "git merge $MergeRef failed (exit $ExitCode)"
+    }
+
+    $Remaining = Resolve-IgnoredMergeConflicts -IgnoredPaths $IgnoredPaths -Prefer 'ours'
+    if ($Remaining.Count -gt 0) {
+        throw "Merge conflict in: $($Remaining -join ', ')"
+    }
+
+    Invoke-Git @('commit', '--no-edit')
+}
+
+function Get-CurrentBranch {
+    return ([string] (Invoke-Git @('branch', '--show-current') | Select-Object -First 1)).Trim()
+}
+
+function Restore-DevBranch {
+    param([string] $Branch)
+    if ($Branch) {
+        Invoke-Git @('checkout', $Branch)
+    }
+}
+
+function Get-GitConfigJson {
+    param(
+        [string[]] $Refs,
+        [string] $RepoPath = "team/test-combined.json"
+    )
+
+    foreach ($Ref in $Refs) {
+        if (-not $Ref) { continue }
+        $Spec = "${Ref}:${RepoPath}"
+        $Json = & git show $Spec 2>$null
+        if ($LASTEXITCODE -eq 0 -and $Json) {
+            return @{ Source = $Spec; Json = [string] $Json }
+        }
+    }
+
+    return $null
+}
+
+function Resolve-ConfigSource {
+    param(
+        [string] $ExplicitPath,
+        [string] $TeamRef
+    )
+
+    if ($ExplicitPath) {
+        if (Test-Path $ExplicitPath) {
+            return @{
+                Source = (Resolve-Path $ExplicitPath).Path
+                Json   = $null
+            }
+        }
+        if ($ExplicitPath -match ':') {
+            $Json = & git show $ExplicitPath 2>$null
+            if ($LASTEXITCODE -eq 0 -and $Json) {
+                return @{ Source = $ExplicitPath; Json = [string] $Json }
+            }
+        }
+        throw "Config file not found: $ExplicitPath"
+    }
+
+    $LocalCandidates = @(
+        (Join-Path $RepoRoot "scripts/test-combined.json"),
+        (Join-Path $RepoRoot "team/test-combined.json")
+    )
+
+    foreach ($Candidate in $LocalCandidates) {
+        if (Test-Path $Candidate) {
+            return @{
+                Source = (Resolve-Path $Candidate).Path
+                Json   = $null
+            }
+        }
+    }
+
+    $GitRefs = @(
+        $TeamRef,
+        "origin/$TeamRef"
+    )
+    $FromGit = Get-GitConfigJson -Refs $GitRefs
+    if ($FromGit) {
+        return $FromGit
+    }
+
+    $Example = Join-Path $RepoRoot "scripts/test-combined.example.json"
+    if (Test-Path $Example) {
+        Write-Warning "Using example config ($Example). Copy to scripts/test-combined.json or update team/local."
+        return @{
+            Source = (Resolve-Path $Example).Path
+            Json   = $null
+        }
+    }
+
+    throw @"
+No test-combined config found.
+Fetch team/local (git fetch origin team/local) or create scripts/test-combined.json from scripts/test-combined.example.json.
+"@
+}
+
+function Read-TestCombinedConfig {
+    param(
+        [string] $Source,
+        [string] $Json
+    )
+
+    try {
+        if ($Json) {
+            $Config = $Json | ConvertFrom-Json
+        }
+        else {
+            $Config = Get-Content -Raw -Path $Source | ConvertFrom-Json
+        }
+    }
+    catch {
+        throw "Failed to parse config JSON at '$Source': $_"
+    }
+
+    foreach ($Required in @("baseBranch", "testBranch", "extraFeatureBranches")) {
+        if (-not ($Config.PSObject.Properties.Name -contains $Required)) {
+            throw "Config '$Source' is missing required field '$Required'."
+        }
+    }
+
+    return $Config
+}
+
+if (-not (Test-Path "FYPA.py")) {
+    throw "FYPA.py not found in $RepoRoot — run this script from the FYPA repo."
+}
+
+# Soft-fetch team config ref so git show origin/team/local:... works.
+if (-not $ConfigPath) {
+    try {
+        Sync-RemoteBranches -RemoteName $Remote -Branches @($TeamConfigRef)
+    }
+    catch {
+        Write-Warning "Fetch $Remote $TeamConfigRef failed; using existing refs if present."
+        Write-Warning "$_"
+    }
+}
+
+$ConfigSource = Resolve-ConfigSource -ExplicitPath $ConfigPath -TeamRef $TeamConfigRef
+Write-Host "==> Config: $($ConfigSource.Source)"
+$Config = Read-TestCombinedConfig -Source $ConfigSource.Source -Json $ConfigSource.Json
+
+$BaseBranch = if ($PSBoundParameters.ContainsKey("BaseBranch")) { $BaseBranch } else { [string] $Config.baseBranch }
+$TestBranch = if ($PSBoundParameters.ContainsKey("TestBranch")) { $TestBranch } else { [string] $Config.testBranch }
+$ExtraFeatureBranches = if ($PSBoundParameters.ContainsKey("ExtraFeatureBranches")) {
+    $ExtraFeatureBranches
+}
+else {
+    @($Config.extraFeatureBranches | ForEach-Object { [string] $_ })
+}
+$DeleteTestBranchFirst = if ($PSBoundParameters.ContainsKey("DeleteTestBranchFirst")) {
+    $DeleteTestBranchFirst
+}
+elseif ($Config.PSObject.Properties.Name -contains "deleteTestBranchFirst") {
+    [bool] $Config.deleteTestBranchFirst
+}
+else {
+    $false
+}
+
+if (-not $BaseBranch) { throw "baseBranch is empty." }
+if (-not $TestBranch) { throw "testBranch is empty." }
+
+Write-Host "==> Branch source: $Remote tips only (no local-ahead merge)"
+
+$ReturnBranch = Get-CurrentBranch
+if (-not $ReturnBranch) {
+    throw "Could not determine the current branch (detached HEAD?). Check out a branch first."
+}
+
+Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches + @($TestBranch))
+
+$BaseTarget = Resolve-RemoteTip -Branch $BaseBranch -RemoteName $Remote
+if (-not $BaseTarget) {
+    throw "Base branch '$BaseBranch' not found as $Remote/$BaseBranch. Push it first."
+}
+
+$BaseRef = $BaseTarget.MergeRef
+$BaseSha = $BaseTarget.Sha
+Write-Host "==> Base: $BaseRef"
+
+$ExtraStampPairs = [System.Collections.Generic.List[string]]::new()
+$ResolvedExtras = [System.Collections.Generic.List[hashtable]]::new()
+$MissingExtras = [System.Collections.Generic.List[string]]::new()
+foreach ($ExtraBranch in $ExtraFeatureBranches) {
+    if (-not $ExtraBranch) { continue }
+    $ExtraTarget = Resolve-RemoteTip -Branch $ExtraBranch -RemoteName $Remote
+    if (-not $ExtraTarget) {
+        $MissingExtras.Add($ExtraBranch)
+        continue
+    }
+    Write-Host "==> Extra: $($ExtraTarget.MergeRef)"
+    $ExtraStampPairs.Add("$ExtraBranch=$($ExtraTarget.Sha)")
+    $ResolvedExtras.Add(@{
+        Branch   = $ExtraTarget.Branch
+        MergeRef = $ExtraTarget.MergeRef
+    })
+}
+
+if ($MissingExtras.Count -gt 0) {
+    throw @"
+Missing on ${Remote}: $($MissingExtras -join ', ').
+Push each feature branch before maintaining $TestBranch.
+"@
+}
+
+$ConfigIdentity = @(
+    "base=$BaseBranch",
+    "test=$TestBranch",
+    "deleteFirst=$DeleteTestBranchFirst",
+    "extras=$($ExtraFeatureBranches -join ',')"
+) -join ';'
+
+$DesiredStamp = ConvertTo-NormalizedStamp (Get-InputStamp `
+    -ConfigIdentity $ConfigIdentity `
+    -BaseName $BaseBranch `
+    -BaseSha $BaseSha `
+    -ExtraPairs @($ExtraStampPairs))
+
+$TestBranchExists = Test-GitRef "refs/heads/$TestBranch"
+$ExistingTip = if ($TestBranchExists) { Get-RefSha -Ref $TestBranch } else { $null }
+$ExistingStamp = ConvertTo-NormalizedStamp (Get-TestCombinedStamp -Commit $ExistingTip)
+$CanReuse = (
+    -not $Rebuild -and
+    $TestBranchExists -and
+    $ExistingStamp -and
+    ($ExistingStamp -eq $DesiredStamp)
+)
+
+if (-not $CanReuse -and $TestBranchExists -and -not $Rebuild) {
+    if (-not $ExistingStamp) {
+        Write-Host "==> No reuse stamp on $TestBranch — will rebuild"
+    }
+    else {
+        Write-Host "==> Stamp mismatch on $TestBranch — will rebuild"
+    }
+}
+
+$IgnoredPaths = @('.gitignore', 'FYPA.code-workspace')
+$Status = @(Invoke-Git @('status', '--porcelain'))
+$BlockingStatus = @($Status | Where-Object {
+    $path = $_.Substring(3).Trim()
+    if ($path -match ' -> ') { $path = ($path -split ' -> ', 2)[-1].Trim() }
+    elseif ($path -match "`t") { $path = ($path -split "`t", 2)[-1].Trim() }
+    $path -notin $IgnoredPaths
+})
+if ($BlockingStatus.Count -gt 0) {
+    throw @"
+Uncommitted changes detected on '$ReturnBranch'.
+Commit or stash them before running maintain-test-combined.
+"@
+}
+
+$Returned = $false
+try {
+    if ($CanReuse) {
+        Write-Host "==> Reuse $TestBranch (inputs unchanged)"
+        if ((Get-CurrentBranch) -ne $TestBranch) {
+            Invoke-Git @('checkout', $TestBranch)
+        }
+    }
+    else {
+        if ($Rebuild) {
+            Write-Host "==> Rebuild requested — recreating $TestBranch"
+        }
+        elseif (-not $TestBranchExists) {
+            Write-Host "==> $TestBranch missing — creating from $BaseRef"
+        }
+        else {
+            Write-Host "==> Inputs changed — recreating $TestBranch from $BaseRef"
+        }
+
+        if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
+            Write-Host "==> Delete $TestBranch"
+            if ((Get-CurrentBranch) -eq $TestBranch) {
+                Invoke-Git @('checkout', $ReturnBranch)
+            }
+            Invoke-Git @('branch', '-D', $TestBranch)
+        }
+
+        if (Test-GitRef "refs/heads/$TestBranch") {
+            Write-Host "==> Recreate $TestBranch from $BaseRef"
+            Invoke-Git @('branch', '-f', $TestBranch, $BaseRef)
+            Invoke-Git @('checkout', $TestBranch)
+        }
+        else {
+            Write-Host "==> Create $TestBranch from $BaseRef"
+            Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
+        }
+
+        foreach ($Extra in $ResolvedExtras) {
+            Write-Host "==> Merge $($Extra.MergeRef) into $TestBranch"
+            Merge-FeatureBranch -MergeRef $Extra.MergeRef -ExtraBranch $Extra.Branch -IgnoredPaths $IgnoredPaths
+        }
+
+        $NewTip = Get-RefSha -Ref 'HEAD'
+        if ($NewTip) {
+            Set-TestCombinedStamp -Commit $NewTip -Stamp $DesiredStamp
+            Write-Host "==> Stamp written for $TestBranch"
+        }
+    }
+
+    $Tip = Get-RefSha -Ref 'HEAD'
+    Write-Host "==> $TestBranch tip: $Tip"
+
+    if ($Push) {
+        Write-Host "==> Push --force-with-lease $Remote $TestBranch"
+        Invoke-Git @('push', '--force-with-lease', $Remote, "HEAD:refs/heads/$TestBranch")
+        Write-Host "==> Pushed $Remote/$TestBranch"
+    }
+    else {
+        Write-Host "==> Local only (pass -Push to update $Remote/$TestBranch)"
+    }
+}
+catch {
+    if ((Get-CurrentBranch) -ne $ReturnBranch) {
+        & git merge --abort 2>$null | Out-Null
+        & git rebase --abort 2>$null | Out-Null
+    }
+    throw
+}
+finally {
+    $Current = Get-CurrentBranch
+    if ($Current -ne $ReturnBranch) {
+        Write-Host "==> Return to $ReturnBranch"
+        Restore-DevBranch -Branch $ReturnBranch
+        $Returned = $true
+    }
+}
+
+if (-not $Returned) {
+    Write-Host "==> Return to $ReturnBranch"
+    Restore-DevBranch -Branch $ReturnBranch
+}

--- a/scripts/test-combined.example.json
+++ b/scripts/test-combined.example.json
@@ -1,0 +1,9 @@
+{
+  "baseBranch": "main",
+  "testBranch": "test/combined",
+  "deleteTestBranchFirst": true,
+  "extraFeatureBranches": [
+    "feature/example-a",
+    "fix/example-b"
+  ]
+}

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -10,6 +10,7 @@
 #   pwsh scripts/test-combined.ps1
 #   pwsh scripts/test-combined.ps1 --local-only
 #   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
+#   pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
 #
 # By default baseBranch and extraFeatureBranches are fetched from origin and merged
 # via origin/<branch>. Pass --local-only to use local branches only.
@@ -30,7 +31,8 @@ param(
     [string] $BaseBranch,
     [string] $TestBranch,
     [string[]] $ExtraFeatureBranches,
-    [bool] $DeleteTestBranchFirst
+    [bool] $DeleteTestBranchFirst,
+    [string] $PrjPcb
 )
 
 $ErrorActionPreference = "Stop"
@@ -341,6 +343,14 @@ else {
     $false
 }
 
+$PrjPcbPath = $null
+if ($PrjPcb) {
+    if (-not (Test-Path -LiteralPath $PrjPcb)) {
+        throw "PrjPcb not found: $PrjPcb"
+    }
+    $PrjPcbPath = (Resolve-Path -LiteralPath $PrjPcb).Path
+}
+
 if (-not $BaseBranch) { throw "baseBranch is empty." }
 if (-not $TestBranch) { throw "testBranch is empty." }
 
@@ -434,7 +444,13 @@ try {
     }
 
     Write-Host "==> uv run FYPA.py"
-    & uv run --extra spacemouse FYPA.py
+    if ($PrjPcbPath) {
+        Write-Host "    Project: $PrjPcbPath"
+        & uv run --extra spacemouse FYPA.py gui $PrjPcbPath
+    }
+    else {
+        & uv run --extra spacemouse FYPA.py
+    }
     $FypaExit = $LASTEXITCODE
 }
 catch {

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -1,0 +1,463 @@
+# Build a local combined test branch from a base branch + feature branches, run tests/FYPA, then switch back.
+#
+# Config (first match wins):
+#   scripts/test-combined.json          local override (gitignored)
+#   team/test-combined.json             working tree
+#   team/local:team/test-combined.json  from team/local branch via git show (no checkout)
+#   scripts/test-combined.example.json  fallback
+#
+# Usage (from repo root, any branch):
+#   pwsh scripts/test-combined.ps1
+#   pwsh scripts/test-combined.ps1 --local-only
+#   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
+#
+# By default baseBranch and extraFeatureBranches are fetched from origin and merged
+# via origin/<branch>. Pass --local-only to use local branches only.
+#
+# Workflow:
+#   1. Remember current branch
+#   2. Optionally delete the test branch, then recreate it from the base branch
+#   3. Merge every extra feature branch (.gitignore conflicts auto-resolved with --ours)
+#   4. Run pytest topology suite, then uv run FYPA.py
+#   5. Return to the branch you started on (even if a step exits with an error)
+
+[CmdletBinding()]
+param(
+    [string] $ConfigPath,
+    [string] $TeamConfigRef = "team/local",
+    [string] $Remote = "origin",
+    [switch] $LocalOnly,
+    [string] $BaseBranch,
+    [string] $TestBranch,
+    [string[]] $ExtraFeatureBranches,
+    [bool] $DeleteTestBranchFirst
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+Set-Location $RepoRoot
+
+function Invoke-GitCore {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs,
+        [switch] $Quiet
+    )
+    if ($GitArgs.Count -eq 0) {
+        throw "Invoke-GitCore: no arguments"
+    }
+
+    $Output = @(& git.exe @GitArgs 2>&1)
+    $ExitCode = $LASTEXITCODE
+
+    if (-not $Quiet) {
+        foreach ($Line in $Output) {
+            if ($Line -is [System.Management.Automation.ErrorRecord]) {
+                Write-Warning $Line.ToString()
+            }
+            else {
+                Write-Host $Line
+            }
+        }
+    }
+
+    $Stdout = @(
+        $Output |
+            Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] } |
+            ForEach-Object { [string] $_ }
+    )
+
+    return @{
+        ExitCode = $ExitCode
+        Output   = $Stdout
+    }
+}
+
+function Invoke-Git {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs
+    )
+    $Result = Invoke-GitCore @GitArgs
+    if ($Result.ExitCode -ne 0) {
+        throw "git $($GitArgs -join ' ') failed (exit $($Result.ExitCode))"
+    }
+    return $Result.Output
+}
+
+function Invoke-GitSoft {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs
+    )
+    return (Invoke-GitCore @GitArgs).ExitCode
+}
+
+function Test-GitRef {
+    param([string] $Ref)
+    & git show-ref --verify --quiet $Ref
+    return $LASTEXITCODE -eq 0
+}
+
+function Get-BranchMergeRef {
+    param(
+        [string] $Branch,
+        [string] $RemoteName,
+        [bool] $UseLocalOnly
+    )
+
+    if ($UseLocalOnly) {
+        return $Branch
+    }
+    return "$RemoteName/$Branch"
+}
+
+function Test-BranchAvailable {
+    param(
+        [string] $Branch,
+        [string] $RemoteName,
+        [bool] $UseLocalOnly
+    )
+
+    if ($UseLocalOnly) {
+        return Test-GitRef "refs/heads/$Branch"
+    }
+    return Test-GitRef "refs/remotes/$RemoteName/$Branch"
+}
+
+function Sync-RemoteBranches {
+    param(
+        [string] $RemoteName,
+        [string[]] $Branches
+    )
+
+    $UniqueBranches = @($Branches | Where-Object { $_ } | Select-Object -Unique)
+    if ($UniqueBranches.Count -eq 0) {
+        return
+    }
+
+    Write-Host "==> Fetch $RemoteName $($UniqueBranches -join ', ')"
+    Invoke-Git @(@('fetch', $RemoteName) + $UniqueBranches)
+}
+
+function Test-MergeInProgress {
+    $MergeHead = & git.exe rev-parse -q --verify MERGE_HEAD 2>$null
+    return [bool] $MergeHead
+}
+
+function Get-UnmergedPaths {
+    $Output = & git.exe diff --name-only --diff-filter=U 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        return @()
+    }
+    return @($Output | Where-Object { $_ })
+}
+
+function Resolve-IgnoredMergeConflicts {
+    param(
+        [string[]] $IgnoredPaths,
+        [ValidateSet('ours', 'theirs')]
+        [string] $Prefer = 'ours'
+    )
+
+    foreach ($Path in (Get-UnmergedPaths)) {
+        if ($Path -in $IgnoredPaths) {
+            Write-Host "==> Auto-resolve merge conflict in $Path ($Prefer)"
+            Invoke-Git @('checkout', "--$Prefer", '--', $Path)
+            Invoke-Git @('add', '--', $Path)
+        }
+    }
+
+    return @(Get-UnmergedPaths)
+}
+
+function Merge-FeatureBranch {
+    param(
+        [string] $MergeRef,
+        [string] $ExtraBranch,
+        [string[]] $IgnoredPaths
+    )
+
+    $MergeMessage = "test: merge $ExtraBranch for local testing"
+    $ExitCode = Invoke-GitSoft @(
+        'merge', $MergeRef, '--no-edit', '-m', $MergeMessage
+    )
+    if ($ExitCode -eq 0) {
+        return
+    }
+
+    if (-not (Test-MergeInProgress)) {
+        throw "git merge $MergeRef failed (exit $ExitCode)"
+    }
+
+    $Remaining = Resolve-IgnoredMergeConflicts -IgnoredPaths $IgnoredPaths -Prefer 'ours'
+    if ($Remaining.Count -gt 0) {
+        throw "Merge conflict in: $($Remaining -join ', ')"
+    }
+
+    Invoke-Git @('commit', '--no-edit')
+}
+
+function Get-CurrentBranch {
+    return ([string] (Invoke-Git @('branch', '--show-current') | Select-Object -First 1)).Trim()
+}
+
+function Restore-DevBranch {
+    param([string] $Branch)
+    if ($Branch) {
+        Invoke-Git @('checkout', $Branch)
+    }
+}
+
+function Get-GitConfigJson {
+    param(
+        [string[]] $Refs,
+        [string] $RepoPath = "team/test-combined.json"
+    )
+
+    foreach ($Ref in $Refs) {
+        if (-not $Ref) { continue }
+        $Spec = "${Ref}:${RepoPath}"
+        $Json = & git show $Spec 2>$null
+        if ($LASTEXITCODE -eq 0 -and $Json) {
+            return @{ Source = $Spec; Json = [string] $Json }
+        }
+    }
+
+    return $null
+}
+
+function Resolve-ConfigSource {
+    param(
+        [string] $ExplicitPath,
+        [string] $TeamRef
+    )
+
+    if ($ExplicitPath) {
+        if (Test-Path $ExplicitPath) {
+            return @{
+                Source = (Resolve-Path $ExplicitPath).Path
+                Json   = $null
+            }
+        }
+        if ($ExplicitPath -match ':') {
+            $Json = & git show $ExplicitPath 2>$null
+            if ($LASTEXITCODE -eq 0 -and $Json) {
+                return @{ Source = $ExplicitPath; Json = [string] $Json }
+            }
+        }
+        throw "Config file not found: $ExplicitPath"
+    }
+
+    $LocalCandidates = @(
+        (Join-Path $RepoRoot "scripts/test-combined.json"),
+        (Join-Path $RepoRoot "team/test-combined.json")
+    )
+
+    foreach ($Candidate in $LocalCandidates) {
+        if (Test-Path $Candidate) {
+            return @{
+                Source = (Resolve-Path $Candidate).Path
+                Json   = $null
+            }
+        }
+    }
+
+    $GitRefs = @(
+        $TeamRef,
+        "origin/$TeamRef"
+    )
+    $FromGit = Get-GitConfigJson -Refs $GitRefs
+    if ($FromGit) {
+        return $FromGit
+    }
+
+    $Example = Join-Path $RepoRoot "scripts/test-combined.example.json"
+    if (Test-Path $Example) {
+        Write-Warning "Using example config ($Example). Copy to scripts/test-combined.json or update team/local."
+        return @{
+            Source = (Resolve-Path $Example).Path
+            Json   = $null
+        }
+    }
+
+    throw @"
+No test-combined config found.
+Fetch team/local (git fetch origin team/local) or create scripts/test-combined.json from scripts/test-combined.example.json.
+"@
+}
+
+function Read-TestCombinedConfig {
+    param(
+        [string] $Source,
+        [string] $Json
+    )
+
+    try {
+        if ($Json) {
+            $Config = $Json | ConvertFrom-Json
+        }
+        else {
+            $Config = Get-Content -Raw -Path $Source | ConvertFrom-Json
+        }
+    }
+    catch {
+        throw "Failed to parse config JSON at '$Source': $_"
+    }
+
+    foreach ($Required in @("baseBranch", "testBranch", "extraFeatureBranches")) {
+        if (-not ($Config.PSObject.Properties.Name -contains $Required)) {
+            throw "Config '$Source' is missing required field '$Required'."
+        }
+    }
+
+    return $Config
+}
+
+if (-not (Test-Path "FYPA.py")) {
+    throw "FYPA.py not found in $RepoRoot — run this script from the FYPA repo."
+}
+
+$ConfigSource = Resolve-ConfigSource -ExplicitPath $ConfigPath -TeamRef $TeamConfigRef
+Write-Host "==> Config: $($ConfigSource.Source)"
+$Config = Read-TestCombinedConfig -Source $ConfigSource.Source -Json $ConfigSource.Json
+
+$BaseBranch = if ($PSBoundParameters.ContainsKey("BaseBranch")) { $BaseBranch } else { [string] $Config.baseBranch }
+$TestBranch = if ($PSBoundParameters.ContainsKey("TestBranch")) { $TestBranch } else { [string] $Config.testBranch }
+$ExtraFeatureBranches = if ($PSBoundParameters.ContainsKey("ExtraFeatureBranches")) {
+    $ExtraFeatureBranches
+}
+else {
+    @($Config.extraFeatureBranches | ForEach-Object { [string] $_ })
+}
+$DeleteTestBranchFirst = if ($PSBoundParameters.ContainsKey("DeleteTestBranchFirst")) {
+    $DeleteTestBranchFirst
+}
+elseif ($Config.PSObject.Properties.Name -contains "deleteTestBranchFirst") {
+    [bool] $Config.deleteTestBranchFirst
+}
+else {
+    $false
+}
+
+if (-not $BaseBranch) { throw "baseBranch is empty." }
+if (-not $TestBranch) { throw "testBranch is empty." }
+
+$UseLocalOnly = [bool] $LocalOnly
+if ($UseLocalOnly) {
+    Write-Host "==> Branch source: local only"
+}
+else {
+    Write-Host "==> Branch source: $Remote (fetch + merge remote-tracking refs)"
+}
+
+$ReturnBranch = Get-CurrentBranch
+if (-not $ReturnBranch) {
+    throw "Could not determine the current branch."
+}
+
+if ($UseLocalOnly) {
+    if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $true)) {
+        throw "Base branch '$BaseBranch' not found locally."
+    }
+}
+else {
+    Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
+    if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $false)) {
+        throw "Remote branch '$Remote/$BaseBranch' not found after fetch."
+    }
+}
+
+$BaseRef = Get-BranchMergeRef -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+
+$IgnoredPaths = @('.gitignore', 'FYPA.code-workspace')
+$Status = @(Invoke-Git @('status', '--porcelain'))
+$BlockingStatus = @($Status | Where-Object {
+    $path = $_.Substring(3).Trim()
+    if ($path -match ' -> ') { $path = ($path -split ' -> ', 2)[-1].Trim() }
+    elseif ($path -match "`t") { $path = ($path -split "`t", 2)[-1].Trim() }
+    $path -notin $IgnoredPaths
+})
+if ($BlockingStatus.Count -gt 0) {
+    throw @"
+Uncommitted changes detected on '$ReturnBranch'.
+Commit or stash them before running the test script.
+"@
+}
+
+$Returned = $false
+$FypaExit = 0
+try {
+    if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
+        Write-Host "==> Delete $TestBranch"
+        if (Get-CurrentBranch -eq $TestBranch) {
+            Invoke-Git @('checkout', $ReturnBranch)
+        }
+        Invoke-Git @('branch', '-D', $TestBranch)
+    }
+
+    if (Test-GitRef "refs/heads/$TestBranch") {
+        Write-Host "==> Recreate $TestBranch from $BaseRef"
+        Invoke-Git @('branch', '-f', $TestBranch, $BaseRef)
+        Invoke-Git @('checkout', $TestBranch)
+    }
+    else {
+        Write-Host "==> Create $TestBranch from $BaseRef"
+        Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
+    }
+
+    foreach ($ExtraBranch in $ExtraFeatureBranches) {
+        if (-not $ExtraBranch) { continue }
+
+        $MergeRef = Get-BranchMergeRef -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+        if (Test-BranchAvailable -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly) {
+            Write-Host "==> Merge $MergeRef into $TestBranch"
+            Merge-FeatureBranch -MergeRef $MergeRef -ExtraBranch $ExtraBranch -IgnoredPaths $IgnoredPaths
+        }
+        else {
+            $Label = if ($UseLocalOnly) { "local branch" } else { "remote branch" }
+            Write-Warning "Extra feature $Label '$ExtraBranch' not found — continuing without it."
+        }
+    }
+
+    Write-Host "==> pytest topology tests"
+    & uv run python -m pytest `
+        tests/test_topology_invariants.py `
+        tests/test_topology_regressions.py `
+        tests/test_topology_layout.py `
+        tests/test_topology_geometry.py `
+        tests/test_topology_labels.py `
+        tests/test_pdn_topology.py -q
+    if ($LASTEXITCODE -ne 0) {
+        throw "pytest failed (exit $LASTEXITCODE)"
+    }
+
+    Write-Host "==> uv run FYPA.py"
+    & uv run --extra spacemouse FYPA.py
+    $FypaExit = $LASTEXITCODE
+}
+catch {
+    if (Get-CurrentBranch -ne $ReturnBranch) {
+        & git merge --abort 2>$null | Out-Null
+        & git rebase --abort 2>$null | Out-Null
+    }
+    throw
+}
+finally {
+    $Current = Get-CurrentBranch
+    if ($Current -ne $ReturnBranch) {
+        Write-Host "==> Return to $ReturnBranch"
+        Restore-DevBranch -Branch $ReturnBranch
+        $Returned = $true
+    }
+}
+
+if (-not $Returned) {
+    Write-Host "==> Return to $ReturnBranch"
+    Restore-DevBranch -Branch $ReturnBranch
+}
+
+if ($FypaExit -and $FypaExit -ne 0) {
+    exit $FypaExit
+}

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -1,36 +1,112 @@
-# Build a local combined test branch from a base branch + feature branches, run tests/FYPA, then switch back.
-#
-# Config (first match wins):
-#   scripts/test-combined.json          local override (gitignored)
-#   team/test-combined.json             working tree
-#   team/local:team/test-combined.json  from team/local branch via git show (no checkout)
-#   scripts/test-combined.example.json  fallback
-#
-# Usage (from repo root, any branch):
-#   pwsh scripts/test-combined.ps1
-#   pwsh scripts/test-combined.ps1 -LocalOnly
-#   pwsh scripts/test-combined.ps1 -Rebuild
-#   pwsh scripts/test-combined.ps1 -SkipTests
-#   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
-#   pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
-#
-# By default baseBranch and extraFeatureBranches are soft-fetched from origin.
-# Each input is resolved to the tip that includes local work: if the local branch
-# is ahead of (or diverged from) origin/<branch>, the local tip is merged; if
-# local is behind, origin/<branch> is used; local-only or remote-only branches
-# are accepted either way. If fetch fails (offline), existing refs are resolved
-# the same way. When input SHAs match the stamp on an existing test branch, that
-# branch is reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
-# Pass -LocalOnly to skip fetch and use local branches only.
-#
-# Workflow:
-#   1. Remember current branch
-#   2. Soft-fetch inputs (or local-only); resolve tips (prefer local when ahead);
-#      reuse test branch if stamp matches
-#   3. Otherwise optionally delete, recreate from base, merge feature branches
-#      (.gitignore conflicts auto-resolved with --ours); write stamp note
-#   4. Optionally run pytest topology suite (-SkipTests to skip), then uv run FYPA.py
-#   5. Return to the branch you started on (even if a step exits with an error)
+<#
+.SYNOPSIS
+    Build a local combined test branch, run tests/FYPA, then switch back.
+
+.DESCRIPTION
+    Merges a base branch plus feature branches into a disposable test branch,
+    optionally runs the pytest topology suite and FYPA.py, then returns to the
+    branch you started on (even if a step exits with an error).
+
+    Config resolution (first match wins):
+      scripts/test-combined.json          local override (gitignored)
+      team/test-combined.json             working tree
+      team/local:team/test-combined.json  from team/local via git show (no checkout)
+      scripts/test-combined.example.json  fallback
+
+    By default baseBranch and extraFeatureBranches are soft-fetched from origin.
+    Each input is resolved to the tip that includes local work: if the local
+    branch is ahead of (or diverged from) origin/<branch>, the local tip is
+    merged; if local is behind, origin/<branch> is used; local-only or
+    remote-only branches are accepted either way. If fetch fails (offline),
+    existing refs are resolved the same way.
+
+    When input SHAs match the stamp on an existing test branch, that branch is
+    reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
+    Pass -LocalOnly to skip fetch and use local branches only.
+
+    Workflow:
+      1. Remember current branch
+      2. Soft-fetch inputs (or local-only); resolve tips (prefer local when ahead);
+         reuse test branch if stamp matches
+      3. Otherwise optionally delete, recreate from base, merge feature branches
+         (.gitignore conflicts auto-resolved with --ours); write stamp note
+      4. Optionally run pytest topology suite (-SkipTests to skip), then uv run FYPA.py
+      5. Return to the starting branch
+
+.PARAMETER ConfigPath
+    Path to a JSON config file. Overrides the default config search order.
+
+.PARAMETER TeamConfigRef
+    Git ref used when reading team/test-combined.json via git show.
+    Default: team/local
+
+.PARAMETER Remote
+    Remote name used for soft-fetch and tip resolution. Default: origin
+
+.PARAMETER LocalOnly
+    Skip fetch; resolve and merge local branches only.
+
+.PARAMETER Rebuild
+    Force delete/recreate of the test branch even when the stamp matches.
+
+.PARAMETER SkipTests
+    Skip the pytest topology suite; still runs FYPA.py unless the script exits earlier.
+
+.PARAMETER BaseBranch
+    Override config baseBranch (branch the test branch is created from).
+
+.PARAMETER TestBranch
+    Override config testBranch (name of the disposable combined branch).
+
+.PARAMETER ExtraFeatureBranches
+    Override config extraFeatureBranches (branches merged onto the base).
+
+.PARAMETER DeleteTestBranchFirst
+    Override config deleteTestBranchFirst. When true, delete the existing test
+    branch before recreating it.
+
+.PARAMETER PrjPcb
+    Path to a .PrjPcb passed through to FYPA.py.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1
+
+    Use default config resolution, soft-fetch, reuse or rebuild the test branch,
+    run tests and FYPA, then switch back.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1 -LocalOnly
+
+    Skip remote fetch; use local branch tips only.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1 -Rebuild
+
+    Force a clean recreate of the test branch.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1 -SkipTests
+
+    Build/reuse the test branch and run FYPA without pytest.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
+
+    Use an explicit local config file.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
+
+    Pass a project file through to FYPA.py.
+
+.EXAMPLE
+    Get-Help .\scripts\test-combined.ps1 -Full
+
+    Show this help. Equivalent: pwsh scripts/test-combined.ps1 -?
+
+.NOTES
+    Run from the repo root (or any branch); the script cds to the repo root itself.
+#>
 
 [CmdletBinding()]
 param(

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -9,17 +9,23 @@
 # Usage (from repo root, any branch):
 #   pwsh scripts/test-combined.ps1
 #   pwsh scripts/test-combined.ps1 --local-only
+#   pwsh scripts/test-combined.ps1 -Rebuild
+#   pwsh scripts/test-combined.ps1 -SkipTests
 #   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
 #   pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
 #
-# By default baseBranch and extraFeatureBranches are fetched from origin and merged
-# via origin/<branch>. Pass --local-only to use local branches only.
+# By default baseBranch and extraFeatureBranches are soft-fetched from origin and
+# merged via origin/<branch>. If fetch fails (offline), local refs are used.
+# When input SHAs match the stamp on an existing test branch, that branch is
+# reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
+# Pass --local-only to skip fetch and use local branches only.
 #
 # Workflow:
 #   1. Remember current branch
-#   2. Optionally delete the test branch, then recreate it from the base branch
-#   3. Merge every extra feature branch (.gitignore conflicts auto-resolved with --ours)
-#   4. Run pytest topology suite, then uv run FYPA.py
+#   2. Soft-fetch inputs (or local-only); reuse test branch if stamp matches
+#   3. Otherwise optionally delete, recreate from base, merge feature branches
+#      (.gitignore conflicts auto-resolved with --ours); write stamp note
+#   4. Optionally run pytest topology suite (-SkipTests to skip), then uv run FYPA.py
 #   5. Return to the branch you started on (even if a step exits with an error)
 
 [CmdletBinding()]
@@ -28,6 +34,8 @@ param(
     [string] $TeamConfigRef = "team/local",
     [string] $Remote = "origin",
     [switch] $LocalOnly,
+    [switch] $Rebuild,
+    [switch] $SkipTests,
     [string] $BaseBranch,
     [string] $TestBranch,
     [string[]] $ExtraFeatureBranches,
@@ -140,7 +148,78 @@ function Sync-RemoteBranches {
     }
 
     Write-Host "==> Fetch $RemoteName $($UniqueBranches -join ', ')"
-    Invoke-Git @(@('fetch', $RemoteName) + $UniqueBranches)
+    # git writes progress to stderr; don't surface it as PowerShell warnings.
+    $Result = Invoke-GitCore -Quiet @(@('fetch', $RemoteName) + $UniqueBranches)
+    if ($Result.ExitCode -ne 0) {
+        $Detail = ($Result.Output -join "`n").Trim()
+        if ($Detail) {
+            throw "git fetch $RemoteName failed (exit $($Result.ExitCode)): $Detail"
+        }
+        throw "git fetch $RemoteName failed (exit $($Result.ExitCode))"
+    }
+}
+
+function Get-RefSha {
+    param([string] $Ref)
+    $Sha = ([string] (& git.exe rev-parse --verify "$Ref^{commit}" 2>$null)).Trim()
+    if ($LASTEXITCODE -ne 0 -or -not $Sha) {
+        return $null
+    }
+    return $Sha
+}
+
+function Get-InputStamp {
+    param(
+        [string] $ConfigIdentity,
+        [string] $BaseName,
+        [string] $BaseSha,
+        [string[]] $ExtraPairs
+    )
+
+    # Single-line stamp: PowerShell [string] casts of multi-line git output join
+    # with spaces and would break equality checks if we used newlines.
+    $Parts = [System.Collections.Generic.List[string]]::new()
+    $Parts.Add("config=$ConfigIdentity")
+    $Parts.Add("base=$BaseName=$BaseSha")
+    foreach ($Pair in $ExtraPairs) {
+        if ($Pair) { $Parts.Add("extra=$Pair") }
+    }
+    return ($Parts -join '|')
+}
+
+function Get-TestCombinedStamp {
+    param([string] $Commit)
+    if (-not $Commit) { return $null }
+    $Lines = @(& git.exe notes --ref=test-combined show $Commit 2>$null)
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+    # Join exactly as written; Trim only outer whitespace.
+    return (($Lines -join "`n").Trim())
+}
+
+function Set-TestCombinedStamp {
+    param(
+        [string] $Commit,
+        [string] $Stamp
+    )
+    $ExitCode = Invoke-GitSoft @(
+        'notes', '--ref=test-combined', 'add', '-f', '-m', $Stamp, $Commit
+    )
+    if ($ExitCode -ne 0) {
+        Write-Warning "Could not write test-combined stamp note on $Commit"
+    }
+}
+
+function ConvertTo-NormalizedStamp {
+    param([string] $Stamp)
+    if (-not $Stamp) { return $null }
+    # Accept legacy multiline notes (joined with `n) and new single-line (`|`) form.
+    $Normalized = $Stamp.Trim() -replace "`r`n", "`n" -replace "`r", "`n"
+    if ($Normalized.Contains("`n")) {
+        $Normalized = (($Normalized -split "`n") | ForEach-Object { $_.Trim() } | Where-Object { $_ }) -join '|'
+    }
+    return $Normalized
 }
 
 function Test-MergeInProgress {
@@ -359,7 +438,7 @@ if ($UseLocalOnly) {
     Write-Host "==> Branch source: local only"
 }
 else {
-    Write-Host "==> Branch source: $Remote (fetch + merge remote-tracking refs)"
+    Write-Host "==> Branch source: $Remote (soft-fetch + merge remote-tracking refs)"
 }
 
 $ReturnBranch = Get-CurrentBranch
@@ -373,13 +452,87 @@ if ($UseLocalOnly) {
     }
 }
 else {
-    Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
-    if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $false)) {
-        throw "Remote branch '$Remote/$BaseBranch' not found after fetch."
+    try {
+        Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
+        if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $false)) {
+            throw "Remote branch '$Remote/$BaseBranch' not found after fetch."
+        }
+    }
+    catch {
+        Write-Warning "Fetch from $Remote failed or remote base missing; falling back to local refs."
+        Write-Warning "$_"
+        $UseLocalOnly = $true
+        if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $true)) {
+            throw "Base branch '$BaseBranch' not found locally after soft-fetch fallback."
+        }
+        Write-Host "==> Branch source: local only (fallback)"
     }
 }
 
 $BaseRef = Get-BranchMergeRef -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+$BaseSha = Get-RefSha -Ref $BaseRef
+if (-not $BaseSha) {
+    throw "Could not resolve SHA for base ref '$BaseRef'."
+}
+
+$ExtraStampPairs = [System.Collections.Generic.List[string]]::new()
+$ResolvedExtras = [System.Collections.Generic.List[hashtable]]::new()
+foreach ($ExtraBranch in $ExtraFeatureBranches) {
+    if (-not $ExtraBranch) { continue }
+    $MergeRef = Get-BranchMergeRef -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+    if (Test-BranchAvailable -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly) {
+        $ExtraSha = Get-RefSha -Ref $MergeRef
+        if (-not $ExtraSha) {
+            Write-Warning "Could not resolve SHA for '$MergeRef' — continuing without it."
+            continue
+        }
+        $ExtraStampPairs.Add("$ExtraBranch=$ExtraSha")
+        $ResolvedExtras.Add(@{
+            Branch   = $ExtraBranch
+            MergeRef = $MergeRef
+        })
+    }
+    else {
+        $Label = if ($UseLocalOnly) { "local branch" } else { "remote branch" }
+        Write-Warning "Extra feature $Label '$ExtraBranch' not found — continuing without it."
+    }
+}
+
+$ConfigIdentity = @(
+    "base=$BaseBranch",
+    "test=$TestBranch",
+    "deleteFirst=$DeleteTestBranchFirst",
+    "extras=$($ExtraFeatureBranches -join ',')"
+) -join ';'
+
+$DesiredStamp = ConvertTo-NormalizedStamp (Get-InputStamp `
+    -ConfigIdentity $ConfigIdentity `
+    -BaseName $BaseBranch `
+    -BaseSha $BaseSha `
+    -ExtraPairs @($ExtraStampPairs))
+
+$TestBranchExists = Test-GitRef "refs/heads/$TestBranch"
+$ExistingTip = if ($TestBranchExists) { Get-RefSha -Ref $TestBranch } else { $null }
+$ExistingStampRaw = $null
+if ($ExistingTip) {
+    $ExistingStampRaw = Get-TestCombinedStamp -Commit $ExistingTip
+}
+$ExistingStamp = ConvertTo-NormalizedStamp $ExistingStampRaw
+$CanReuse = (
+    -not $Rebuild -and
+    $TestBranchExists -and
+    $ExistingStamp -and
+    ($ExistingStamp -eq $DesiredStamp)
+)
+
+if (-not $CanReuse -and $TestBranchExists -and -not $Rebuild) {
+    if (-not $ExistingStamp) {
+        Write-Host "==> No reuse stamp on $TestBranch — will rebuild"
+    }
+    else {
+        Write-Host "==> Stamp mismatch on $TestBranch — will rebuild"
+    }
+}
 
 $IgnoredPaths = @('.gitignore', 'FYPA.code-workspace')
 $Status = @(Invoke-Git @('status', '--porcelain'))
@@ -399,48 +552,68 @@ Commit or stash them before running the test script.
 $Returned = $false
 $FypaExit = 0
 try {
-    if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
-        Write-Host "==> Delete $TestBranch"
-        if (Get-CurrentBranch -eq $TestBranch) {
-            Invoke-Git @('checkout', $ReturnBranch)
+    if ($CanReuse) {
+        Write-Host "==> Reuse $TestBranch (inputs unchanged)"
+        if ((Get-CurrentBranch) -ne $TestBranch) {
+            Invoke-Git @('checkout', $TestBranch)
         }
-        Invoke-Git @('branch', '-D', $TestBranch)
-    }
-
-    if (Test-GitRef "refs/heads/$TestBranch") {
-        Write-Host "==> Recreate $TestBranch from $BaseRef"
-        Invoke-Git @('branch', '-f', $TestBranch, $BaseRef)
-        Invoke-Git @('checkout', $TestBranch)
     }
     else {
-        Write-Host "==> Create $TestBranch from $BaseRef"
-        Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
-    }
-
-    foreach ($ExtraBranch in $ExtraFeatureBranches) {
-        if (-not $ExtraBranch) { continue }
-
-        $MergeRef = Get-BranchMergeRef -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
-        if (Test-BranchAvailable -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly) {
-            Write-Host "==> Merge $MergeRef into $TestBranch"
-            Merge-FeatureBranch -MergeRef $MergeRef -ExtraBranch $ExtraBranch -IgnoredPaths $IgnoredPaths
+        if ($Rebuild) {
+            Write-Host "==> Rebuild requested — recreating $TestBranch"
+        }
+        elseif (-not $TestBranchExists) {
+            Write-Host "==> $TestBranch missing — creating from $BaseRef"
         }
         else {
-            $Label = if ($UseLocalOnly) { "local branch" } else { "remote branch" }
-            Write-Warning "Extra feature $Label '$ExtraBranch' not found — continuing without it."
+            Write-Host "==> Inputs changed — recreating $TestBranch from $BaseRef"
+        }
+
+        if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
+            Write-Host "==> Delete $TestBranch"
+            if ((Get-CurrentBranch) -eq $TestBranch) {
+                Invoke-Git @('checkout', $ReturnBranch)
+            }
+            Invoke-Git @('branch', '-D', $TestBranch)
+        }
+
+        if (Test-GitRef "refs/heads/$TestBranch") {
+            Write-Host "==> Recreate $TestBranch from $BaseRef"
+            Invoke-Git @('branch', '-f', $TestBranch, $BaseRef)
+            Invoke-Git @('checkout', $TestBranch)
+        }
+        else {
+            Write-Host "==> Create $TestBranch from $BaseRef"
+            Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
+        }
+
+        foreach ($Extra in $ResolvedExtras) {
+            Write-Host "==> Merge $($Extra.MergeRef) into $TestBranch"
+            Merge-FeatureBranch -MergeRef $Extra.MergeRef -ExtraBranch $Extra.Branch -IgnoredPaths $IgnoredPaths
+        }
+
+        $NewTip = Get-RefSha -Ref 'HEAD'
+        if ($NewTip) {
+            Set-TestCombinedStamp -Commit $NewTip -Stamp $DesiredStamp
+            Write-Host "==> Stamp written for $TestBranch"
         }
     }
 
-    Write-Host "==> pytest topology tests"
-    & uv run python -m pytest `
-        tests/test_topology_invariants.py `
-        tests/test_topology_regressions.py `
-        tests/test_topology_layout.py `
-        tests/test_topology_geometry.py `
-        tests/test_topology_labels.py `
-        tests/test_pdn_topology.py -q
-    if ($LASTEXITCODE -ne 0) {
-        throw "pytest failed (exit $LASTEXITCODE)"
+    if ($SkipTests) {
+        Write-Host "==> Skip pytest (-SkipTests)"
+    }
+    else {
+        Write-Host "==> pytest topology tests"
+        & uv run python -m pytest `
+            tests/test_topology_invariants.py `
+            tests/test_topology_regressions.py `
+            tests/test_topology_layout.py `
+            tests/test_topology_geometry.py `
+            tests/test_topology_labels.py `
+            tests/test_pdn_topology.py -q
+        if ($LASTEXITCODE -ne 0) {
+            throw "pytest failed (exit $LASTEXITCODE)"
+        }
     }
 
     Write-Host "==> uv run FYPA.py"

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -8,7 +8,7 @@
 #
 # Usage (from repo root, any branch):
 #   pwsh scripts/test-combined.ps1
-#   pwsh scripts/test-combined.ps1 --local-only
+#   pwsh scripts/test-combined.ps1 -LocalOnly
 #   pwsh scripts/test-combined.ps1 -Rebuild
 #   pwsh scripts/test-combined.ps1 -SkipTests
 #   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
@@ -21,7 +21,7 @@
 # are accepted either way. If fetch fails (offline), existing refs are resolved
 # the same way. When input SHAs match the stamp on an existing test branch, that
 # branch is reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
-# Pass --local-only to skip fetch and use local branches only.
+# Pass -LocalOnly to skip fetch and use local branches only.
 #
 # Workflow:
 #   1. Remember current branch

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -14,15 +14,19 @@
 #   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
 #   pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
 #
-# By default baseBranch and extraFeatureBranches are soft-fetched from origin and
-# merged via origin/<branch>. If fetch fails (offline), local refs are used.
-# When input SHAs match the stamp on an existing test branch, that branch is
-# reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
+# By default baseBranch and extraFeatureBranches are soft-fetched from origin.
+# Each input is resolved to the tip that includes local work: if the local branch
+# is ahead of (or diverged from) origin/<branch>, the local tip is merged; if
+# local is behind, origin/<branch> is used; local-only or remote-only branches
+# are accepted either way. If fetch fails (offline), existing refs are resolved
+# the same way. When input SHAs match the stamp on an existing test branch, that
+# branch is reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
 # Pass --local-only to skip fetch and use local branches only.
 #
 # Workflow:
 #   1. Remember current branch
-#   2. Soft-fetch inputs (or local-only); reuse test branch if stamp matches
+#   2. Soft-fetch inputs (or local-only); resolve tips (prefer local when ahead);
+#      reuse test branch if stamp matches
 #   3. Otherwise optionally delete, recreate from base, merge feature branches
 #      (.gitignore conflicts auto-resolved with --ours); write stamp note
 #   4. Optionally run pytest topology suite (-SkipTests to skip), then uv run FYPA.py
@@ -110,30 +114,120 @@ function Test-GitRef {
     return $LASTEXITCODE -eq 0
 }
 
-function Get-BranchMergeRef {
+function Test-GitAncestor {
     param(
-        [string] $Branch,
-        [string] $RemoteName,
-        [bool] $UseLocalOnly
+        [string] $Ancestor,
+        [string] $Descendant
     )
-
-    if ($UseLocalOnly) {
-        return $Branch
-    }
-    return "$RemoteName/$Branch"
+    & git.exe merge-base --is-ancestor $Ancestor $Descendant 2>$null | Out-Null
+    return $LASTEXITCODE -eq 0
 }
 
-function Test-BranchAvailable {
+function Resolve-BranchMergeTarget {
     param(
         [string] $Branch,
         [string] $RemoteName,
         [bool] $UseLocalOnly
     )
 
+    $LocalRef = $Branch
+    $RemoteRef = "$RemoteName/$Branch"
+    $HasLocal = Test-GitRef "refs/heads/$Branch"
+    $HasRemote = Test-GitRef "refs/remotes/$RemoteName/$Branch"
+
     if ($UseLocalOnly) {
-        return Test-GitRef "refs/heads/$Branch"
+        if (-not $HasLocal) { return $null }
+        $Sha = Get-RefSha -Ref $LocalRef
+        if (-not $Sha) { return $null }
+        return @{
+            Branch   = $Branch
+            MergeRef = $LocalRef
+            Sha      = $Sha
+            Source   = 'local'
+        }
     }
-    return Test-GitRef "refs/remotes/$RemoteName/$Branch"
+
+    if ($HasLocal -and $HasRemote) {
+        $LocalSha = Get-RefSha -Ref $LocalRef
+        $RemoteSha = Get-RefSha -Ref $RemoteRef
+        if (-not $LocalSha -and -not $RemoteSha) { return $null }
+        if (-not $LocalSha) {
+            return @{
+                Branch   = $Branch
+                MergeRef = $RemoteRef
+                Sha      = $RemoteSha
+                Source   = 'remote'
+            }
+        }
+        if (-not $RemoteSha) {
+            return @{
+                Branch   = $Branch
+                MergeRef = $LocalRef
+                Sha      = $LocalSha
+                Source   = 'local'
+            }
+        }
+        if ($LocalSha -eq $RemoteSha) {
+            return @{
+                Branch   = $Branch
+                MergeRef = $LocalRef
+                Sha      = $LocalSha
+                Source   = 'local'
+            }
+        }
+        # Local contains remote → unpushed local commits; keep them.
+        if (Test-GitAncestor -Ancestor $RemoteSha -Descendant $LocalSha) {
+            Write-Host "==> ${Branch}: using local (ahead of $RemoteRef)"
+            return @{
+                Branch   = $Branch
+                MergeRef = $LocalRef
+                Sha      = $LocalSha
+                Source   = 'local'
+            }
+        }
+        # Remote contains local → local checkout is stale; take remote.
+        if (Test-GitAncestor -Ancestor $LocalSha -Descendant $RemoteSha) {
+            return @{
+                Branch   = $Branch
+                MergeRef = $RemoteRef
+                Sha      = $RemoteSha
+                Source   = 'remote'
+            }
+        }
+        # Diverged: never drop local work.
+        Write-Warning "${Branch}: local and $RemoteRef have diverged — using local tip"
+        return @{
+            Branch   = $Branch
+            MergeRef = $LocalRef
+            Sha      = $LocalSha
+            Source   = 'local'
+        }
+    }
+
+    if ($HasLocal) {
+        $Sha = Get-RefSha -Ref $LocalRef
+        if (-not $Sha) { return $null }
+        Write-Host "==> ${Branch}: no $RemoteRef — using local"
+        return @{
+            Branch   = $Branch
+            MergeRef = $LocalRef
+            Sha      = $Sha
+            Source   = 'local'
+        }
+    }
+
+    if ($HasRemote) {
+        $Sha = Get-RefSha -Ref $RemoteRef
+        if (-not $Sha) { return $null }
+        return @{
+            Branch   = $Branch
+            MergeRef = $RemoteRef
+            Sha      = $Sha
+            Source   = 'remote'
+        }
+    }
+
+    return $null
 }
 
 function Sync-RemoteBranches {
@@ -438,7 +532,7 @@ if ($UseLocalOnly) {
     Write-Host "==> Branch source: local only"
 }
 else {
-    Write-Host "==> Branch source: $Remote (soft-fetch + merge remote-tracking refs)"
+    Write-Host "==> Branch source: $Remote (soft-fetch; prefer local when ahead/diverged)"
 }
 
 $ReturnBranch = Get-CurrentBranch
@@ -446,56 +540,42 @@ if (-not $ReturnBranch) {
     throw "Could not determine the current branch."
 }
 
-if ($UseLocalOnly) {
-    if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $true)) {
-        throw "Base branch '$BaseBranch' not found locally."
-    }
-}
-else {
+if (-not $UseLocalOnly) {
     try {
         Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
-        if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $false)) {
-            throw "Remote branch '$Remote/$BaseBranch' not found after fetch."
-        }
     }
     catch {
-        Write-Warning "Fetch from $Remote failed or remote base missing; falling back to local refs."
+        Write-Warning "Fetch from $Remote failed; resolving from existing local/remote-tracking refs."
         Write-Warning "$_"
-        $UseLocalOnly = $true
-        if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $true)) {
-            throw "Base branch '$BaseBranch' not found locally after soft-fetch fallback."
-        }
-        Write-Host "==> Branch source: local only (fallback)"
     }
 }
 
-$BaseRef = Get-BranchMergeRef -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
-$BaseSha = Get-RefSha -Ref $BaseRef
-if (-not $BaseSha) {
-    throw "Could not resolve SHA for base ref '$BaseRef'."
+$BaseTarget = Resolve-BranchMergeTarget -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+if (-not $BaseTarget) {
+    $Where = if ($UseLocalOnly) { "locally" } else { "locally or as $Remote/$BaseBranch" }
+    throw "Base branch '$BaseBranch' not found $Where."
 }
+
+$BaseRef = $BaseTarget.MergeRef
+$BaseSha = $BaseTarget.Sha
+Write-Host "==> Base: $BaseRef ($($BaseTarget.Source))"
 
 $ExtraStampPairs = [System.Collections.Generic.List[string]]::new()
 $ResolvedExtras = [System.Collections.Generic.List[hashtable]]::new()
 foreach ($ExtraBranch in $ExtraFeatureBranches) {
     if (-not $ExtraBranch) { continue }
-    $MergeRef = Get-BranchMergeRef -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
-    if (Test-BranchAvailable -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly) {
-        $ExtraSha = Get-RefSha -Ref $MergeRef
-        if (-not $ExtraSha) {
-            Write-Warning "Could not resolve SHA for '$MergeRef' — continuing without it."
-            continue
-        }
-        $ExtraStampPairs.Add("$ExtraBranch=$ExtraSha")
-        $ResolvedExtras.Add(@{
-            Branch   = $ExtraBranch
-            MergeRef = $MergeRef
-        })
+    $ExtraTarget = Resolve-BranchMergeTarget -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+    if (-not $ExtraTarget) {
+        $Where = if ($UseLocalOnly) { "locally" } else { "locally or on $Remote" }
+        Write-Warning "Extra feature branch '$ExtraBranch' not found $Where — continuing without it."
+        continue
     }
-    else {
-        $Label = if ($UseLocalOnly) { "local branch" } else { "remote branch" }
-        Write-Warning "Extra feature $Label '$ExtraBranch' not found — continuing without it."
-    }
+    Write-Host "==> Extra: $($ExtraTarget.MergeRef) ($($ExtraTarget.Source))"
+    $ExtraStampPairs.Add("$ExtraBranch=$($ExtraTarget.Sha)")
+    $ResolvedExtras.Add(@{
+        Branch   = $ExtraTarget.Branch
+        MergeRef = $ExtraTarget.MergeRef
+    })
 }
 
 $ConfigIdentity = @(

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -1,69 +1,26 @@
 <#
 .SYNOPSIS
-    Build a local combined test branch, run tests/FYPA, then switch back.
+    Check out origin/test/combined, optionally run tests/FYPA, then switch back.
 
 .DESCRIPTION
-    Merges a base branch plus feature branches into a disposable test branch,
-    optionally runs the pytest topology suite and FYPA.py, then returns to the
-    branch you started on (even if a step exits with an error).
+    The combined branch is maintained centrally (see scripts/maintain-test-combined.ps1).
+    This script only fetches and checks out the remote tip — it does not merge
+    feature branches.
 
-    Config resolution (first match wins):
-      scripts/test-combined.json          local override (gitignored)
-      team/test-combined.json             working tree
-      team/local:team/test-combined.json  from team/local via git show (no checkout)
-      scripts/test-combined.example.json  fallback
-
-    By default baseBranch and extraFeatureBranches are soft-fetched from origin.
-    Each input is resolved to the tip that includes local work: if the local
-    branch is ahead of (or diverged from) origin/<branch>, the local tip is
-    merged; if local is behind, origin/<branch> is used; local-only or
-    remote-only branches are accepted either way. If fetch fails (offline),
-    existing refs are resolved the same way.
-
-    When input SHAs match the stamp on an existing test branch, that branch is
-    reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
-    Pass -LocalOnly to skip fetch and use local branches only.
-
-    Workflow:
-      1. Remember current branch
-      2. Soft-fetch inputs (or local-only); resolve tips (prefer local when ahead);
-         reuse test branch if stamp matches
-      3. Otherwise optionally delete, recreate from base, merge feature branches
-         (.gitignore conflicts auto-resolved with --ours); write stamp note
-      4. Optionally run pytest topology suite (-SkipTests to skip), then uv run FYPA.py
-      5. Return to the starting branch
-
-.PARAMETER ConfigPath
-    Path to a JSON config file. Overrides the default config search order.
-
-.PARAMETER TeamConfigRef
-    Git ref used when reading team/test-combined.json via git show.
-    Default: team/local
+    To rebuild and push test/combined:
+      pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
 
 .PARAMETER Remote
-    Remote name used for soft-fetch and tip resolution. Default: origin
+    Remote name. Default: origin
 
-.PARAMETER LocalOnly
-    Skip fetch; resolve and merge local branches only.
+.PARAMETER TestBranch
+    Combined branch name. Default: test/combined
 
 .PARAMETER Rebuild
-    Force delete/recreate of the test branch even when the stamp matches.
+    Not supported here — prints how to run maintain-test-combined.ps1 and exits 1.
 
 .PARAMETER SkipTests
     Skip the pytest topology suite; still runs FYPA.py unless the script exits earlier.
-
-.PARAMETER BaseBranch
-    Override config baseBranch (branch the test branch is created from).
-
-.PARAMETER TestBranch
-    Override config testBranch (name of the disposable combined branch).
-
-.PARAMETER ExtraFeatureBranches
-    Override config extraFeatureBranches (branches merged onto the base).
-
-.PARAMETER DeleteTestBranchFirst
-    Override config deleteTestBranchFirst. When true, delete the existing test
-    branch before recreating it.
 
 .PARAMETER PrjPcb
     Path to a .PrjPcb passed through to FYPA.py.
@@ -71,55 +28,16 @@
 .EXAMPLE
     pwsh scripts/test-combined.ps1
 
-    Use default config resolution, soft-fetch, reuse or rebuild the test branch,
-    run tests and FYPA, then switch back.
-
 .EXAMPLE
-    pwsh scripts/test-combined.ps1 -LocalOnly
-
-    Skip remote fetch; use local branch tips only.
-
-.EXAMPLE
-    pwsh scripts/test-combined.ps1 -Rebuild
-
-    Force a clean recreate of the test branch.
-
-.EXAMPLE
-    pwsh scripts/test-combined.ps1 -SkipTests
-
-    Build/reuse the test branch and run FYPA without pytest.
-
-.EXAMPLE
-    pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
-
-    Use an explicit local config file.
-
-.EXAMPLE
-    pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
-
-    Pass a project file through to FYPA.py.
-
-.EXAMPLE
-    Get-Help .\scripts\test-combined.ps1 -Full
-
-    Show this help. Equivalent: pwsh scripts/test-combined.ps1 -?
-
-.NOTES
-    Run from the repo root (or any branch); the script cds to the repo root itself.
+    pwsh scripts/test-combined.ps1 -SkipTests -PrjPcb path\to\Board.PrjPcb
 #>
 
 [CmdletBinding()]
 param(
-    [string] $ConfigPath,
-    [string] $TeamConfigRef = "team/local",
     [string] $Remote = "origin",
-    [switch] $LocalOnly,
+    [string] $TestBranch = "test/combined",
     [switch] $Rebuild,
     [switch] $SkipTests,
-    [string] $BaseBranch,
-    [string] $TestBranch,
-    [string[]] $ExtraFeatureBranches,
-    [bool] $DeleteTestBranchFirst,
     [string] $PrjPcb
 )
 
@@ -127,6 +45,18 @@ $ErrorActionPreference = "Stop"
 
 $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
 Set-Location $RepoRoot
+
+if ($Rebuild) {
+    Write-Error @"
+-Rebuild is no longer supported by test-combined.ps1.
+Rebuild and publish the shared branch with:
+
+  pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+
+Then re-run this script to check out $Remote/$TestBranch.
+"@
+    exit 1
+}
 
 function Invoke-GitCore {
     param(
@@ -176,12 +106,8 @@ function Invoke-Git {
     return $Result.Output
 }
 
-function Invoke-GitSoft {
-    param(
-        [Parameter(Mandatory, ValueFromRemainingArguments)]
-        [string[]] $GitArgs
-    )
-    return (Invoke-GitCore @GitArgs).ExitCode
+function Get-CurrentBranch {
+    return ([string] (Invoke-Git @('branch', '--show-current') | Select-Object -First 1)).Trim()
 }
 
 function Test-GitRef {
@@ -190,406 +116,8 @@ function Test-GitRef {
     return $LASTEXITCODE -eq 0
 }
 
-function Test-GitAncestor {
-    param(
-        [string] $Ancestor,
-        [string] $Descendant
-    )
-    & git.exe merge-base --is-ancestor $Ancestor $Descendant 2>$null | Out-Null
-    return $LASTEXITCODE -eq 0
-}
-
-function Resolve-BranchMergeTarget {
-    param(
-        [string] $Branch,
-        [string] $RemoteName,
-        [bool] $UseLocalOnly
-    )
-
-    $LocalRef = $Branch
-    $RemoteRef = "$RemoteName/$Branch"
-    $HasLocal = Test-GitRef "refs/heads/$Branch"
-    $HasRemote = Test-GitRef "refs/remotes/$RemoteName/$Branch"
-
-    if ($UseLocalOnly) {
-        if (-not $HasLocal) { return $null }
-        $Sha = Get-RefSha -Ref $LocalRef
-        if (-not $Sha) { return $null }
-        return @{
-            Branch   = $Branch
-            MergeRef = $LocalRef
-            Sha      = $Sha
-            Source   = 'local'
-        }
-    }
-
-    if ($HasLocal -and $HasRemote) {
-        $LocalSha = Get-RefSha -Ref $LocalRef
-        $RemoteSha = Get-RefSha -Ref $RemoteRef
-        if (-not $LocalSha -and -not $RemoteSha) { return $null }
-        if (-not $LocalSha) {
-            return @{
-                Branch   = $Branch
-                MergeRef = $RemoteRef
-                Sha      = $RemoteSha
-                Source   = 'remote'
-            }
-        }
-        if (-not $RemoteSha) {
-            return @{
-                Branch   = $Branch
-                MergeRef = $LocalRef
-                Sha      = $LocalSha
-                Source   = 'local'
-            }
-        }
-        if ($LocalSha -eq $RemoteSha) {
-            return @{
-                Branch   = $Branch
-                MergeRef = $LocalRef
-                Sha      = $LocalSha
-                Source   = 'local'
-            }
-        }
-        # Local contains remote → unpushed local commits; keep them.
-        if (Test-GitAncestor -Ancestor $RemoteSha -Descendant $LocalSha) {
-            Write-Host "==> ${Branch}: using local (ahead of $RemoteRef)"
-            return @{
-                Branch   = $Branch
-                MergeRef = $LocalRef
-                Sha      = $LocalSha
-                Source   = 'local'
-            }
-        }
-        # Remote contains local → local checkout is stale; take remote.
-        if (Test-GitAncestor -Ancestor $LocalSha -Descendant $RemoteSha) {
-            return @{
-                Branch   = $Branch
-                MergeRef = $RemoteRef
-                Sha      = $RemoteSha
-                Source   = 'remote'
-            }
-        }
-        # Diverged: never drop local work.
-        Write-Warning "${Branch}: local and $RemoteRef have diverged — using local tip"
-        return @{
-            Branch   = $Branch
-            MergeRef = $LocalRef
-            Sha      = $LocalSha
-            Source   = 'local'
-        }
-    }
-
-    if ($HasLocal) {
-        $Sha = Get-RefSha -Ref $LocalRef
-        if (-not $Sha) { return $null }
-        Write-Host "==> ${Branch}: no $RemoteRef — using local"
-        return @{
-            Branch   = $Branch
-            MergeRef = $LocalRef
-            Sha      = $Sha
-            Source   = 'local'
-        }
-    }
-
-    if ($HasRemote) {
-        $Sha = Get-RefSha -Ref $RemoteRef
-        if (-not $Sha) { return $null }
-        return @{
-            Branch   = $Branch
-            MergeRef = $RemoteRef
-            Sha      = $Sha
-            Source   = 'remote'
-        }
-    }
-
-    return $null
-}
-
-function Sync-RemoteBranches {
-    param(
-        [string] $RemoteName,
-        [string[]] $Branches
-    )
-
-    $UniqueBranches = @($Branches | Where-Object { $_ } | Select-Object -Unique)
-    if ($UniqueBranches.Count -eq 0) {
-        return
-    }
-
-    Write-Host "==> Fetch $RemoteName $($UniqueBranches -join ', ')"
-    # git writes progress to stderr; don't surface it as PowerShell warnings.
-    $Result = Invoke-GitCore -Quiet @(@('fetch', $RemoteName) + $UniqueBranches)
-    if ($Result.ExitCode -ne 0) {
-        $Detail = ($Result.Output -join "`n").Trim()
-        if ($Detail) {
-            throw "git fetch $RemoteName failed (exit $($Result.ExitCode)): $Detail"
-        }
-        throw "git fetch $RemoteName failed (exit $($Result.ExitCode))"
-    }
-}
-
-function Get-RefSha {
-    param([string] $Ref)
-    $Sha = ([string] (& git.exe rev-parse --verify "$Ref^{commit}" 2>$null)).Trim()
-    if ($LASTEXITCODE -ne 0 -or -not $Sha) {
-        return $null
-    }
-    return $Sha
-}
-
-function Get-InputStamp {
-    param(
-        [string] $ConfigIdentity,
-        [string] $BaseName,
-        [string] $BaseSha,
-        [string[]] $ExtraPairs
-    )
-
-    # Single-line stamp: PowerShell [string] casts of multi-line git output join
-    # with spaces and would break equality checks if we used newlines.
-    $Parts = [System.Collections.Generic.List[string]]::new()
-    $Parts.Add("config=$ConfigIdentity")
-    $Parts.Add("base=$BaseName=$BaseSha")
-    foreach ($Pair in $ExtraPairs) {
-        if ($Pair) { $Parts.Add("extra=$Pair") }
-    }
-    return ($Parts -join '|')
-}
-
-function Get-TestCombinedStamp {
-    param([string] $Commit)
-    if (-not $Commit) { return $null }
-    $Lines = @(& git.exe notes --ref=test-combined show $Commit 2>$null)
-    if ($LASTEXITCODE -ne 0) {
-        return $null
-    }
-    # Join exactly as written; Trim only outer whitespace.
-    return (($Lines -join "`n").Trim())
-}
-
-function Set-TestCombinedStamp {
-    param(
-        [string] $Commit,
-        [string] $Stamp
-    )
-    $ExitCode = Invoke-GitSoft @(
-        'notes', '--ref=test-combined', 'add', '-f', '-m', $Stamp, $Commit
-    )
-    if ($ExitCode -ne 0) {
-        Write-Warning "Could not write test-combined stamp note on $Commit"
-    }
-}
-
-function ConvertTo-NormalizedStamp {
-    param([string] $Stamp)
-    if (-not $Stamp) { return $null }
-    # Accept legacy multiline notes (joined with `n) and new single-line (`|`) form.
-    $Normalized = $Stamp.Trim() -replace "`r`n", "`n" -replace "`r", "`n"
-    if ($Normalized.Contains("`n")) {
-        $Normalized = (($Normalized -split "`n") | ForEach-Object { $_.Trim() } | Where-Object { $_ }) -join '|'
-    }
-    return $Normalized
-}
-
-function Test-MergeInProgress {
-    $MergeHead = & git.exe rev-parse -q --verify MERGE_HEAD 2>$null
-    return [bool] $MergeHead
-}
-
-function Get-UnmergedPaths {
-    $Output = & git.exe diff --name-only --diff-filter=U 2>$null
-    if ($LASTEXITCODE -ne 0) {
-        return @()
-    }
-    return @($Output | Where-Object { $_ })
-}
-
-function Resolve-IgnoredMergeConflicts {
-    param(
-        [string[]] $IgnoredPaths,
-        [ValidateSet('ours', 'theirs')]
-        [string] $Prefer = 'ours'
-    )
-
-    foreach ($Path in (Get-UnmergedPaths)) {
-        if ($Path -in $IgnoredPaths) {
-            Write-Host "==> Auto-resolve merge conflict in $Path ($Prefer)"
-            Invoke-Git @('checkout', "--$Prefer", '--', $Path)
-            Invoke-Git @('add', '--', $Path)
-        }
-    }
-
-    return @(Get-UnmergedPaths)
-}
-
-function Merge-FeatureBranch {
-    param(
-        [string] $MergeRef,
-        [string] $ExtraBranch,
-        [string[]] $IgnoredPaths
-    )
-
-    $MergeMessage = "test: merge $ExtraBranch for local testing"
-    $ExitCode = Invoke-GitSoft @(
-        'merge', $MergeRef, '--no-edit', '-m', $MergeMessage
-    )
-    if ($ExitCode -eq 0) {
-        return
-    }
-
-    if (-not (Test-MergeInProgress)) {
-        throw "git merge $MergeRef failed (exit $ExitCode)"
-    }
-
-    $Remaining = Resolve-IgnoredMergeConflicts -IgnoredPaths $IgnoredPaths -Prefer 'ours'
-    if ($Remaining.Count -gt 0) {
-        throw "Merge conflict in: $($Remaining -join ', ')"
-    }
-
-    Invoke-Git @('commit', '--no-edit')
-}
-
-function Get-CurrentBranch {
-    return ([string] (Invoke-Git @('branch', '--show-current') | Select-Object -First 1)).Trim()
-}
-
-function Restore-DevBranch {
-    param([string] $Branch)
-    if ($Branch) {
-        Invoke-Git @('checkout', $Branch)
-    }
-}
-
-function Get-GitConfigJson {
-    param(
-        [string[]] $Refs,
-        [string] $RepoPath = "team/test-combined.json"
-    )
-
-    foreach ($Ref in $Refs) {
-        if (-not $Ref) { continue }
-        $Spec = "${Ref}:${RepoPath}"
-        $Json = & git show $Spec 2>$null
-        if ($LASTEXITCODE -eq 0 -and $Json) {
-            return @{ Source = $Spec; Json = [string] $Json }
-        }
-    }
-
-    return $null
-}
-
-function Resolve-ConfigSource {
-    param(
-        [string] $ExplicitPath,
-        [string] $TeamRef
-    )
-
-    if ($ExplicitPath) {
-        if (Test-Path $ExplicitPath) {
-            return @{
-                Source = (Resolve-Path $ExplicitPath).Path
-                Json   = $null
-            }
-        }
-        if ($ExplicitPath -match ':') {
-            $Json = & git show $ExplicitPath 2>$null
-            if ($LASTEXITCODE -eq 0 -and $Json) {
-                return @{ Source = $ExplicitPath; Json = [string] $Json }
-            }
-        }
-        throw "Config file not found: $ExplicitPath"
-    }
-
-    $LocalCandidates = @(
-        (Join-Path $RepoRoot "scripts/test-combined.json"),
-        (Join-Path $RepoRoot "team/test-combined.json")
-    )
-
-    foreach ($Candidate in $LocalCandidates) {
-        if (Test-Path $Candidate) {
-            return @{
-                Source = (Resolve-Path $Candidate).Path
-                Json   = $null
-            }
-        }
-    }
-
-    $GitRefs = @(
-        $TeamRef,
-        "origin/$TeamRef"
-    )
-    $FromGit = Get-GitConfigJson -Refs $GitRefs
-    if ($FromGit) {
-        return $FromGit
-    }
-
-    $Example = Join-Path $RepoRoot "scripts/test-combined.example.json"
-    if (Test-Path $Example) {
-        Write-Warning "Using example config ($Example). Copy to scripts/test-combined.json or update team/local."
-        return @{
-            Source = (Resolve-Path $Example).Path
-            Json   = $null
-        }
-    }
-
-    throw @"
-No test-combined config found.
-Fetch team/local (git fetch origin team/local) or create scripts/test-combined.json from scripts/test-combined.example.json.
-"@
-}
-
-function Read-TestCombinedConfig {
-    param(
-        [string] $Source,
-        [string] $Json
-    )
-
-    try {
-        if ($Json) {
-            $Config = $Json | ConvertFrom-Json
-        }
-        else {
-            $Config = Get-Content -Raw -Path $Source | ConvertFrom-Json
-        }
-    }
-    catch {
-        throw "Failed to parse config JSON at '$Source': $_"
-    }
-
-    foreach ($Required in @("baseBranch", "testBranch", "extraFeatureBranches")) {
-        if (-not ($Config.PSObject.Properties.Name -contains $Required)) {
-            throw "Config '$Source' is missing required field '$Required'."
-        }
-    }
-
-    return $Config
-}
-
 if (-not (Test-Path "FYPA.py")) {
     throw "FYPA.py not found in $RepoRoot — run this script from the FYPA repo."
-}
-
-$ConfigSource = Resolve-ConfigSource -ExplicitPath $ConfigPath -TeamRef $TeamConfigRef
-Write-Host "==> Config: $($ConfigSource.Source)"
-$Config = Read-TestCombinedConfig -Source $ConfigSource.Source -Json $ConfigSource.Json
-
-$BaseBranch = if ($PSBoundParameters.ContainsKey("BaseBranch")) { $BaseBranch } else { [string] $Config.baseBranch }
-$TestBranch = if ($PSBoundParameters.ContainsKey("TestBranch")) { $TestBranch } else { [string] $Config.testBranch }
-$ExtraFeatureBranches = if ($PSBoundParameters.ContainsKey("ExtraFeatureBranches")) {
-    $ExtraFeatureBranches
-}
-else {
-    @($Config.extraFeatureBranches | ForEach-Object { [string] $_ })
-}
-$DeleteTestBranchFirst = if ($PSBoundParameters.ContainsKey("DeleteTestBranchFirst")) {
-    $DeleteTestBranchFirst
-}
-elseif ($Config.PSObject.Properties.Name -contains "deleteTestBranchFirst") {
-    [bool] $Config.deleteTestBranchFirst
-}
-else {
-    $false
 }
 
 $PrjPcbPath = $null
@@ -600,94 +128,9 @@ if ($PrjPcb) {
     $PrjPcbPath = (Resolve-Path -LiteralPath $PrjPcb).Path
 }
 
-if (-not $BaseBranch) { throw "baseBranch is empty." }
-if (-not $TestBranch) { throw "testBranch is empty." }
-
-$UseLocalOnly = [bool] $LocalOnly
-if ($UseLocalOnly) {
-    Write-Host "==> Branch source: local only"
-}
-else {
-    Write-Host "==> Branch source: $Remote (soft-fetch; prefer local when ahead/diverged)"
-}
-
 $ReturnBranch = Get-CurrentBranch
 if (-not $ReturnBranch) {
     throw "Could not determine the current branch."
-}
-
-if (-not $UseLocalOnly) {
-    try {
-        Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
-    }
-    catch {
-        Write-Warning "Fetch from $Remote failed; resolving from existing local/remote-tracking refs."
-        Write-Warning "$_"
-    }
-}
-
-$BaseTarget = Resolve-BranchMergeTarget -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
-if (-not $BaseTarget) {
-    $Where = if ($UseLocalOnly) { "locally" } else { "locally or as $Remote/$BaseBranch" }
-    throw "Base branch '$BaseBranch' not found $Where."
-}
-
-$BaseRef = $BaseTarget.MergeRef
-$BaseSha = $BaseTarget.Sha
-Write-Host "==> Base: $BaseRef ($($BaseTarget.Source))"
-
-$ExtraStampPairs = [System.Collections.Generic.List[string]]::new()
-$ResolvedExtras = [System.Collections.Generic.List[hashtable]]::new()
-foreach ($ExtraBranch in $ExtraFeatureBranches) {
-    if (-not $ExtraBranch) { continue }
-    $ExtraTarget = Resolve-BranchMergeTarget -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
-    if (-not $ExtraTarget) {
-        $Where = if ($UseLocalOnly) { "locally" } else { "locally or on $Remote" }
-        Write-Warning "Extra feature branch '$ExtraBranch' not found $Where — continuing without it."
-        continue
-    }
-    Write-Host "==> Extra: $($ExtraTarget.MergeRef) ($($ExtraTarget.Source))"
-    $ExtraStampPairs.Add("$ExtraBranch=$($ExtraTarget.Sha)")
-    $ResolvedExtras.Add(@{
-        Branch   = $ExtraTarget.Branch
-        MergeRef = $ExtraTarget.MergeRef
-    })
-}
-
-$ConfigIdentity = @(
-    "base=$BaseBranch",
-    "test=$TestBranch",
-    "deleteFirst=$DeleteTestBranchFirst",
-    "extras=$($ExtraFeatureBranches -join ',')"
-) -join ';'
-
-$DesiredStamp = ConvertTo-NormalizedStamp (Get-InputStamp `
-    -ConfigIdentity $ConfigIdentity `
-    -BaseName $BaseBranch `
-    -BaseSha $BaseSha `
-    -ExtraPairs @($ExtraStampPairs))
-
-$TestBranchExists = Test-GitRef "refs/heads/$TestBranch"
-$ExistingTip = if ($TestBranchExists) { Get-RefSha -Ref $TestBranch } else { $null }
-$ExistingStampRaw = $null
-if ($ExistingTip) {
-    $ExistingStampRaw = Get-TestCombinedStamp -Commit $ExistingTip
-}
-$ExistingStamp = ConvertTo-NormalizedStamp $ExistingStampRaw
-$CanReuse = (
-    -not $Rebuild -and
-    $TestBranchExists -and
-    $ExistingStamp -and
-    ($ExistingStamp -eq $DesiredStamp)
-)
-
-if (-not $CanReuse -and $TestBranchExists -and -not $Rebuild) {
-    if (-not $ExistingStamp) {
-        Write-Host "==> No reuse stamp on $TestBranch — will rebuild"
-    }
-    else {
-        Write-Host "==> Stamp mismatch on $TestBranch — will rebuild"
-    }
 }
 
 $IgnoredPaths = @('.gitignore', 'FYPA.code-workspace')
@@ -705,55 +148,27 @@ Commit or stash them before running the test script.
 "@
 }
 
+$RemoteRef = "$Remote/$TestBranch"
+Write-Host "==> Fetch $Remote $TestBranch"
+$FetchResult = Invoke-GitCore -Quiet @('fetch', $Remote, $TestBranch)
+if ($FetchResult.ExitCode -ne 0) {
+    Write-Warning "Fetch failed; using existing $RemoteRef if present."
+}
+
+if (-not (Test-GitRef "refs/remotes/$Remote/$TestBranch")) {
+    throw @"
+$RemoteRef not found.
+Publish the shared branch first:
+  pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+"@
+}
+
 $Returned = $false
 $FypaExit = 0
 try {
-    if ($CanReuse) {
-        Write-Host "==> Reuse $TestBranch (inputs unchanged)"
-        if ((Get-CurrentBranch) -ne $TestBranch) {
-            Invoke-Git @('checkout', $TestBranch)
-        }
-    }
-    else {
-        if ($Rebuild) {
-            Write-Host "==> Rebuild requested — recreating $TestBranch"
-        }
-        elseif (-not $TestBranchExists) {
-            Write-Host "==> $TestBranch missing — creating from $BaseRef"
-        }
-        else {
-            Write-Host "==> Inputs changed — recreating $TestBranch from $BaseRef"
-        }
-
-        if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
-            Write-Host "==> Delete $TestBranch"
-            if ((Get-CurrentBranch) -eq $TestBranch) {
-                Invoke-Git @('checkout', $ReturnBranch)
-            }
-            Invoke-Git @('branch', '-D', $TestBranch)
-        }
-
-        if (Test-GitRef "refs/heads/$TestBranch") {
-            Write-Host "==> Recreate $TestBranch from $BaseRef"
-            Invoke-Git @('branch', '-f', $TestBranch, $BaseRef)
-            Invoke-Git @('checkout', $TestBranch)
-        }
-        else {
-            Write-Host "==> Create $TestBranch from $BaseRef"
-            Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
-        }
-
-        foreach ($Extra in $ResolvedExtras) {
-            Write-Host "==> Merge $($Extra.MergeRef) into $TestBranch"
-            Merge-FeatureBranch -MergeRef $Extra.MergeRef -ExtraBranch $Extra.Branch -IgnoredPaths $IgnoredPaths
-        }
-
-        $NewTip = Get-RefSha -Ref 'HEAD'
-        if ($NewTip) {
-            Set-TestCombinedStamp -Commit $NewTip -Stamp $DesiredStamp
-            Write-Host "==> Stamp written for $TestBranch"
-        }
-    }
+    Write-Host "==> Checkout $TestBranch from $RemoteRef"
+    Invoke-Git @('checkout', '-B', $TestBranch, $RemoteRef)
+    Invoke-Git @('reset', '--hard', $RemoteRef)
 
     if ($SkipTests) {
         Write-Host "==> Skip pytest (-SkipTests)"
@@ -783,24 +198,20 @@ try {
     $FypaExit = $LASTEXITCODE
 }
 catch {
-    if (Get-CurrentBranch -ne $ReturnBranch) {
-        & git merge --abort 2>$null | Out-Null
-        & git rebase --abort 2>$null | Out-Null
-    }
     throw
 }
 finally {
     $Current = Get-CurrentBranch
     if ($Current -ne $ReturnBranch) {
         Write-Host "==> Return to $ReturnBranch"
-        Restore-DevBranch -Branch $ReturnBranch
+        Invoke-Git @('checkout', $ReturnBranch)
         $Returned = $true
     }
 }
 
 if (-not $Returned) {
     Write-Host "==> Return to $ReturnBranch"
-    Restore-DevBranch -Branch $ReturnBranch
+    Invoke-Git @('checkout', $ReturnBranch)
 }
 
 if ($FypaExit -and $FypaExit -ne 0) {

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -4312,8 +4312,9 @@ def test_multi_instance_lx_supply_map_infers_downstream_smps_vin():
     """Shared local OUT=LX with different PDN_V must not drop Vin for rails.
 
     Two regulator placements publish LX.1=5 V / LX.2=12 V; SERIES inductors
-    map LX→VDD_OUT to VDD_5V0 / VDD_12V; a downstream SMPS on VDD_12V infers
-    Vin without an explicit PDN_GAIN.
+    map LX→VDD_OUT to VDD_5V0 / VDD_12V; a second SERIES (listed *before* the
+    inductor in the source list) bridges VDD_12V→VDD_12V_S so multi-hop
+    fixpoint propagation still reaches a downstream SMPS on VDD_12V_S.
     """
     from fypa.altium.annotations import _expand_sheet_bound_parameter_sources
 
@@ -4326,14 +4327,27 @@ def test_multi_instance_lx_supply_map_infers_downstream_smps_vin():
         "PDN_IN_P_NET": "VIN",
         "PDN_IN_N_NET": "GND",
     }
-    # nets: 0 GND, 1 VIN, 2 LX.1, 3 LX.2, 4 VDD_5V0, 5 VDD_12V, 6 VDD_3V3
+    # nets: 0 GND, 1 VIN, 2 LX.1, 3 LX.2, 4 VDD_5V0, 5 VDD_12V,
+    #       6 VDD_12V_S, 7 VDD_3V3
     proj = _minimal_proj(
         nets=(
             RawNet("GND"), RawNet("VIN"),
             RawNet("LX.1"), RawNet("LX.2"),
-            RawNet("VDD_5V0"), RawNet("VDD_12V"), RawNet("VDD_3V3"),
+            RawNet("VDD_5V0"), RawNet("VDD_12V"),
+            RawNet("VDD_12V_S"), RawNet("VDD_3V3"),
         ),
         sch_components=(
+            # Q1 before L1: one-pass copy would miss VDD_12V_S; fixpoint must not.
+            RawSchComponent(
+                designator="Q1", schdoc_name="Load.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN_R": "10m",
+                    "PDN_P_NET": "VDD_12V",
+                    "PDN_N_NET": "VDD_12V_S",
+                },
+                pin_designators=("1", "2"),
+            ),
             RawSchComponent(
                 designator="U1", schdoc_name="Pwr.SchDoc",
                 parameters={**reg_params, "PDN_V": "5V"},
@@ -4360,7 +4374,7 @@ def test_multi_instance_lx_supply_map_infers_downstream_smps_vin():
                     "PDN_REGULATOR_EFFICIENCY": "0.85",
                     "PDN_OUT_P_NET": "VDD_3V3",
                     "PDN_OUT_N_NET": "GND",
-                    "PDN_IN_P_NET": "VDD_12V",
+                    "PDN_IN_P_NET": "VDD_12V_S",
                     "PDN_IN_N_NET": "GND",
                 },
                 pin_designators=("1", "2", "3", "4"),
@@ -4416,6 +4430,10 @@ def test_multi_instance_lx_supply_map_infers_downstream_smps_vin():
                 source_unique_id=r"\SYM12\L",
             ),
             RawPcbComponent(
+                designator="Q1", center=Pt2D(35, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="FET", source_designator="Q1",
+            ),
+            RawPcbComponent(
                 designator="U2", center=Pt2D(40, 0), rotation_deg=0.0,
                 layer_name="TOP", footprint="QFN", source_designator="U2",
             ),
@@ -4435,11 +4453,13 @@ def test_multi_instance_lx_supply_map_infers_downstream_smps_vin():
             _pad(2, "1", 2, 5), _pad(2, "2", 4, 6),
             # L1.2: LX.2 — VDD_12V
             _pad(3, "1", 3, 25), _pad(3, "2", 5, 26),
-            # U2: OUT VDD_3V3, IN VDD_12V
-            _pad(4, "1", 6, 40), _pad(4, "2", 0, 41),
-            _pad(4, "3", 5, 42), _pad(4, "4", 0, 43),
+            # Q1: VDD_12V — VDD_12V_S
+            _pad(4, "1", 5, 35), _pad(4, "2", 6, 36),
+            # U2: OUT VDD_3V3, IN VDD_12V_S
+            _pad(5, "1", 7, 40), _pad(5, "2", 0, 41),
+            _pad(5, "3", 6, 42), _pad(5, "4", 0, 43),
             # J1 SOURCE
-            _pad(5, "1", 1, -10), _pad(5, "2", 0, -9),
+            _pad(6, "1", 1, -10), _pad(6, "2", 0, -9),
         ),
         compiled_netlist=_FakeNetlist(nets=[
             _FakeNet(
@@ -4474,6 +4494,7 @@ def test_multi_instance_lx_supply_map_infers_downstream_smps_vin():
     assert supply_map.get("LX.2") == pytest.approx(12.0)
     assert supply_map.get("VDD_5V0") == pytest.approx(5.0)
     assert supply_map.get("VDD_12V") == pytest.approx(12.0)
+    assert supply_map.get("VDD_12V_S") == pytest.approx(12.0)
 
     ann = parse_annotations(proj, enabled_layers=[1])
     assert ann.ok, ann.errors
@@ -4485,14 +4506,6 @@ def test_multi_instance_lx_supply_map_infers_downstream_smps_vin():
     assert "U2" in regs
     # Vin=12, Vout=3.3, eta=0.85 -> gain = 3.3/(12*0.85)
     assert regs["U2"].gain == pytest.approx(3.3 / (12.0 * 0.85))
-
-# --- retained from main/rebase base ---
-
-
-# --- retained from main/rebase base ---
-
-
-
 def test_a_failed_page_map_does_not_discard_a_good_netlist():
 
     from fypa.altium.extract import _compile_schematic_netlist
@@ -5432,3 +5445,120 @@ def test_unmapped_physical_page_id_is_unknown_not_guessed():
     smap = _sheet_map(proj)
     assert _sheet_name_matches("Power.SchDoc", [child], sheet_map=smap)
     assert not _sheet_name_matches("main.SchDoc", [child], sheet_map=smap)
+
+def test_autoinfer_series_propagates_supply_voltage_for_smps_vin():
+    """2-pin SERIES without P/N nets still forwards Vin via pad autoinfer."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("VIN"), RawNet("VIN_L"), RawNet("VOUT")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Main.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SOURCE",
+                    "PDN_V": "12",
+                    "PDN_P_NET": "VIN",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="L1", schdoc_name="Main.SchDoc",
+                parameters={"PDN_ROLE": "SERIES", "PDN_R": "5m"},
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="U1", schdoc_name="Main.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_V": "3.3",
+                    "PDN_REGULATOR_TYPE": "SMPS",
+                    "PDN_REGULATOR_EFFICIENCY": "0.9",
+                    "PDN_OUT_P_NET": "VOUT",
+                    "PDN_OUT_N_NET": "GND",
+                    "PDN_IN_P_NET": "VIN_L",
+                    "PDN_IN_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="CONN", source_designator="J1",
+            ),
+            RawPcbComponent(
+                designator="L1", center=Pt2D(5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="IND", source_designator="L1",
+            ),
+            RawPcbComponent(
+                designator="U1", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            # L1 autoinfer: pad1 VIN (upstream), pad2 VIN_L (downstream)
+            _pad(1, "1", 1, 5), _pad(1, "2", 2, 6),
+            _pad(2, "1", 3, 10), _pad(2, "2", 0, 11),
+            _pad(2, "3", 2, 12), _pad(2, "4", 0, 13),
+        ),
+    )
+    supply_map = _collect_supply_voltages_by_net(
+        _iter_pdn_parameter_sources(proj), proj,
+    )
+    assert supply_map.get("VIN") == pytest.approx(12.0)
+    assert supply_map.get("VIN_L") == pytest.approx(12.0)
+
+    ann = parse_annotations(proj, enabled_layers=[1])
+    assert ann.ok, ann.errors
+    reg = next(d for d in ann.directives if isinstance(d, RegulatorSpec))
+    assert reg.gain == pytest.approx(3.3 / (12.0 * 0.9))
+
+def test_series_supply_flow_uses_primary_net_not_alias_cross_product():
+    """SERIES edges pair one primary expand per side (no alias fan-out)."""
+    from fypa.altium.annotations import _iter_series_supply_flow_edges
+
+    proj = _minimal_proj(
+        nets=(
+            RawNet("GND"), RawNet("LX.2"), RawNet("VDD_12V"),
+            # Extra PCB net that also expands from local LX / VDD_OUT aliases
+            # would create a spurious cross edge if all expansions were paired.
+            RawNet("LX_ALT"), RawNet("VDD_ALT"),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="L1", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN_R": "6m",
+                    "PDN_P_NET": "LX",
+                    "PDN_N_NET": "VDD_OUT",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="L1.2", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="IND", source_designator="L1",
+                source_unique_id=r"\SYM12\L",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 2, 1)),
+        compiled_netlist=_FakeNetlist(nets=[
+            _FakeNet(
+                name="LX.2", aliases=["LX", "LX_ALT"],
+                source_sheets=["pwr.schdoc"],
+                terminals=[_FakeTerminal("L1.2", "1")],
+            ),
+            _FakeNet(
+                name="VDD_12V", aliases=["VDD_OUT", "VDD_ALT"],
+                source_sheets=["pwr.schdoc"],
+                terminals=[_FakeTerminal("L1.2", "2")],
+            ),
+        ]),
+    )
+    edges = list(_iter_series_supply_flow_edges(
+        _iter_pdn_parameter_sources(proj), proj,
+    ))
+    assert edges == [("LX.2", "VDD_12V")]

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -55,6 +55,7 @@ from fypa.altium.extract import (
     RawPad,
     RawPcbComponent,
     RawSchComponent,
+    RawSchSheetSymbol,
     RawStackupLayer,
 )
 
@@ -3478,3 +3479,1442 @@ def test_channel_token_must_come_from_flattening():
     assert not _local_net_label_matches("VIN_3", "VIN", {"SW_3"})
     # An exact label still matches regardless.
     assert _local_net_label_matches("VIN", "VIN", {"FB_2"})
+
+# --- Sheet-symbol per-instance overrides ---
+
+# --- Sheet-symbol per-instance overrides --------------------------------------
+
+def test_sheet_symbol_override_different_currents_per_instance():
+    """Two sheet symbols override PDN_J1_I differently for J1.1 / J1.2."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("VBUS.1"), RawNet("VBUS.2")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "500mA",
+                    "PDN_P_NET": "VBUS",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("A4", "A1"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMAAAAA",
+                parameters={"PDN_J1_I": "1.5A"},
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-B",
+                child_filename="Port.SchDoc",
+                unique_id="SYMBBBBB",
+                parameters={"PDN_J1_I": "3A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMAAAAA\COMPUID1",
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMBBBBB\COMPUID1",
+            ),
+        ),
+        pads=(
+            _pad(0, "A4", 1), _pad(0, "A1", 0, 1),
+            _pad(1, "A4", 2, 10), _pad(1, "A1", 0, 11),
+        ),
+        compiled_netlist=_FakeNetlist(nets=[
+            _FakeNet(
+                name="VBUS.1", aliases=["VBUS"],
+                source_sheets=["port.schdoc"],
+                terminals=[_FakeTerminal("J1.1", "A4")],
+            ),
+            _FakeNet(
+                name="VBUS.2", aliases=["VBUS"],
+                source_sheets=["port.schdoc"],
+                terminals=[_FakeTerminal("J1.2", "A4")],
+            ),
+            _FakeNet(
+                name="GND",
+                source_sheets=["port.schdoc"],
+                terminals=[
+                    _FakeTerminal("J1.1", "A1"),
+                    _FakeTerminal("J1.2", "A1"),
+                ],
+            ),
+        ]),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = {d.designator: d for d in result.directives if isinstance(d, SinkSpec)}
+    assert set(sinks) == {"J1.1", "J1.2"}
+    assert sinks["J1.1"].current == pytest.approx(1.5)
+    assert sinks["J1.2"].current == pytest.approx(3.0)
+
+
+
+def test_sheet_symbol_override_absent_keeps_shared_child_current():
+    """Without sheet overrides, every instance inherits the child PDN_I."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "500mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMB\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 1, 5), _pad(1, "2", 0, 6),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 2
+    assert all(d.current == pytest.approx(0.5) for d in sinks)
+
+
+
+def test_sheet_symbol_nested_uid_deepest_wins():
+    """Deeper UniqueID in SOURCEUNIQUEID overrides a shallower symbol."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="OUTER",
+                child_filename="Mid.SchDoc",
+                unique_id="OUTERUID",
+                parameters={"PDN_J1_I": "1A"},
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Mid.SchDoc",
+                sheet_name="INNER",
+                child_filename="Port.SchDoc",
+                unique_id="INNERUID",
+                parameters={"PDN_J1_I": "2A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\OUTERUID\INNERUID\COMP",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].current == pytest.approx(2.0)
+
+
+
+def test_sheet_symbol_indexed_channel_override():
+    """``PDN_U1_1_I`` overrides only the indexed PDN channel on the child."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+3V3"), RawNet("+1V8")),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Chip.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "50mA",
+                    "PDN_P_NET": "+3V3",
+                    "PDN_N_NET": "GND",
+                    "PDN1_I": "10mA",
+                    "PDN1_P_NET": "+1V8",
+                    "PDN1_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CH",
+                child_filename="Chip.SchDoc",
+                unique_id="CHIPSYM",
+                parameters={"PDN_U1_1_I": "80mA"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+                source_unique_id=r"\CHIPSYM\U1UID",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 2, 1), _pad(0, "3", 0, 2),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = {
+        d.channel_index: d
+        for d in result.directives if isinstance(d, SinkSpec)
+    }
+    assert sinks[None].current == pytest.approx(0.05)
+    assert sinks[1].current == pytest.approx(0.08)
+
+
+
+def test_sheet_symbol_repeat_slot_qualified_override():
+    """One REPEAT sheet symbol: ``PDN_J1_I.1`` / ``PDN_J1_I.2`` per channel."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("VBUS.1"), RawNet("VBUS.2")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "VBUS",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="Repeat(PORT,1,2)",
+                child_filename="Port.SchDoc",
+                unique_id="REPEATSYM",
+                parameters={
+                    "PDN_J1_I.1": "1A",
+                    "PDN_J1_I.2": "2A",
+                },
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\REPEATSYM\COMP",
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\REPEATSYM\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 2, 10), _pad(1, "2", 0, 11),
+        ),
+        compiled_netlist=_FakeNetlist(nets=[
+            _FakeNet(
+                name="VBUS.1", aliases=["VBUS"],
+                source_sheets=["port.schdoc"],
+                terminals=[_FakeTerminal("J1.1", "1")],
+            ),
+            _FakeNet(
+                name="VBUS.2", aliases=["VBUS"],
+                source_sheets=["port.schdoc"],
+                terminals=[_FakeTerminal("J1.2", "1")],
+            ),
+            _FakeNet(
+                name="GND",
+                source_sheets=["port.schdoc"],
+                terminals=[
+                    _FakeTerminal("J1.1", "2"),
+                    _FakeTerminal("J1.2", "2"),
+                ],
+            ),
+        ]),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = {d.designator: d for d in result.directives if isinstance(d, SinkSpec)}
+    assert sinks["J1.1"].current == pytest.approx(1.0)
+    assert sinks["J1.2"].current == pytest.approx(2.0)
+
+
+
+def test_sheet_symbol_only_directive_without_child_pdn_role():
+    """Full SINK directive can live entirely on the sheet symbol."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={"Comment": "USB"},
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={
+                    "PDN_J1_ROLE": "SINK",
+                    "PDN_J1_I": "1.2A",
+                    "PDN_J1_P_NET": "+5V",
+                    "PDN_J1_N_NET": "GND",
+                },
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].designator == "J1.1"
+    assert sinks[0].current == pytest.approx(1.2)
+
+
+
+def test_sheet_symbol_params_via_owner_index():
+    """Sheet-symbol PDN_* must be read from schdoc.parameters OwnerIndex.
+
+    altium_monkey does not put sheet-symbol parameters on ``symbol.children``.
+    """
+    from fypa.altium.extract import (
+        _extract_sch_sheet_symbol,
+        _parameters_owned_by_index,
+    )
+
+    @dataclass
+    class _Param:
+        name: str
+        text: str
+        owner_index: int
+
+    @dataclass
+    class _Record:
+        unique_id: str = "SYMUID"
+        index_in_sheet: int = 42
+        children: tuple = ()
+        sheet_name: object = None
+        file_name: object = None
+
+    @dataclass
+    class _Info:
+        record: _Record
+        designator: str = "CON-A"
+        file_name: str = "Port.SchDoc"
+        unique_id: str = "SYMUID"
+
+    @dataclass
+    class _SchDoc:
+        parameters: list
+
+    schdoc = _SchDoc(parameters=[
+        _Param("PDN_J1_I", "1.5A", 42),
+        _Param("PDN_J1_ROLE", "SINK", 42),
+        _Param("Design Item Id", "BOM-PART", 42),  # filtered out
+        _Param("Other", "x", 99),  # different owner — ignored
+    ])
+    owned = _parameters_owned_by_index(schdoc, 42)
+    assert owned["PDN_J1_I"] == "1.5A"
+    assert "Design Item Id" in owned  # raw owner lookup keeps all
+
+    info = _Info(record=_Record())
+    sym = _extract_sch_sheet_symbol(info, "Main.SchDoc", schdoc=schdoc)
+    assert sym is not None
+    assert sym.parameters == {"PDN_J1_I": "1.5A", "PDN_J1_ROLE": "SINK"}
+    assert "Design Item Id" not in sym.parameters
+    assert "Other" not in sym.parameters
+
+
+
+def test_sheet_symbol_override_via_hierarchical_path_fallback():
+    """When SOURCEUNIQUEID is empty, match sheet symbols via hierarchy path."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={"PDN_J1_I": "2.5A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id="",  # force fallback
+                source_hierarchical_path=r"main\CON-A",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].current == pytest.approx(2.5)
+
+
+
+def test_sheet_symbol_extract_to_parse_round_trip():
+    """OwnerIndex extract → RawSchSheetSymbol → parse_annotations."""
+    from fypa.altium.extract import _extract_sch_sheet_symbol
+
+    @dataclass
+    class _Param:
+        name: str
+        text: str
+        owner_index: int
+
+    @dataclass
+    class _Record:
+        unique_id: str = "SYMA"
+        index_in_sheet: int = 7
+        children: tuple = ()
+
+    @dataclass
+    class _Info:
+        record: _Record
+        designator: str = "CON-A"
+        file_name: str = "Port.SchDoc"
+        unique_id: str = "SYMA"
+
+    @dataclass
+    class _SchDoc:
+        parameters: list
+
+    sym = _extract_sch_sheet_symbol(
+        _Info(record=_Record()),
+        "Main.SchDoc",
+        schdoc=_SchDoc(parameters=[
+            _Param("PDN_J1_I", "1.5A", 7),
+            _Param("Manufacturer", "ACME", 7),
+        ]),
+    )
+    assert sym is not None
+    assert sym.parameters == {"PDN_J1_I": "1.5A"}
+
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(sym,),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].current == pytest.approx(1.5)
+
+
+
+def test_sheet_symbol_repeat_slot_skipped_for_non_numeric_designator():
+    """Slot-qualified override warns when PCB designator has no .N suffix."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="Repeat(PORT,1,2)",
+                child_filename="Port.SchDoc",
+                unique_id="REPEATSYM",
+                parameters={"PDN_J1_I.1": "2A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1_CH1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\REPEATSYM\COMP",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    # Override not applied — falls back to child default.
+    assert sinks[0].current == pytest.approx(0.1)
+    assert any(
+        "PDN_J1_I.1" in w and "no numeric channel suffix" in w
+        for w in result.warnings
+    )
+
+
+
+def test_multi_instance_missing_value_reports_once():
+    """Missing PDN_I after expand → one logical error, not one per instance.
+
+    A bound sheet symbol carries only a REPEAT slot that matches no PCB
+    designator (``.99``). Discovery still sees ``PDN_I``, but no instance
+    receives the override.
+    """
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={"PDN_J1_I.99": "1A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+            RawPcbComponent(
+                designator="J1.3", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 1, 5), _pad(1, "2", 0, 6),
+            _pad(2, "1", 1, 10), _pad(2, "2", 0, 11),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert not result.ok
+    missing = [e for e in result.errors if "missing PDN_I" in e]
+    assert len(missing) == 1
+    assert "SINK on J1:" in missing[0]
+
+
+
+def test_multi_instance_missing_net_reports_once():
+    """Missing PDN_P_NET on every instance → one logical error."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "1A",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 1, 5), _pad(1, "2", 0, 6),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert not result.ok
+    missing = [e for e in result.errors if "missing PDN_P_NET" in e]
+    assert len(missing) == 1
+    assert "SINK on J1:" in missing[0]
+
+
+
+def test_orphan_sheet_override_does_not_invent_discovery_channel():
+    """Unbound sheet-symbol PDN_I must not make a child channel 'present'."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="ORPHAN",
+                child_filename="Port.SchDoc",
+                unique_id="NOTONPCB",
+                parameters={"PDN_J1_I": "1A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\OTHER\COMP",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert not result.ok
+    assert any(
+        "missing PDN_I" in e and "SINK on J1" in e
+        for e in result.errors
+    )
+    assert not any("missing required parameter PDN_I" in e for e in result.errors)
+
+
+
+def test_orphan_sheet_override_warnings_consolidated():
+    """Multiple orphan PDN keys on one symbol → one warning listing them."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"),),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="ORPHAN",
+                child_filename="Port.SchDoc",
+                unique_id="NOSUCHUID",
+                parameters={
+                    "PDN_J1_I": "1A",
+                    "PDN_J1_ROLE": "SINK",
+                    "PDN_J1_P_NET": "+5V",
+                },
+            ),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    uid_warns = [
+        w for w in result.warnings
+        if "NOSUCHUID" in w and "not bound to any PCB placement" in w
+    ]
+    assert len(uid_warns) == 1
+    assert "PDN_J1_I" in uid_warns[0]
+    assert "PDN_J1_ROLE" in uid_warns[0]
+    assert "PDN_J1_P_NET" in uid_warns[0]
+
+
+
+def test_sheet_symbol_only_multi_instance_different_currents():
+    """Full sheet-symbol-only directive with different I per placement."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={"Comment": "USB"},
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={
+                    "PDN_J1_ROLE": "SINK",
+                    "PDN_J1_I": "1.5A",
+                    "PDN_J1_P_NET": "+5V",
+                    "PDN_J1_N_NET": "GND",
+                },
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-B",
+                child_filename="Port.SchDoc",
+                unique_id="SYMB",
+                parameters={
+                    "PDN_J1_ROLE": "SINK",
+                    "PDN_J1_I": "3A",
+                    "PDN_J1_P_NET": "+5V",
+                    "PDN_J1_N_NET": "GND",
+                },
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMB\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 1, 5), _pad(1, "2", 0, 6),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = {d.designator: d for d in result.directives if isinstance(d, SinkSpec)}
+    assert sinks["J1.1"].current == pytest.approx(1.5)
+    assert sinks["J1.2"].current == pytest.approx(3.0)
+
+
+
+def test_indexed_sheet_override_does_not_force_sibling_channel():
+    """PDN_J1_2_I on one placement must not invent channel 2 on siblings."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={
+                    "PDN_J1_2_I": "2A",
+                    "PDN_J1_2_P_NET": "+5V",
+                    "PDN_J1_2_N_NET": "GND",
+                },
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-B",
+                child_filename="Port.SchDoc",
+                unique_id="SYMB",
+                parameters={"PDN_J1_I": "500mA"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMB\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 1, 5), _pad(1, "2", 0, 6),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    by_des = {}
+    for s in sinks:
+        by_des.setdefault(s.designator, []).append(s)
+    # J1.1: unindexed child I + indexed channel 2 from sheet
+    assert len(by_des["J1.1"]) == 2
+    assert {s.channel_index for s in by_des["J1.1"]} == {None, 2}
+    # J1.2: only unindexed (overridden to 500mA) — no channel 2
+    assert len(by_des["J1.2"]) == 1
+    assert by_des["J1.2"][0].channel_index is None
+    assert by_des["J1.2"][0].current == pytest.approx(0.5)
+    assert not any("missing" in e and "PDN2" in e for e in result.errors)
+
+
+
+def test_hierpath_bound_override_no_orphan_warning():
+    """Hierpath-only binding must not emit UniqueID orphan warnings."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={"PDN_J1_I": "2.5A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id="",
+                source_hierarchical_path=r"main\CON-A",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    assert not any("not bound to any PCB placement" in w for w in result.warnings)
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].current == pytest.approx(2.5)
+
+
+
+def test_ambiguous_hierpath_sheet_name_warns():
+    """Two symbols with the same sheet_name → one used, others ignored."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={"PDN_J1_I": "1A"},
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Other.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMB",
+                parameters={"PDN_J1_I": "2A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id="",
+                source_hierarchical_path=r"main\CON-A",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    assert any(
+        "SOURCEHIERARCHICALPATH matches" in w
+        and "using 'SYMA'" in w
+        and "ignoring" in w
+        for w in result.warnings
+    )
+    assert not any(
+        "not bound to any PCB placement" in w and "SYMB" in w
+        for w in result.warnings
+    )
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].current == pytest.approx(1.0)  # SYMA wins over SYMB
+
+
+
+def test_sheet_override_designator_with_trailing_letter():
+    """PDN_U12A_I targets designator U12A, not U12 + suffix A_I."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="U12A", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={"PDN_U12A_I": "1.8A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U12A.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOIC", source_designator="U12A",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].current == pytest.approx(1.8)
+
+
+
+def test_sheet_override_role_changes_parser_per_instance():
+    """Per-placement PDN_J1_ROLE must dispatch SOURCE vs SINK correctly."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={"PDN_J1_I": "1A"},
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-B",
+                child_filename="Port.SchDoc",
+                unique_id="SYMB",
+                parameters={
+                    "PDN_J1_ROLE": "SOURCE",
+                    "PDN_J1_V": "5V",
+                    "PDN_J1_P_NET": "+5V",
+                    "PDN_J1_N_NET": "GND",
+                },
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMB\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 1, 5), _pad(1, "2", 0, 6),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    assert not any("unknown PDN parameter 'PDN_I'" in w for w in result.warnings)
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    sources = [d for d in result.directives if isinstance(d, SourceSpec)]
+    assert len(sinks) == 1 and sinks[0].designator == "J1.1"
+    assert sinks[0].current == pytest.approx(1.0)
+    assert len(sources) == 1 and sources[0].designator == "J1.2"
+    assert sources[0].voltage == pytest.approx(5.0)
+
+
+
+def test_duplicate_sch_designator_with_sheet_symbols_not_multiplied():
+    """Two SchDocs with same J1 + sheet binding → one warning, no dup sinks."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="J1", schdoc_name="AltPort.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "9A",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={"PDN_J1_I": "1.5A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    assert any(
+        "appears in multiple schdocs with PDN_ROLE" in w
+        for w in result.warnings
+    )
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].current == pytest.approx(1.5)
+
+
+
+def test_sheet_symbol_only_partial_coverage_warns():
+    """Full sheet-only on one placement, sibling unbound → warning."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={"Comment": "USB"},
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={
+                    "PDN_J1_ROLE": "SINK",
+                    "PDN_J1_I": "1.5A",
+                    "PDN_J1_P_NET": "+5V",
+                    "PDN_J1_N_NET": "GND",
+                },
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-B",
+                child_filename="Port.SchDoc",
+                unique_id="SYMB",
+                parameters={},  # no PDN — sibling uncovered
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMB\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 1, 5), _pad(1, "2", 0, 6),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert any(
+        "sheet-symbol-only PDN directive covers" in w
+        and "J1.1" in w
+        and "J1.2" in w
+        for w in result.warnings
+    )
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].designator == "J1.1"
+
+
+
+def test_hierpath_skips_root_sheet_segment():
+    """A sheet symbol named like the root path segment must not bind."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Top.SchDoc",
+                sheet_name="main",  # same as root segment
+                child_filename="Other.SchDoc",
+                unique_id="ROOTISH",
+                parameters={"PDN_J1_I": "9A"},
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={"PDN_J1_I": "1.2A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id="",
+                source_hierarchical_path=r"main\CON-A",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].current == pytest.approx(1.2)
+
+
+
+def test_hierpath_single_segment_binds():
+    """Path with only the sheet-symbol name (no root) still binds."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={"PDN_J1_I": "1.7A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id="",
+                source_hierarchical_path="CON-A",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].current == pytest.approx(1.7)
+
+
+
+def test_hierpath_nested_sheet_symbol_first_segment():
+    """Path CON-A\\INNER (first segment is a sheet symbol) binds both; deeper wins."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Mid.SchDoc",
+                unique_id="OUTER",
+                parameters={"PDN_J1_I": "1A"},
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Mid.SchDoc",
+                sheet_name="INNER",
+                child_filename="Port.SchDoc",
+                unique_id="INNER",
+                parameters={"PDN_J1_I": "2.5A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id="",
+                source_hierarchical_path=r"CON-A\INNER",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].current == pytest.approx(2.5)
+
+
+
+def test_ambiguous_hierpath_loser_still_warns_missing_designator():
+    """Name-loser skips unbound warn but still flags unknown PDN designator."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={"PDN_J1_I": "1A"},
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Other.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMB",
+                parameters={
+                    "PDN_J1_I": "2A",
+                    "PDN_J99_I": "9A",  # no such PCB designator
+                },
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id="",
+                source_hierarchical_path=r"main\CON-A",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    assert not any(
+        "not bound to any PCB placement" in w and "SYMB" in w
+        for w in result.warnings
+    )
+    assert any(
+        "PDN_J99_I" in w
+        and "no PCB component with source designator 'J99'" in w
+        and "Other.SchDoc" in w
+        for w in result.warnings
+    )
+
+
+
+def test_sheet_override_role_strips_regulator_terminal_keys():
+    """Leaving REGULATOR via sheet ROLE drops OUT_/IN_ keys without noise."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V"), RawNet("VIN")),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_V": "3.3",
+                    "PDN_OUT_P_NET": "+5V",
+                    "PDN_OUT_N_NET": "GND",
+                    "PDN_IN_P_NET": "VIN",
+                    "PDN_IN_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="REG-A",
+                child_filename="Pwr.SchDoc",
+                unique_id="SYMA",
+                parameters={
+                    "PDN_U1_ROLE": "SINK",
+                    "PDN_U1_I": "0.5A",
+                    "PDN_U1_P_NET": "+5V",
+                    "PDN_U1_N_NET": "GND",
+                },
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOIC", source_designator="U1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(0, "3", 2, 2), _pad(0, "4", 0, 3),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    assert not any("OUT_P_NET" in w or "IN_P_NET" in w for w in result.warnings)
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].current == pytest.approx(0.5)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -23,11 +23,19 @@ from fypa.altium.annotations import (
     SourceSpec,
     TerminalPin,
     TerminalSpec,
+    _LOCAL_NET_TIER_ALIAS,
+    _LOCAL_NET_TIER_NAME,
+    _LOCAL_NET_TIER_PCB,
+    _arbitrate_overlapping_terminals,
+    _collect_series_upstream_map,
     _collect_supply_voltages_by_net,
     _iter_pdn_parameter_sources,
     _iter_series_bridge_pairs,
     _union_series_bridge_net_indices,
     _lookup_inferred_vin,
+    _local_net_label_matches,
+    _SeriesVinGraph,
+    _SERIES_VIN_MAX_HOPS,
     _require_value,
     _resolve_local_net_pins,
     _resolve_terminal,
@@ -370,7 +378,7 @@ def test_resolve_local_net_pins_finds_alias_on_sheet():
             terminals=[_FakeTerminal("U1", "14"), _FakeTerminal("C1", "1")],
         ),
     ])
-    pins = _resolve_local_net_pins(netlist, "U1", "Power.SchDoc", "+3V3")
+    pins, _tier = _resolve_local_net_pins(netlist, "U1", "Power.SchDoc", "+3V3")
     assert pins == ["14"]
 
 
@@ -394,7 +402,7 @@ def test_resolve_local_net_pins_matches_multichannel_mangled_alias():
             ],
         ),
     ])
-    pins = _resolve_local_net_pins(
+    pins, _tier = _resolve_local_net_pins(
         netlist, "J3", "SL8_Module.SchDoc", "S00A",
         pcb_designator="J3_SL8M7",
     )
@@ -413,7 +421,7 @@ def test_resolve_local_net_pins_mangled_alias_is_channel_scoped():
             terminals=[_FakeTerminal("J3_SL8M7", "29")],
         ),
     ])
-    pins = _resolve_local_net_pins(
+    pins, _tier = _resolve_local_net_pins(
         netlist, "J3", "SL8_Module.SchDoc", "S00A",
         pcb_designator="J3_SL8M7",
     )
@@ -458,12 +466,12 @@ def test_resolve_terminal_local_net_per_channel_instance():
         compiled_netlist=netlist,
     )
     warnings: list[str] = []
-    spec0, err0 = _resolve_terminal(
+    spec0, err0, _t0 = _resolve_terminal(
         proj, 0, "+3V3", None, [1], "SINK P",
         warnings=warnings,
         sch_lookup_designator="U1", schdoc_name="Child.SchDoc",
     )
-    spec1, err1 = _resolve_terminal(
+    spec1, err1, _t1 = _resolve_terminal(
         proj, 1, "+3V3", None, [1], "SINK P",
         warnings=warnings,
         sch_lookup_designator="U1", schdoc_name="Child.SchDoc",
@@ -862,7 +870,10 @@ def test_bridge_pairs_indexed_series_nets():
             ),
         ),
     )
-    pairs = {(p, n) for _idx, p, n in _iter_series_bridge_pairs([source], proj)}
+    pairs = {
+        (p, n) for _idx, p, n, _directed
+        in _iter_series_bridge_pairs([source], proj)
+    }
     assert pairs == {("RAIL_A", "RAIL_B"), ("RAIL_C", "RAIL_D")}
 
 
@@ -879,6 +890,92 @@ def test_sheet_name_matches_full_path_not_basename_collision():
         "Power.SchDoc",
         ["SubB/Power.SchDoc"],
     )
+
+
+def _sheet_map(proj):
+    from fypa.altium.annotations import _physical_sheet_file_map
+    return _physical_sheet_file_map(proj)
+
+
+def test_sheet_name_matches_physical_page_id_via_map():
+    """altium_monkey ≥ 2026.7 emits physical page ids in source_sheets."""
+    physical = (
+        "physical:0:logical:0:main.SchDoc:child:1:sheet_symbol:U_PWR"
+        ":sheet:power.SchDoc"
+    )
+    proj = _minimal_proj(
+        physical_sheet_names=((physical, "Power.SchDoc"),),
+    )
+    smap = _sheet_map(proj)
+    assert _sheet_name_matches("Power.SchDoc", [physical], sheet_map=smap)
+    assert not _sheet_name_matches("Other.SchDoc", [physical], sheet_map=smap)
+
+
+def test_sheet_map_keeps_same_named_sheets_in_different_directories_apart():
+    """Harvesting the bare leaf would collapse these onto one name, which is
+    the collision _sheet_name_matches exists to prevent."""
+    page_a = "physical:0:logical:0:SubA/Power.SchDoc"
+    page_b = "physical:1:logical:1:SubB/Power.SchDoc"
+    proj = _minimal_proj(physical_sheet_names=(
+        (page_a, "SubA/Power.SchDoc"),
+        (page_b, "SubB/Power.SchDoc"),
+    ))
+    smap = _sheet_map(proj)
+    assert _sheet_name_matches("SubA/Power.SchDoc", [page_a], sheet_map=smap)
+    assert not _sheet_name_matches("SubA/Power.SchDoc", [page_b], sheet_map=smap)
+
+
+def test_unmapped_physical_page_id_is_unknown_not_guessed():
+    """A child page id embeds its PARENT's logical id, so scanning it for a
+    ``*.SchDoc`` token yields the root sheet — which both hides real matches
+    and invents false ones. An unmapped id must read as unknown provenance,
+    degrading to the permissive path rather than binding to a guess."""
+    from fypa.altium.annotations import _logical_schdoc_name
+
+    child = (
+        "physical:0:logical:0:main.SchDoc:child:logical:0:main.SchDoc"
+        ":sheet_symbol:UID-ABC:1"
+    )
+    assert _logical_schdoc_name(child, {}) is None
+    # Not "matches the root sheet", and not a hard reject either: with no
+    # usable provenance the net is accepted the same way one with no
+    # source_sheets at all is.
+    assert _sheet_name_matches("Power.SchDoc", [child])
+    assert _sheet_name_matches("main.SchDoc", [child])
+    # …but a page the map DOES cover still discriminates.
+    proj = _minimal_proj(physical_sheet_names=((child, "Power.SchDoc"),))
+    smap = _sheet_map(proj)
+    assert _sheet_name_matches("Power.SchDoc", [child], sheet_map=smap)
+    assert not _sheet_name_matches("main.SchDoc", [child], sheet_map=smap)
+
+
+def test_plain_sheet_names_are_unaffected_by_the_page_id_path():
+    assert _sheet_name_matches("Power.SchDoc", ["Power.SchDoc"])
+    assert _sheet_name_matches("Power.SchDoc", ["SubA/Power.SchDoc"])
+    assert not _sheet_name_matches("SubA/Power.SchDoc", ["SubB/Power.SchDoc"])
+
+
+def test_resolve_local_net_pins_physical_source_sheet():
+    physical = (
+        "physical:0:logical:0:main.SchDoc:child:1:sheet_symbol:U_PWR"
+        ":sheet:power.SchDoc"
+    )
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="Sheet1_+3V3",
+            aliases=["+3V3"],
+            source_sheets=[physical],
+            terminals=[_FakeTerminal("U1", "14"), _FakeTerminal("C1", "1")],
+        ),
+    ])
+    proj = _minimal_proj(
+        physical_sheet_names=((physical, "Power.SchDoc"),),
+        compiled_netlist=netlist,
+    )
+    pins, _tier = _resolve_local_net_pins(
+        netlist, "U1", "Power.SchDoc", "+3V3", sheet_map=_sheet_map(proj),
+    )
+    assert pins == ["14"]
 
 
 def test_pcb_sourced_local_net_scoped_per_instance():
@@ -1034,7 +1131,7 @@ def test_resolve_local_net_pins_dot_channel_alias():
             ],
         ),
     ])
-    pins = _resolve_local_net_pins(
+    pins, _tier = _resolve_local_net_pins(
         netlist, "J3", "Child.SchDoc", "S00A",
         pcb_designator="J3.4",
     )
@@ -1050,7 +1147,7 @@ def test_resolve_local_net_pins_dot_channel_alias_scoped():
             terminals=[_FakeTerminal("J3.4", "29")],
         ),
     ])
-    pins = _resolve_local_net_pins(
+    pins, _tier = _resolve_local_net_pins(
         netlist, "J3", "Child.SchDoc", "S00A",
         pcb_designator="J3.4",
     )
@@ -1144,7 +1241,7 @@ def test_variant_alias_pattern_via_pad_netlist():
         pads=(_pad(0, "1", 0, 0), _pad(0, "2", 1, 1)),
         compiled_netlist=netlist,
     )
-    spec, errors = _resolve_terminal(
+    spec, errors, _tier = _resolve_terminal(
         proj, 0, "MDI.TD_P", None, [1], "SERIES P",
         sch_lookup_designator="R1", schdoc_name="eth.schdoc",
     )
@@ -1189,9 +1286,9 @@ def test_alias_fallback_no_cross_channel_family_leak():
     )
     with patch(
         "fypa.altium.annotations._resolve_local_net_pins",
-        return_value=[],
+        return_value=([], 2),
     ):
-        spec, errors = _resolve_terminal(
+        spec, errors, _tier = _resolve_terminal(
             proj, 0, "+3V3", None, [1], "SINK P",
             sch_lookup_designator="U1", schdoc_name="child2.schdoc",
         )
@@ -1225,9 +1322,9 @@ def test_alias_fallback_flattened_terminal_designator():
     )
     with patch(
         "fypa.altium.annotations._resolve_local_net_pins",
-        return_value=[],
+        return_value=([], 2),
     ):
-        spec, errors = _resolve_terminal(
+        spec, errors, _tier = _resolve_terminal(
             proj, 0, "S00A", None, [1], "SINK P",
             sch_lookup_designator="J3", schdoc_name="Child.SchDoc",
         )
@@ -1435,7 +1532,7 @@ def test_resolve_terminal_no_double_suffix_on_qualified_net():
         pads=(_pad(0, "2", 0, 0),),
         compiled_netlist=None,
     )
-    spec, errors = _resolve_terminal(
+    spec, errors, _tier = _resolve_terminal(
         proj, 0, "VCC_EFUSE.4", None, [1], "SERIES N",
     )
     assert not errors
@@ -1457,7 +1554,7 @@ def test_resolve_terminal_degraded_suffix_guess_warns():
         compiled_netlist=None,
     )
     warnings: list[str] = []
-    spec, errors = _resolve_terminal(
+    spec, errors, _tier = _resolve_terminal(
         proj, 0, "VCC_EFUSE", None, [1], "SERIES N", warnings=warnings,
     )
     assert not errors
@@ -1497,7 +1594,7 @@ def test_local_fallback_skips_no_net_pad():
         ),
         compiled_netlist=netlist,
     )
-    spec, errors = _resolve_terminal(
+    spec, errors, _tier = _resolve_terminal(
         proj, 0, "+3V3", None, [1], "SINK P",
         sch_lookup_designator="U1", schdoc_name="Power.SchDoc",
     )
@@ -1506,6 +1603,194 @@ def test_local_fallback_skips_no_net_pad():
     assert len(spec.pins) == 1
     assert spec.pins[0].pad_designator == "2"
     assert spec.pins[0].net_index == 1
+
+
+def test_local_net_label_matches_separator_agnostic_channel_token():
+    """Net VIN_1 must match local VIN on designator R1.1 (._ separators differ)."""
+    assert _local_net_label_matches("VIN_1", "VIN", {"R1", "R1.1"})
+    assert _local_net_label_matches("VIN.1", "VIN", {"R1", "R1_1"})
+    assert not _local_net_label_matches("VIN_L.1", "VIN", {"R1", "R1.1"})
+    assert _local_net_label_matches("VIN_L.1", "VIN_L", {"R1", "R1.1"})
+
+
+def test_resolve_local_net_pins_prefers_name_over_shared_alias():
+    """Two nets sharing bare alias VIN: keep only the channel name-level match.
+
+    Models the multi-channel case where both sides of a SERIES element carry
+    the same local alias in the compiled netlist. The P label VIN must resolve
+    to pin 2 (net VIN_1) and not also claim pin 1 (net VIN_L.1).
+    """
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="VIN_1",
+            aliases=["VIN", "VIN.1"],
+            source_sheets=["Supply.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "2")],
+        ),
+        _FakeNet(
+            name="VIN_L.1",
+            aliases=["VIN", "VIN.1", "VIN.2"],
+            source_sheets=["Supply.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "1")],
+        ),
+    ])
+    pins, tier = _resolve_local_net_pins(
+        netlist, "R1", "Supply.SchDoc", "VIN",
+        pcb_designator="R1.1",
+        routed_pin_keys={"1", "2"},
+    )
+    assert pins == ["2"]
+    assert tier == _LOCAL_NET_TIER_NAME
+
+    n_pins, n_tier = _resolve_local_net_pins(
+        netlist, "R1", "Supply.SchDoc", "VIN_L",
+        pcb_designator="R1.1",
+        routed_pin_keys={"1", "2"},
+    )
+    assert n_pins == ["1"]
+    assert n_tier == _LOCAL_NET_TIER_NAME
+
+
+def test_resolve_local_net_pins_pcb_confirmed_beats_name():
+    """When PCB net confirms a row, prefer that tier over bare name matches."""
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="OTHER",
+            aliases=["VIN"],
+            source_sheets=["Supply.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "2")],
+        ),
+        _FakeNet(
+            name="VIN_1",
+            aliases=["VIN"],
+            source_sheets=["Supply.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "1")],
+        ),
+    ])
+    pins, tier = _resolve_local_net_pins(
+        netlist, "R1", "Supply.SchDoc", "VIN",
+        pcb_designator="R1.1",
+        routed_pin_keys={"1", "2"},
+        pcb_net_by_pin={"1": "VIN_1", "2": "VOUT"},
+    )
+    # Pin 1 is PCB-confirmed (VIN_1 on the row); pin 2 is alias-only → drop it.
+    assert pins == ["1"]
+    assert tier == _LOCAL_NET_TIER_PCB
+
+
+def test_series_shared_alias_resolves_disjoint_p_n():
+    """SERIES with local VIN / VIN_L must not short both pads of a 2-pin part."""
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="VIN_1",
+            aliases=["VIN", "VIN.1"],
+            source_sheets=["Supply.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "2")],
+        ),
+        _FakeNet(
+            name="VIN_L.1",
+            aliases=["VIN", "VIN.1"],
+            source_sheets=["Supply.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "1")],
+        ),
+    ])
+    proj = _minimal_proj(
+        nets=(RawNet("VIN_1"), RawNet("VIN_L.1")),
+        pcb_components=(
+            RawPcbComponent(
+                designator="R1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1005R", source_designator="R1",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN_R": "10m",
+                    "PDN_P_NET": "VIN",
+                    "PDN_N_NET": "VIN_L",
+                },
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1, 0),  # VIN_L.1
+            _pad(0, "2", 0, 1),  # VIN_1
+        ),
+        compiled_netlist=netlist,
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    series = [d for d in result.directives if isinstance(d, ResistorSpec)]
+    assert len(series) == 1
+    r = series[0]
+    p_nets = {p.net_index for p in r.p.pins}
+    n_nets = {p.net_index for p in r.n.pins}
+    assert p_nets == {0}
+    assert n_nets == {1}
+    assert p_nets.isdisjoint(n_nets)
+
+
+def test_arbitrate_overlapping_terminals_drops_weaker_side():
+    p = TerminalSpec(
+        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),
+              TerminalPin("2", 1, 1, Pt2D(1, 0))),
+        requested_net="VIN",
+        resolved_via_local=True,
+    )
+    n = TerminalSpec(
+        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),),
+        requested_net="VIN_L",
+        resolved_via_local=True,
+    )
+    result = AnnotationResult()
+    p2, n2 = _arbitrate_overlapping_terminals(
+        p, n, _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_NAME, "SERIES on R1.1", result,
+    )
+    assert p2 is not None and n2 is not None
+    assert {pin.pad_designator for pin in p2.pins} == {"2"}
+    assert {pin.pad_designator for pin in n2.pins} == {"1"}
+    assert any("both matched pin(s)" in w for w in result.warnings)
+    # The pad designator, not the internal "R1.1:1" arbitration key: the
+    # message tells the user to set PDN_*_PINS, which matches on pad names.
+    assert any("kept on N" in w and "dropped from P" in w
+               for w in result.warnings)
+    assert not result.errors
+
+
+def test_arbitrate_overlapping_terminals_equal_tier_errors():
+    p = TerminalSpec(
+        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),),
+        requested_net="VIN",
+    )
+    n = TerminalSpec(
+        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),),
+        requested_net="VIN_L",
+    )
+    result = AnnotationResult()
+    p2, n2 = _arbitrate_overlapping_terminals(
+        p, n, _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_ALIAS, "SERIES on R1", result,
+    )
+    assert p2 is None and n2 is None
+    assert any("PDN_P_PINS" in e for e in result.errors)
+
+
+def test_arbitrate_overlapping_terminals_ignores_same_pad_on_other_parts():
+    """Banana-jack style: pad '1' on J2 vs pad '1' on J3 is not an overlap."""
+    p = TerminalSpec(
+        pins=(TerminalPin(
+            "1", 1, 0, Pt2D(0, 0), component_designator="J2",
+        ),),
+        requested_net="+5V",
+    )
+    n = TerminalSpec(
+        pins=(TerminalPin(
+            "1", 1, 1, Pt2D(10, 0), component_designator="J3",
+        ),),
+        requested_net="GND",
+    )
+    result = AnnotationResult()
+    p2, n2 = _arbitrate_overlapping_terminals(
+        p, n, _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_ALIAS, "SOURCE on J2", result,
+    )
+    assert p2 is p and n2 is n
+    assert not result.errors
+    assert not result.warnings
 
 
 def _regulator_proj_with_source(**extra_regulator_params):
@@ -1600,11 +1885,478 @@ def test_regulator_explicit_gain_overrides_type():
     assert any("overrides" in w for w in result.warnings)
 
 
-def test_lookup_inferred_vin_ignores_series_bridge_groups():
-    """Sense paths through GND must not make Vin ambiguous (project_a / PDN5_R)."""
+def test_lookup_inferred_vin_exact_match_without_series_walk():
+    """Without a SERIES graph, only direct supply_map hits resolve."""
     supply_map = {"VDD_48V": 48.0, "VDD_12V": 12.0}
-    assert _lookup_inferred_vin("VDD_48V", supply_map) == 48.0
-    assert _lookup_inferred_vin("VDD_12V", supply_map) == 12.0
+    assert _lookup_inferred_vin("VDD_48V", supply_map) == (48.0, None, 0)
+    assert _lookup_inferred_vin("VDD_12V", supply_map) == (12.0, None, 0)
+    assert _lookup_inferred_vin("VDD_48V_RP", supply_map) == (None, None, 0)
+
+
+def test_lookup_inferred_vin_walks_series_upstream():
+    supply_map = {"VDD_48V_IN": 48.0}
+    graph = _SeriesVinGraph(
+        upstream={"VDD_48V_RP": "VDD_48V", "VDD_48V": "VDD_48V_IN"},
+    )
+    # Two hops from the named rail — the caller warns on any non-zero hop count.
+    assert _lookup_inferred_vin(
+        "VDD_48V_RP", supply_map, graph=graph,
+    ) == (48.0, None, 2)
+
+
+def test_lookup_inferred_vin_series_ambiguous_and_cycle():
+    supply_map = {"VDD_48V_IN": 48.0}
+    assert _lookup_inferred_vin(
+        "VDD_48V_RP", supply_map,
+        graph=_SeriesVinGraph(ambiguous=frozenset({"VDD_48V_RP"})),
+    ) == (None, "ambiguous", 0)
+    assert _lookup_inferred_vin(
+        "VDD_48V_RP", supply_map,
+        graph=_SeriesVinGraph(
+            upstream={"VDD_48V_RP": "VDD_48V", "VDD_48V": "VDD_48V_RP"},
+        ),
+    ) == (None, "cycle", 1)
+
+
+def test_lookup_inferred_vin_declared_rail_beats_series_ambiguity():
+    """A rail whose voltage is declared resolves even when SERIES links to it
+    disagree — parallel ferrites / ORing FETs / fuse+bypass all land here."""
+    assert _lookup_inferred_vin(
+        "VDD_12V", {"VDD_12V": 12.0},
+        graph=_SeriesVinGraph(ambiguous=frozenset({"VDD_12V"})),
+    ) == (12.0, None, 0)
+
+
+def test_lookup_inferred_vin_crosses_single_undirected_link():
+    """An auto-inferred 2-pin element has no P/N direction, so it is crossed
+    only when it is the one unvisited way out of the net."""
+    supply_map = {"VDD_48V_IN": 48.0}
+    one_way = _SeriesVinGraph(
+        undirected={
+            "VDD_48V": frozenset({"VDD_48V_IN"}),
+            "VDD_48V_IN": frozenset({"VDD_48V"}),
+        },
+    )
+    assert _lookup_inferred_vin("VDD_48V", supply_map, graph=one_way) == (
+        48.0, None, 1,
+    )
+    forked = _SeriesVinGraph(
+        undirected={"VDD_48V": frozenset({"VDD_48V_IN", "VDD_SENSE"})},
+    )
+    assert _lookup_inferred_vin("VDD_48V", supply_map, graph=forked) == (
+        None, "undirected", 0,
+    )
+
+
+def test_lookup_inferred_vin_bounds_chain_length():
+    """A chain longer than the hop cap errors instead of walking on."""
+    chain = {f"N{i}": f"N{i + 1}" for i in range(_SERIES_VIN_MAX_HOPS + 3)}
+    vin, failure, _hops = _lookup_inferred_vin(
+        "N0", {"N99": 48.0}, graph=_SeriesVinGraph(upstream=chain),
+    )
+    assert vin is None
+    assert failure == "too_deep"
+
+
+def test_regulator_smps_vin_through_series_chain():
+    """VIP-style: SOURCE -> SERIES -> SERIES -> SMPS on downstream net."""
+    proj = _minimal_proj(
+        nets=(
+            RawNet("GND"), RawNet("VDD_48V_IN"), RawNet("VDD_48V"),
+            RawNet("VDD_48V_RP"), RawNet("VDD_12V"),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="J7", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SOURCE",
+                    "PDN_V": "48",
+                    "PDN_P_NET": "VDD_48V_IN",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="J8", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN_R": "50m",
+                    "PDN_P_NET": "VDD_48V_IN",
+                    "PDN_N_NET": "VDD_48V",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="Q3", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN_R": "300m",
+                    "PDN_P_NET": "VDD_48V",
+                    "PDN_N_NET": "VDD_48V_RP",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="U5", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_REGULATOR_TYPE": "SMPS",
+                    "PDN_REGULATOR_EFFICIENCY": "0.8",
+                    "PDN_V": "12",
+                    "PDN_OUT_P_NET": "VDD_12V",
+                    "PDN_OUT_N_NET": "GND",
+                    "PDN_IN_P_NET": "VDD_48V_RP",
+                    "PDN_IN_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J7", center=Pt2D(-15, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="CONN", source_designator="J7",
+            ),
+            RawPcbComponent(
+                designator="J8", center=Pt2D(-10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="FUSE", source_designator="J8",
+            ),
+            RawPcbComponent(
+                designator="Q3", center=Pt2D(-5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOT", source_designator="Q3",
+            ),
+            RawPcbComponent(
+                designator="U5", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOT", source_designator="U5",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1, -15), _pad(0, "2", 0, -14),
+            _pad(1, "1", 1, -10), _pad(1, "2", 2, -9),
+            _pad(2, "1", 2, -5), _pad(2, "2", 3, -4),
+            _pad(3, "1", 4, 0), _pad(3, "2", 0, 1),
+            _pad(3, "3", 3, 2), _pad(3, "4", 0, 3),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    reg = next(d for d in result.directives if d.designator == "U5")
+    assert isinstance(reg, RegulatorSpec)
+    assert reg.regulator_type == "SMPS"
+    assert abs(reg.gain - (12.0 / (48.0 * 0.8))) < 1e-6
+    assert not any("cannot infer input voltage" in e for e in result.errors)
+
+
+def test_regulator_smps_vin_series_ambiguous_fork():
+    proj = _minimal_proj(
+        nets=(
+            RawNet("GND"), RawNet("VDD_48V_IN"), RawNet("VDD_48V"),
+            RawNet("VDD_48V_RP"), RawNet("VDD_12V"), RawNet("ALT_48V"),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="J7", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SOURCE", "PDN_V": "48",
+                    "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="J8", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES", "PDN_R": "50m",
+                    "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="Q3a", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES", "PDN_R": "100m",
+                    "PDN_P_NET": "VDD_48V", "PDN_N_NET": "VDD_48V_RP",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="Q3b", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES", "PDN_R": "200m",
+                    "PDN_P_NET": "ALT_48V", "PDN_N_NET": "VDD_48V_RP",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="U5", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_REGULATOR_TYPE": "SMPS",
+                    "PDN_REGULATOR_EFFICIENCY": "0.8",
+                    "PDN_V": "12",
+                    "PDN_OUT_P_NET": "VDD_12V",
+                    "PDN_OUT_N_NET": "GND",
+                    "PDN_IN_P_NET": "VDD_48V_RP",
+                    "PDN_IN_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J7", center=Pt2D(-15, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="CONN", source_designator="J7",
+            ),
+            RawPcbComponent(
+                designator="J8", center=Pt2D(-10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="FUSE", source_designator="J8",
+            ),
+            RawPcbComponent(
+                designator="Q3a", center=Pt2D(-5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOT", source_designator="Q3a",
+            ),
+            RawPcbComponent(
+                designator="Q3b", center=Pt2D(-4, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOT", source_designator="Q3b",
+            ),
+            RawPcbComponent(
+                designator="U5", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOT", source_designator="U5",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1, -15), _pad(0, "2", 0, -14),
+            _pad(1, "1", 1, -10), _pad(1, "2", 2, -9),
+            _pad(2, "1", 2, -5), _pad(2, "2", 3, -4),
+            _pad(3, "1", 5, -4), _pad(3, "2", 3, -3),
+            _pad(4, "1", 4, 0), _pad(4, "2", 0, 1),
+            _pad(4, "3", 3, 2), _pad(4, "4", 0, 3),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert not result.ok
+    assert any("ambiguous SERIES upstream" in e for e in result.errors)
+
+
+# --- SERIES Vin graph construction --------------------------------------------
+
+_SERIES_VIN_NETS = {
+    "GND": 0, "VDD_48V_IN": 1, "VDD_48V": 2, "VDD_12V": 3, "VDD_48V_F": 4,
+}
+
+
+def _series_vin_proj(
+    series_params: dict[str, str],
+    *,
+    in_p_net: str = "VDD_48V",
+    in_p_pad_net: int | None = None,
+    series_pads: tuple[tuple[str, int], ...] = (("1", 1), ("2", 2)),
+    extra_series: dict[str, str] | None = None,
+) -> ExtractedProject:
+    """SOURCE(48 V on VDD_48V_IN) → one SERIES part → SMPS on ``in_p_net``.
+
+    ``series_params`` is the SERIES component's parameter dict, so each test can
+    vary only how that one part declares its two nets. ``series_pads`` is its
+    ``(pin, net_index)`` list *in file order* — the order 2-pin auto-inference
+    reads P/N off. ``in_p_pad_net`` overrides the net the regulator's IN_P pad
+    sits on, modelling the state ``_apply_net_remap`` leaves behind: the pad
+    carries the canonical index while the annotation still names the folded one.
+    """
+    sch = [
+        RawSchComponent(
+            designator="J7", schdoc_name="Pwr.SchDoc",
+            parameters={
+                "PDN_ROLE": "SOURCE", "PDN_V": "48",
+                "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "GND",
+            },
+            pin_designators=("1", "2"),
+        ),
+        RawSchComponent(
+            designator="F1", schdoc_name="Pwr.SchDoc",
+            parameters=series_params,
+            pin_designators=("1", "2", "3"),
+        ),
+        RawSchComponent(
+            designator="U5", schdoc_name="Pwr.SchDoc",
+            parameters={
+                "PDN_ROLE": "REGULATOR", "PDN_REGULATOR_TYPE": "SMPS",
+                "PDN_REGULATOR_EFFICIENCY": "0.8", "PDN_V": "12",
+                "PDN_OUT_P_NET": "VDD_12V", "PDN_OUT_N_NET": "GND",
+                "PDN_IN_P_NET": in_p_net, "PDN_IN_N_NET": "GND",
+            },
+            pin_designators=("1", "2", "3", "4"),
+        ),
+    ]
+    pcb = [
+        RawPcbComponent(
+            designator="J7", center=Pt2D(-15, 0), rotation_deg=0.0,
+            layer_name="TOP", footprint="CONN", source_designator="J7",
+        ),
+        RawPcbComponent(
+            designator="F1", center=Pt2D(-10, 0), rotation_deg=0.0,
+            layer_name="TOP", footprint="FUSE", source_designator="F1",
+        ),
+        RawPcbComponent(
+            designator="U5", center=Pt2D(0, 0), rotation_deg=0.0,
+            layer_name="TOP", footprint="SOT", source_designator="U5",
+        ),
+    ]
+    # J7 = pcb 0, F1 = pcb 1, [R9 = pcb 2], U5 last.
+    pads = [_pad(0, "1", 1, -15), _pad(0, "2", 0, -14)]
+    pads += [_pad(1, pin, net, -10) for pin, net in series_pads]
+    u5_index = 2
+    if extra_series is not None:
+        sch.insert(2, RawSchComponent(
+            designator="R9", schdoc_name="Pwr.SchDoc",
+            parameters=extra_series, pin_designators=("1", "2"),
+        ))
+        pcb.insert(2, RawPcbComponent(
+            designator="R9", center=Pt2D(-7, 0), rotation_deg=0.0,
+            layer_name="TOP", footprint="0402", source_designator="R9",
+        ))
+        pads += [_pad(2, "1", 2, -7), _pad(2, "2", 4, -6)]
+        u5_index = 3
+    pads += [
+        _pad(u5_index, "1", 3, 0),                              # OUT_P
+        _pad(u5_index, "2", 0, 1),                              # OUT_N
+        _pad(
+            u5_index, "3",
+            _SERIES_VIN_NETS[in_p_net] if in_p_pad_net is None else in_p_pad_net,
+            2,
+        ),                                                      # IN_P
+        _pad(u5_index, "4", 0, 3),                              # IN_N
+    ]
+    return _minimal_proj(
+        nets=(
+            RawNet("GND"), RawNet("VDD_48V_IN"), RawNet("VDD_48V"),
+            RawNet("VDD_12V"), RawNet("VDD_48V_F"),
+        ),
+        sch_components=tuple(sch),
+        pcb_components=tuple(pcb),
+        pads=tuple(pads),
+    )
+
+
+def test_series_upstream_map_reads_indexed_role_only_channels():
+    """A part whose SERIES channels come only from PDN<n>_ROLE overrides still
+    contributes its links — _is_pdn_annotated admits it, so the graph must too."""
+    proj = _series_vin_proj({
+        "PDN1_ROLE": "SERIES", "PDN1_R": "50m",
+        "PDN1_P_NET": "VDD_48V_IN", "PDN1_N_NET": "VDD_48V",
+        "PDN2_ROLE": "SERIES", "PDN2_R": "50m",
+        "PDN2_P_NET": "VDD_48V", "PDN2_N_NET": "VDD_12V",
+    })
+    graph = _collect_series_upstream_map(_iter_pdn_parameter_sources(proj), proj)
+    assert graph.upstream == {
+        "VDD_48V": "VDD_48V_IN", "VDD_12V": "VDD_48V",
+    }
+
+
+def test_series_upstream_map_reads_pin_specified_channels():
+    """PDN_P_PINS / PDN_N_PINS is a supported way to state a SERIES element's
+    two sides, so it must produce the same edge PDN_P_NET / PDN_N_NET would."""
+    proj = _series_vin_proj(
+        {
+            "PDN_ROLE": "SERIES", "PDN_R": "50m",
+            "PDN_P_PINS": "1", "PDN_N_PINS": "2,3",
+        },
+        # pin 1 on VDD_48V_IN, pins 2+3 both on VDD_48V.
+        series_pads=(("1", 1), ("2", 2), ("3", 2)),
+    )
+    graph = _collect_series_upstream_map(_iter_pdn_parameter_sources(proj), proj)
+    assert graph.upstream == {"VDD_48V": "VDD_48V_IN"}
+
+    result = parse_annotations(proj, enabled_layers=[1])
+    reg = next(d for d in result.directives if d.designator == "U5")
+    assert abs(reg.gain - (12.0 / (48.0 * 0.8))) < 1e-6
+
+
+def test_series_upstream_map_auto_inferred_link_is_direction_agnostic():
+    """_autoinfer_2pin_nets takes P/N from raw pad order, so the Vin result must
+    not change when the two RawPad entries are swapped."""
+    params = {"PDN_ROLE": "SERIES", "PDN_R": "50m"}
+    forward = _series_vin_proj(params, series_pads=(("1", 1), ("2", 2)))
+    reversed_ = _series_vin_proj(params, series_pads=(("2", 2), ("1", 1)))
+    expected = 12.0 / (48.0 * 0.8)
+    for proj in (forward, reversed_):
+        graph = _collect_series_upstream_map(
+            _iter_pdn_parameter_sources(proj), proj,
+        )
+        # Recorded as an undirected pair — pad order states no power flow.
+        assert not graph.upstream
+        assert graph.undirected["VDD_48V"] == frozenset({"VDD_48V_IN"})
+        result = parse_annotations(proj, enabled_layers=[1])
+        reg = next(d for d in result.directives if d.designator == "U5")
+        assert abs(reg.gain - expected) < 1e-6, result.errors
+
+
+def test_series_upstream_map_skips_merged_short_self_edges():
+    """A 0 Ω the merge pre-pass absorbed has both ends on one net now. Neither
+    the skip list nor the self-edge guard may let it shadow the real edge."""
+    proj = _series_vin_proj(
+        {
+            "PDN_ROLE": "SERIES", "PDN_R": "50m",
+            "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
+        },
+        extra_series={
+            "PDN_ROLE": "SERIES", "PDN_R": "0.001",
+            "PDN_P_NET": "VDD_48V", "PDN_N_NET": "VDD_48V_F",
+        },
+    )
+    # VDD_48V_F (index 4) merged into VDD_48V (index 2).
+    net_remap = {4: 2}
+    graph = _collect_series_upstream_map(
+        _iter_pdn_parameter_sources(proj), proj,
+        net_remap=net_remap, skip_designators={"R9"},
+    )
+    assert graph.upstream == {"VDD_48V": "VDD_48V_IN"}
+    assert not graph.ambiguous
+
+    # Even without the skip list, the self-edge guard must hold the line.
+    unskipped = _collect_series_upstream_map(
+        _iter_pdn_parameter_sources(proj), proj, net_remap=net_remap,
+    )
+    assert unskipped.upstream == {"VDD_48V": "VDD_48V_IN"}
+    assert not unskipped.ambiguous
+
+
+def test_regulator_smps_vin_resolves_under_merged_net_name():
+    """The user may write either merged name. Both the supply map and the
+    lookup key are canonicalised, so IN_P_NET on the folded name still lands."""
+    proj = _series_vin_proj(
+        {
+            "PDN_ROLE": "SERIES", "PDN_R": "50m",
+            "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
+        },
+        in_p_net="VDD_48V_F",   # the name the user wrote
+        in_p_pad_net=2,         # ...folded into VDD_48V by the merge pre-pass
+    )
+    result = parse_annotations(proj, enabled_layers=[1], net_remap={4: 2})
+    reg = next(d for d in result.directives if d.designator == "U5")
+    assert abs(reg.gain - (12.0 / (48.0 * 0.8))) < 1e-6, result.errors
+
+
+def test_regulator_smps_vin_warns_when_inferred_through_series_chain():
+    """Vin taken from a walked chain is a guess about which leg is the power
+    path — a sense or bleed resistor produces a silently wrong gain, so say so."""
+    proj = _series_vin_proj({
+        "PDN_ROLE": "SERIES", "PDN_R": "50m",
+        "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
+    })
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert any(
+        "was inferred 1 SERIES hop(s) upstream" in w for w in result.warnings
+    ), result.warnings
+
+
+def test_regulator_smps_vin_does_not_warn_on_directly_declared_rail():
+    proj = _series_vin_proj(
+        {
+            "PDN_ROLE": "SERIES", "PDN_R": "50m",
+            "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
+        },
+        in_p_net="VDD_48V_IN",
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert not any("SERIES hop(s) upstream" in w for w in result.warnings)
 
 
 def test_regulator_smps_vin_not_ambiguous_through_sense_bridges():
@@ -2463,7 +3215,9 @@ def test_indexed_roles_only_source_channel_contributes_supply_voltage():
     assert sources[0].channel_index == 1
     assert sources[0].voltage == pytest.approx(5.0)
 
-    supply_map = _collect_supply_voltages_by_net(_iter_pdn_parameter_sources(proj))
+    supply_map, _ = _collect_supply_voltages_by_net(
+        _iter_pdn_parameter_sources(proj), proj,
+    )
     assert supply_map == {"+5V": 5.0}
 
 
@@ -2529,127 +3283,207 @@ def test_format_solve_blockers_lists_errors():
     assert "fypa.log" in text
 
 
-# --- Sheet-symbol per-instance overrides --------------------------------------
+# --- physical-page-map harvesting ---------------------------------------------
 
-def test_sheet_symbol_override_different_currents_per_instance():
-    """Two sheet symbols override PDN_J1_I differently for J1.1 / J1.2."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("VBUS.1"), RawNet("VBUS.2")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Port.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SINK",
-                    "PDN_I": "500mA",
-                    "PDN_P_NET": "VBUS",
-                    "PDN_N_NET": "GND",
-                },
-                pin_designators=("A4", "A1"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-A",
-                child_filename="Port.SchDoc",
-                unique_id="SYMAAAAA",
-                parameters={"PDN_J1_I": "1.5A"},
-            ),
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-B",
-                child_filename="Port.SchDoc",
-                unique_id="SYMBBBBB",
-                parameters={"PDN_J1_I": "3A"},
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMAAAAA\COMPUID1",
-            ),
-            RawPcbComponent(
-                designator="J1.2", center=Pt2D(10, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMBBBBB\COMPUID1",
-            ),
-        ),
-        pads=(
-            _pad(0, "A4", 1), _pad(0, "A1", 0, 1),
-            _pad(1, "A4", 2, 10), _pad(1, "A1", 0, 11),
-        ),
-        compiled_netlist=_FakeNetlist(nets=[
-            _FakeNet(
-                name="VBUS.1", aliases=["VBUS"],
-                source_sheets=["port.schdoc"],
-                terminals=[_FakeTerminal("J1.1", "A4")],
-            ),
-            _FakeNet(
-                name="VBUS.2", aliases=["VBUS"],
-                source_sheets=["port.schdoc"],
-                terminals=[_FakeTerminal("J1.2", "A4")],
-            ),
-            _FakeNet(
-                name="GND",
-                source_sheets=["port.schdoc"],
-                terminals=[
-                    _FakeTerminal("J1.1", "A1"),
-                    _FakeTerminal("J1.2", "A1"),
-                ],
-            ),
-        ]),
+
+def test_harvest_prefers_source_path_over_bare_file_name():
+    """file_name is the bare leaf, so harvesting it collapses same-named
+    sheets in different directories onto one map value."""
+    from types import SimpleNamespace
+
+    from fypa.altium.extract import _harvest_physical_sheet_names
+
+    compiled = SimpleNamespace(physical_documents=[
+        SimpleNamespace(id="physical:0", source_path="SubA/Power.SchDoc",
+                        file_name="Power.SchDoc"),
+        SimpleNamespace(id="physical:1", source_path="SubB/Power.SchDoc",
+                        file_name="Power.SchDoc"),
+    ])
+    assert _harvest_physical_sheet_names(compiled) == (
+        ("physical:0", "SubA/Power.SchDoc"),
+        ("physical:1", "SubB/Power.SchDoc"),
     )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    sinks = {d.designator: d for d in result.directives if isinstance(d, SinkSpec)}
-    assert set(sinks) == {"J1.1", "J1.2"}
-    assert sinks["J1.1"].current == pytest.approx(1.5)
-    assert sinks["J1.2"].current == pytest.approx(3.0)
 
 
-def test_sheet_symbol_override_absent_keeps_shared_child_current():
-    """Without sheet overrides, every instance inherits the child PDN_I."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+5V")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Port.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SINK",
-                    "PDN_I": "500mA",
-                    "PDN_P_NET": "+5V",
-                    "PDN_N_NET": "GND",
-                },
-                pin_designators=("1", "2"),
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMA\COMP",
-            ),
-            RawPcbComponent(
-                designator="J1.2", center=Pt2D(5, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMB\COMP",
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 1), _pad(0, "2", 0, 1),
-            _pad(1, "1", 1, 5), _pad(1, "2", 0, 6),
-        ),
+def test_harvest_falls_back_to_file_name_when_source_path_is_absent():
+    from types import SimpleNamespace
+
+    from fypa.altium.extract import _harvest_physical_sheet_names
+
+    compiled = SimpleNamespace(physical_documents=[
+        SimpleNamespace(id="physical:0", file_name="Power.SchDoc"),
+    ])
+    assert _harvest_physical_sheet_names(compiled) == (
+        ("physical:0", "Power.SchDoc"),
     )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
-    assert len(sinks) == 2
-    assert all(d.current == pytest.approx(0.5) for d in sinks)
 
 
-def test_sheet_symbol_nested_uid_deepest_wins():
-    """Deeper UniqueID in SOURCEUNIQUEID overrides a shallower symbol."""
+def test_harvest_is_empty_on_a_release_without_physical_documents():
+    """The installed library may predate the compiled model entirely; that
+    must yield an empty map, not an exception."""
+    from types import SimpleNamespace
+
+    from fypa.altium.extract import _harvest_physical_sheet_names
+
+    assert _harvest_physical_sheet_names(SimpleNamespace()) == ()
+    assert _harvest_physical_sheet_names(
+        SimpleNamespace(physical_documents=None)) == ()
+    # Entries missing either half are skipped rather than half-recorded.
+    assert _harvest_physical_sheet_names(SimpleNamespace(physical_documents=[
+        SimpleNamespace(id=None, source_path="A.SchDoc"),
+        SimpleNamespace(id="physical:0", source_path=None, file_name=None),
+    ])) == ()
+
+
+def test_compile_falls_back_to_to_netlist_with_the_designs_own_options():
+    """Rebuilding NetlistOptions.from_prjpcb() drops the merged per-sheet
+    parameters that net labels substitute — only AltiumDesign.from_prjpcb adds
+    them — so a fallback that does so silently renames nets."""
+
+    from fypa.altium.extract import _compile_schematic_netlist
+
+    sentinel = object()
+    calls = []
+
+    class _Design:
+        schdocs = ["a.SchDoc"]
+        project = None
+
+        def to_netlist(self):
+            calls.append("to_netlist")
+            return sentinel
+
+    netlist, sheet_names = _compile_schematic_netlist(_Design())
+    assert netlist is sentinel
+    assert sheet_names == ()
+    assert calls == ["to_netlist"]
+
+
+def test_a_failed_page_map_does_not_discard_a_good_netlist():
+
+    from fypa.altium.extract import _compile_schematic_netlist
+
+    sentinel = object()
+
+    class _Compiled:
+        def to_netlist(self):
+            return sentinel
+
+        @property
+        def physical_documents(self):
+            raise RuntimeError("field renamed upstream")
+
+    class _Design:
+        schdocs = ["a.SchDoc"]
+        project = None
+
+        def compile(self):
+            return _Compiled()
+
+        def to_netlist(self):
+            raise AssertionError("must not recompile after a good compile()")
+
+    netlist, sheet_names = _compile_schematic_netlist(_Design())
+    assert netlist is sentinel
+    assert sheet_names == ()
+
+
+# --- P/N arbitration follow-ups ------------------------------------------------
+
+
+def test_alias_fallback_does_not_outrank_a_name_level_match():
+    """"The pad's PCB net is on the row" is the criterion the PCB tier
+    explicitly rejects, so an alias-only hit must not be stamped tier 0 and
+    strip a genuine net.name match on the other terminal."""
+    from fypa.altium.annotations import (
+        _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_NAME, _LOCAL_NET_TIER_PCB,
+    )
+
+    assert _LOCAL_NET_TIER_ALIAS > _LOCAL_NET_TIER_NAME > _LOCAL_NET_TIER_PCB
+
+
+def test_explicit_pin_override_outranks_a_net_name_match():
+    """The overlap error tells the user to set PDN_*_PINS. That advice only
+    works if an explicit pin list actually breaks the tie."""
+    from fypa.altium.annotations import (
+        _LOCAL_NET_TIER_DIRECT, _LOCAL_NET_TIER_OVERRIDE,
+    )
+
+    assert _LOCAL_NET_TIER_OVERRIDE < _LOCAL_NET_TIER_DIRECT
+
+
+def _pin(pad):
+    return TerminalPin(pad, 1, 0, Pt2D(0, 0))
+
+
+def test_overlap_messages_name_pads_not_arbitration_keys():
+    """The keys are composite ("R5:1") but PDN_*_PINS matches bare pad names,
+    so printing the key sent the user to an error about an unknown pin."""
+    p = TerminalSpec(
+        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0), component_designator="R5"),
+              TerminalPin("2", 1, 0, Pt2D(0, 0), component_designator="R5")),
+        requested_net="VIN",
+    )
+    n = TerminalSpec(
+        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0), component_designator="R5"),),
+        requested_net="VIN_L",
+    )
+    result = AnnotationResult()
+    _arbitrate_overlapping_terminals(
+        p, n, _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_NAME,
+        "SERIES on R5", result,
+    )
+    text = " ".join(result.warnings + result.errors)
+    assert "R5:1" not in text
+    assert "pin(s) 1" in text
+
+
+def test_empty_side_errors_without_a_contradictory_warning():
+    """Warning that pins were "dropped from N" and then that N is empty and
+    the directive discarded reads as two contradictory log lines."""
+    shared = TerminalPin("1", 1, 0, Pt2D(0, 0))
+    p = TerminalSpec(pins=(shared,), requested_net="VIN")
+    n = TerminalSpec(pins=(shared,), requested_net="VIN_L")
+    result = AnnotationResult()
+    p2, n2 = _arbitrate_overlapping_terminals(
+        p, n, _LOCAL_NET_TIER_NAME, _LOCAL_NET_TIER_ALIAS,
+        "SERIES on R5", result,
+    )
+    assert p2 is not None and n2 is None
+    assert result.errors and "would be empty" in result.errors[0]
+    assert result.warnings == []
+
+
+def test_equal_tier_error_points_at_the_remedy_that_works():
+    shared = TerminalPin("1", 1, 0, Pt2D(0, 0))
+    p = TerminalSpec(pins=(shared,), requested_net="VIN")
+    n = TerminalSpec(pins=(shared,), requested_net="VIN")
+    result = AnnotationResult()
+    p2, n2 = _arbitrate_overlapping_terminals(
+        p, n, _LOCAL_NET_TIER_NAME, _LOCAL_NET_TIER_NAME,
+        "SERIES on R5", result,
+    )
+    assert p2 is None and n2 is None
+    assert "outranks a net-name match" in result.errors[0]
+
+
+def test_channel_token_must_come_from_flattening():
+    """A part merely NAMED FB_2 is not channel 2 of FB, so an unrelated
+    repeated sheet's VIN.2 must not match it."""
+    # Genuine channel instance: the placed designator is the schematic one
+    # plus the channel token, so the separators may legitimately disagree.
+    assert _local_net_label_matches("VIN_1", "VIN", {"R1", "R1.1"})
+    assert _local_net_label_matches("VIN.1", "VIN", {"R1", "R1_1"})
+    # Not a channel: nothing in the candidate set is "FB" + sep + "2".
+    assert not _local_net_label_matches("VIN.2", "VIN", {"FB_2"})
+    assert not _local_net_label_matches("VIN_3", "VIN", {"SW_3"})
+    # An exact label still matches regardless.
+    assert _local_net_label_matches("VIN", "VIN", {"FB_2"})
+
+# --- Sheet-symbol PDN overrides (rebased) ---
+
+def test_ambiguous_hierpath_loser_still_warns_missing_designator():
+    """Name-loser skips unbound warn but still flags unknown PDN designator."""
     proj = _minimal_proj(
         nets=(RawNet("GND"), RawNet("+5V")),
         sch_components=(
@@ -2661,170 +3495,6 @@ def test_sheet_symbol_nested_uid_deepest_wins():
                     "PDN_P_NET": "+5V",
                     "PDN_N_NET": "GND",
                 },
-                pin_designators=("1", "2"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="OUTER",
-                child_filename="Mid.SchDoc",
-                unique_id="OUTERUID",
-                parameters={"PDN_J1_I": "1A"},
-            ),
-            RawSchSheetSymbol(
-                parent_schdoc="Mid.SchDoc",
-                sheet_name="INNER",
-                child_filename="Port.SchDoc",
-                unique_id="INNERUID",
-                parameters={"PDN_J1_I": "2A"},
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\OUTERUID\INNERUID\COMP",
-            ),
-        ),
-        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
-    assert len(sinks) == 1
-    assert sinks[0].current == pytest.approx(2.0)
-
-
-def test_sheet_symbol_indexed_channel_override():
-    """``PDN_U1_1_I`` overrides only the indexed PDN channel on the child."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+3V3"), RawNet("+1V8")),
-        sch_components=(
-            RawSchComponent(
-                designator="U1", schdoc_name="Chip.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SINK",
-                    "PDN_I": "50mA",
-                    "PDN_P_NET": "+3V3",
-                    "PDN_N_NET": "GND",
-                    "PDN1_I": "10mA",
-                    "PDN1_P_NET": "+1V8",
-                    "PDN1_N_NET": "GND",
-                },
-                pin_designators=("1", "2", "3"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CH",
-                child_filename="Chip.SchDoc",
-                unique_id="CHIPSYM",
-                parameters={"PDN_U1_1_I": "80mA"},
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="U1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="QFN", source_designator="U1",
-                source_unique_id=r"\CHIPSYM\U1UID",
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 1), _pad(0, "2", 2, 1), _pad(0, "3", 0, 2),
-        ),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    sinks = {
-        d.channel_index: d
-        for d in result.directives if isinstance(d, SinkSpec)
-    }
-    assert sinks[None].current == pytest.approx(0.05)
-    assert sinks[1].current == pytest.approx(0.08)
-
-
-def test_sheet_symbol_repeat_slot_qualified_override():
-    """One REPEAT sheet symbol: ``PDN_J1_I.1`` / ``PDN_J1_I.2`` per channel."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("VBUS.1"), RawNet("VBUS.2")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Port.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SINK",
-                    "PDN_I": "100mA",
-                    "PDN_P_NET": "VBUS",
-                    "PDN_N_NET": "GND",
-                },
-                pin_designators=("1", "2"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="Repeat(PORT,1,2)",
-                child_filename="Port.SchDoc",
-                unique_id="REPEATSYM",
-                parameters={
-                    "PDN_J1_I.1": "1A",
-                    "PDN_J1_I.2": "2A",
-                },
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\REPEATSYM\COMP",
-            ),
-            RawPcbComponent(
-                designator="J1.2", center=Pt2D(10, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\REPEATSYM\COMP",
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 1), _pad(0, "2", 0, 1),
-            _pad(1, "1", 2, 10), _pad(1, "2", 0, 11),
-        ),
-        compiled_netlist=_FakeNetlist(nets=[
-            _FakeNet(
-                name="VBUS.1", aliases=["VBUS"],
-                source_sheets=["port.schdoc"],
-                terminals=[_FakeTerminal("J1.1", "1")],
-            ),
-            _FakeNet(
-                name="VBUS.2", aliases=["VBUS"],
-                source_sheets=["port.schdoc"],
-                terminals=[_FakeTerminal("J1.2", "1")],
-            ),
-            _FakeNet(
-                name="GND",
-                source_sheets=["port.schdoc"],
-                terminals=[
-                    _FakeTerminal("J1.1", "2"),
-                    _FakeTerminal("J1.2", "2"),
-                ],
-            ),
-        ]),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    sinks = {d.designator: d for d in result.directives if isinstance(d, SinkSpec)}
-    assert sinks["J1.1"].current == pytest.approx(1.0)
-    assert sinks["J1.2"].current == pytest.approx(2.0)
-
-
-def test_sheet_symbol_only_directive_without_child_pdn_role():
-    """Full SINK directive can live entirely on the sheet symbol."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+5V")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Port.SchDoc",
-                parameters={"Comment": "USB"},
                 pin_designators=("1", "2"),
             ),
         ),
@@ -2834,12 +3504,269 @@ def test_sheet_symbol_only_directive_without_child_pdn_role():
                 sheet_name="CON-A",
                 child_filename="Port.SchDoc",
                 unique_id="SYMA",
+                parameters={"PDN_J1_I": "1A"},
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Other.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMB",
                 parameters={
-                    "PDN_J1_ROLE": "SINK",
-                    "PDN_J1_I": "1.2A",
-                    "PDN_J1_P_NET": "+5V",
-                    "PDN_J1_N_NET": "GND",
+                    "PDN_J1_I": "2A",
+                    "PDN_J99_I": "9A",  # no such PCB designator
                 },
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id="",
+                source_hierarchical_path=r"main\CON-A",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    assert not any(
+        "not bound to any PCB placement" in w and "SYMB" in w
+        for w in result.warnings
+    )
+    assert any(
+        "PDN_J99_I" in w
+        and "no PCB component with source designator 'J99'" in w
+        and "Other.SchDoc" in w
+        for w in result.warnings
+    )
+
+def test_ambiguous_hierpath_sheet_name_warns():
+    """Two symbols with the same sheet_name → one used, others ignored."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={"PDN_J1_I": "1A"},
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Other.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMB",
+                parameters={"PDN_J1_I": "2A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id="",
+                source_hierarchical_path=r"main\CON-A",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    assert any(
+        "SOURCEHIERARCHICALPATH matches" in w
+        and "using 'SYMA'" in w
+        and "ignoring" in w
+        for w in result.warnings
+    )
+    assert not any(
+        "not bound to any PCB placement" in w and "SYMB" in w
+        for w in result.warnings
+    )
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].current == pytest.approx(1.0)  # SYMA wins over SYMB
+
+def test_autoinfer_series_propagates_supply_voltage_for_smps_vin():
+    """2-pin SERIES without P/N nets still forwards Vin via pad autoinfer."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("VIN"), RawNet("VIN_L"), RawNet("VOUT")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Main.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SOURCE",
+                    "PDN_V": "12",
+                    "PDN_P_NET": "VIN",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="L1", schdoc_name="Main.SchDoc",
+                parameters={"PDN_ROLE": "SERIES", "PDN_R": "5m"},
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="U1", schdoc_name="Main.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_V": "3.3",
+                    "PDN_REGULATOR_TYPE": "SMPS",
+                    "PDN_REGULATOR_EFFICIENCY": "0.9",
+                    "PDN_OUT_P_NET": "VOUT",
+                    "PDN_OUT_N_NET": "GND",
+                    "PDN_IN_P_NET": "VIN_L",
+                    "PDN_IN_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="CONN", source_designator="J1",
+            ),
+            RawPcbComponent(
+                designator="L1", center=Pt2D(5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="IND", source_designator="L1",
+            ),
+            RawPcbComponent(
+                designator="U1", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            # L1 autoinfer: pad1 VIN (upstream), pad2 VIN_L (downstream)
+            _pad(1, "1", 1, 5), _pad(1, "2", 2, 6),
+            _pad(2, "1", 3, 10), _pad(2, "2", 0, 11),
+            _pad(2, "3", 2, 12), _pad(2, "4", 0, 13),
+        ),
+    )
+    supply_map, _ = _collect_supply_voltages_by_net(
+        _iter_pdn_parameter_sources(proj), proj,
+    )
+    assert supply_map.get("VIN") == pytest.approx(12.0)
+    assert supply_map.get("VIN_L") == pytest.approx(12.0)
+
+    ann = parse_annotations(proj, enabled_layers=[1])
+    assert ann.ok, ann.errors
+    reg = next(d for d in ann.directives if isinstance(d, RegulatorSpec))
+    assert reg.gain == pytest.approx(3.3 / (12.0 * 0.9))
+
+def test_autoinfer_series_vin_ignores_reversed_pad_order():
+    """Autoinfer SERIES copies Vin even when pad0 is the downstream net."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("VIN"), RawNet("VIN_L"), RawNet("VOUT")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Main.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SOURCE",
+                    "PDN_V": "12",
+                    "PDN_P_NET": "VIN",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="L1", schdoc_name="Main.SchDoc",
+                parameters={"PDN_ROLE": "SERIES", "PDN_R": "5m"},
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="U1", schdoc_name="Main.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_V": "3.3",
+                    "PDN_REGULATOR_TYPE": "SMPS",
+                    "PDN_REGULATOR_EFFICIENCY": "0.9",
+                    "PDN_OUT_P_NET": "VOUT",
+                    "PDN_OUT_N_NET": "GND",
+                    "PDN_IN_P_NET": "VIN_L",
+                    "PDN_IN_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="CONN", source_designator="J1",
+            ),
+            RawPcbComponent(
+                designator="L1", center=Pt2D(5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="IND", source_designator="L1",
+            ),
+            RawPcbComponent(
+                designator="U1", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            # Reversed vs power flow: pad1=VIN_L (downstream), pad2=VIN (upstream)
+            _pad(1, "1", 2, 5), _pad(1, "2", 1, 6),
+            _pad(2, "1", 3, 10), _pad(2, "2", 0, 11),
+            _pad(2, "3", 2, 12), _pad(2, "4", 0, 13),
+        ),
+    )
+    supply_map, _ = _collect_supply_voltages_by_net(
+        _iter_pdn_parameter_sources(proj), proj,
+    )
+    assert supply_map.get("VIN") == pytest.approx(12.0)
+    assert supply_map.get("VIN_L") == pytest.approx(12.0)
+
+    ann = parse_annotations(proj, enabled_layers=[1])
+    assert ann.ok, ann.errors
+    reg = next(d for d in ann.directives if isinstance(d, RegulatorSpec))
+    assert reg.gain == pytest.approx(3.3 / (12.0 * 0.9))
+
+def test_duplicate_sch_designator_with_sheet_symbols_not_multiplied():
+    """Two SchDocs with same J1 + sheet binding → one warning, no dup sinks."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="J1", schdoc_name="AltPort.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "9A",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={"PDN_J1_I": "1.5A"},
             ),
         ),
         pcb_components=(
@@ -2853,67 +3780,16 @@ def test_sheet_symbol_only_directive_without_child_pdn_role():
     )
     result = parse_annotations(proj, enabled_layers=[1])
     assert result.ok, result.errors
+    assert any(
+        "appears in multiple schdocs with PDN_ROLE" in w
+        for w in result.warnings
+    )
     sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
     assert len(sinks) == 1
-    assert sinks[0].designator == "J1.1"
-    assert sinks[0].current == pytest.approx(1.2)
+    assert sinks[0].current == pytest.approx(1.5)
 
-
-def test_sheet_symbol_params_via_owner_index():
-    """Sheet-symbol PDN_* must be read from schdoc.parameters OwnerIndex.
-
-    altium_monkey does not put sheet-symbol parameters on ``symbol.children``.
-    """
-    from fypa.altium.extract import (
-        _extract_sch_sheet_symbol,
-        _parameters_owned_by_index,
-    )
-
-    @dataclass
-    class _Param:
-        name: str
-        text: str
-        owner_index: int
-
-    @dataclass
-    class _Record:
-        unique_id: str = "SYMUID"
-        index_in_sheet: int = 42
-        children: tuple = ()
-        sheet_name: object = None
-        file_name: object = None
-
-    @dataclass
-    class _Info:
-        record: _Record
-        designator: str = "CON-A"
-        file_name: str = "Port.SchDoc"
-        unique_id: str = "SYMUID"
-
-    @dataclass
-    class _SchDoc:
-        parameters: list
-
-    schdoc = _SchDoc(parameters=[
-        _Param("PDN_J1_I", "1.5A", 42),
-        _Param("PDN_J1_ROLE", "SINK", 42),
-        _Param("Design Item Id", "BOM-PART", 42),  # filtered out
-        _Param("Other", "x", 99),  # different owner — ignored
-    ])
-    owned = _parameters_owned_by_index(schdoc, 42)
-    assert owned["PDN_J1_I"] == "1.5A"
-    assert "Design Item Id" in owned  # raw owner lookup keeps all
-
-    info = _Info(record=_Record())
-    sym = _extract_sch_sheet_symbol(info, "Main.SchDoc", schdoc=schdoc)
-    assert sym is not None
-    assert sym.parameters == {"PDN_J1_I": "1.5A", "PDN_J1_ROLE": "SINK"}
-    assert "Design Item Id" not in sym.parameters
-    assert "Other" not in sym.parameters
-
-
-def test_sheet_symbol_override_via_hierarchical_path_fallback():
-    """When SOURCEUNIQUEID is empty, match sheet symbols via hierarchy path."""
+def test_hierpath_bound_override_no_orphan_warning():
+    """Hierpath-only binding must not emit UniqueID orphan warnings."""
     proj = _minimal_proj(
         nets=(RawNet("GND"), RawNet("+5V")),
         sch_components=(
@@ -2941,8 +3817,57 @@ def test_sheet_symbol_override_via_hierarchical_path_fallback():
             RawPcbComponent(
                 designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
                 layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id="",  # force fallback
+                source_unique_id="",
                 source_hierarchical_path=r"main\CON-A",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    assert not any("not bound to any PCB placement" in w for w in result.warnings)
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].current == pytest.approx(2.5)
+
+def test_hierpath_nested_sheet_symbol_first_segment():
+    """Path CON-A\\INNER (first segment is a sheet symbol) binds both; deeper wins."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Mid.SchDoc",
+                unique_id="OUTER",
+                parameters={"PDN_J1_I": "1A"},
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Mid.SchDoc",
+                sheet_name="INNER",
+                child_filename="Port.SchDoc",
+                unique_id="INNER",
+                parameters={"PDN_J1_I": "2.5A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id="",
+                source_hierarchical_path=r"CON-A\INNER",
             ),
         ),
         pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
@@ -2953,78 +3878,8 @@ def test_sheet_symbol_override_via_hierarchical_path_fallback():
     assert len(sinks) == 1
     assert sinks[0].current == pytest.approx(2.5)
 
-
-def test_sheet_symbol_extract_to_parse_round_trip():
-    """OwnerIndex extract → RawSchSheetSymbol → parse_annotations."""
-    from fypa.altium.extract import _extract_sch_sheet_symbol
-
-    @dataclass
-    class _Param:
-        name: str
-        text: str
-        owner_index: int
-
-    @dataclass
-    class _Record:
-        unique_id: str = "SYMA"
-        index_in_sheet: int = 7
-        children: tuple = ()
-
-    @dataclass
-    class _Info:
-        record: _Record
-        designator: str = "CON-A"
-        file_name: str = "Port.SchDoc"
-        unique_id: str = "SYMA"
-
-    @dataclass
-    class _SchDoc:
-        parameters: list
-
-    sym = _extract_sch_sheet_symbol(
-        _Info(record=_Record()),
-        "Main.SchDoc",
-        schdoc=_SchDoc(parameters=[
-            _Param("PDN_J1_I", "1.5A", 7),
-            _Param("Manufacturer", "ACME", 7),
-        ]),
-    )
-    assert sym is not None
-    assert sym.parameters == {"PDN_J1_I": "1.5A"}
-
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+5V")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Port.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SINK",
-                    "PDN_I": "100mA",
-                    "PDN_P_NET": "+5V",
-                    "PDN_N_NET": "GND",
-                },
-                pin_designators=("1", "2"),
-            ),
-        ),
-        sch_sheet_symbols=(sym,),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMA\COMP",
-            ),
-        ),
-        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
-    assert len(sinks) == 1
-    assert sinks[0].current == pytest.approx(1.5)
-
-
-def test_sheet_symbol_repeat_slot_skipped_for_non_numeric_designator():
-    """Slot-qualified override warns when PCB designator has no .N suffix."""
+def test_hierpath_single_segment_binds():
+    """Path with only the sheet-symbol name (no root) still binds."""
     proj = _minimal_proj(
         nets=(RawNet("GND"), RawNet("+5V")),
         sch_components=(
@@ -3042,17 +3897,18 @@ def test_sheet_symbol_repeat_slot_skipped_for_non_numeric_designator():
         sch_sheet_symbols=(
             RawSchSheetSymbol(
                 parent_schdoc="Main.SchDoc",
-                sheet_name="Repeat(PORT,1,2)",
+                sheet_name="CON-A",
                 child_filename="Port.SchDoc",
-                unique_id="REPEATSYM",
-                parameters={"PDN_J1_I.1": "2A"},
+                unique_id="SYMA",
+                parameters={"PDN_J1_I": "1.7A"},
             ),
         ),
         pcb_components=(
             RawPcbComponent(
-                designator="J1_CH1", center=Pt2D(0, 0), rotation_deg=0.0,
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
                 layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\REPEATSYM\COMP",
+                source_unique_id="",
+                source_hierarchical_path="CON-A",
             ),
         ),
         pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
@@ -3061,21 +3917,10 @@ def test_sheet_symbol_repeat_slot_skipped_for_non_numeric_designator():
     assert result.ok, result.errors
     sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
     assert len(sinks) == 1
-    # Override not applied — falls back to child default.
-    assert sinks[0].current == pytest.approx(0.1)
-    assert any(
-        "PDN_J1_I.1" in w and "no numeric channel suffix" in w
-        for w in result.warnings
-    )
+    assert sinks[0].current == pytest.approx(1.7)
 
-
-def test_multi_instance_missing_value_reports_once():
-    """Missing PDN_I after expand → one logical error, not one per instance.
-
-    A bound sheet symbol carries only a REPEAT slot that matches no PCB
-    designator (``.99``). Discovery still sees ``PDN_I``, but no instance
-    receives the override.
-    """
+def test_hierpath_skips_root_sheet_segment():
+    """A sheet symbol named like the root path segment must not bind."""
     proj = _minimal_proj(
         nets=(RawNet("GND"), RawNet("+5V")),
         sch_components=(
@@ -3083,6 +3928,7 @@ def test_multi_instance_missing_value_reports_once():
                 designator="J1", schdoc_name="Port.SchDoc",
                 parameters={
                     "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
                     "PDN_P_NET": "+5V",
                     "PDN_N_NET": "GND",
                 },
@@ -3090,212 +3936,36 @@ def test_multi_instance_missing_value_reports_once():
             ),
         ),
         sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Top.SchDoc",
+                sheet_name="main",  # same as root segment
+                child_filename="Other.SchDoc",
+                unique_id="ROOTISH",
+                parameters={"PDN_J1_I": "9A"},
+            ),
             RawSchSheetSymbol(
                 parent_schdoc="Main.SchDoc",
                 sheet_name="CON-A",
                 child_filename="Port.SchDoc",
                 unique_id="SYMA",
-                parameters={"PDN_J1_I.99": "1A"},
+                parameters={"PDN_J1_I": "1.2A"},
             ),
         ),
         pcb_components=(
             RawPcbComponent(
                 designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
                 layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMA\COMP",
-            ),
-            RawPcbComponent(
-                designator="J1.2", center=Pt2D(5, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMA\COMP",
-            ),
-            RawPcbComponent(
-                designator="J1.3", center=Pt2D(10, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMA\COMP",
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 1), _pad(0, "2", 0, 1),
-            _pad(1, "1", 1, 5), _pad(1, "2", 0, 6),
-            _pad(2, "1", 1, 10), _pad(2, "2", 0, 11),
-        ),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert not result.ok
-    missing = [e for e in result.errors if "missing PDN_I" in e]
-    assert len(missing) == 1
-    assert "SINK on J1:" in missing[0]
-
-
-def test_multi_instance_missing_net_reports_once():
-    """Missing PDN_P_NET on every instance → one logical error."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+5V")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Port.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SINK",
-                    "PDN_I": "1A",
-                    "PDN_N_NET": "GND",
-                },
-                pin_designators=("1", "2"),
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-            ),
-            RawPcbComponent(
-                designator="J1.2", center=Pt2D(5, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 1), _pad(0, "2", 0, 1),
-            _pad(1, "1", 1, 5), _pad(1, "2", 0, 6),
-        ),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert not result.ok
-    missing = [e for e in result.errors if "missing PDN_P_NET" in e]
-    assert len(missing) == 1
-    assert "SINK on J1:" in missing[0]
-
-
-def test_orphan_sheet_override_does_not_invent_discovery_channel():
-    """Unbound sheet-symbol PDN_I must not make a child channel 'present'."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+5V")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Port.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SINK",
-                    "PDN_P_NET": "+5V",
-                    "PDN_N_NET": "GND",
-                },
-                pin_designators=("1", "2"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="ORPHAN",
-                child_filename="Port.SchDoc",
-                unique_id="NOTONPCB",
-                parameters={"PDN_J1_I": "1A"},
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\OTHER\COMP",
+                source_unique_id="",
+                source_hierarchical_path=r"main\CON-A",
             ),
         ),
         pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
     )
     result = parse_annotations(proj, enabled_layers=[1])
-    assert not result.ok
-    assert any(
-        "missing PDN_I" in e and "SINK on J1" in e
-        for e in result.errors
-    )
-    assert not any("missing required parameter PDN_I" in e for e in result.errors)
-
-
-def test_orphan_sheet_override_warnings_consolidated():
-    """Multiple orphan PDN keys on one symbol → one warning listing them."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"),),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="ORPHAN",
-                child_filename="Port.SchDoc",
-                unique_id="NOSUCHUID",
-                parameters={
-                    "PDN_J1_I": "1A",
-                    "PDN_J1_ROLE": "SINK",
-                    "PDN_J1_P_NET": "+5V",
-                },
-            ),
-        ),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    uid_warns = [
-        w for w in result.warnings
-        if "NOSUCHUID" in w and "not bound to any PCB placement" in w
-    ]
-    assert len(uid_warns) == 1
-    assert "PDN_J1_I" in uid_warns[0]
-    assert "PDN_J1_ROLE" in uid_warns[0]
-    assert "PDN_J1_P_NET" in uid_warns[0]
-
-
-def test_sheet_symbol_only_multi_instance_different_currents():
-    """Full sheet-symbol-only directive with different I per placement."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+5V")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Port.SchDoc",
-                parameters={"Comment": "USB"},
-                pin_designators=("1", "2"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-A",
-                child_filename="Port.SchDoc",
-                unique_id="SYMA",
-                parameters={
-                    "PDN_J1_ROLE": "SINK",
-                    "PDN_J1_I": "1.5A",
-                    "PDN_J1_P_NET": "+5V",
-                    "PDN_J1_N_NET": "GND",
-                },
-            ),
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-B",
-                child_filename="Port.SchDoc",
-                unique_id="SYMB",
-                parameters={
-                    "PDN_J1_ROLE": "SINK",
-                    "PDN_J1_I": "3A",
-                    "PDN_J1_P_NET": "+5V",
-                    "PDN_J1_N_NET": "GND",
-                },
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMA\COMP",
-            ),
-            RawPcbComponent(
-                designator="J1.2", center=Pt2D(5, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMB\COMP",
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 1), _pad(0, "2", 0, 1),
-            _pad(1, "1", 1, 5), _pad(1, "2", 0, 6),
-        ),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
     assert result.ok, result.errors
-    sinks = {d.designator: d for d in result.directives if isinstance(d, SinkSpec)}
-    assert sinks["J1.1"].current == pytest.approx(1.5)
-    assert sinks["J1.2"].current == pytest.approx(3.0)
-
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].current == pytest.approx(1.2)
 
 def test_indexed_sheet_override_does_not_force_sibling_channel():
     """PDN_J1_2_I on one placement must not invent channel 2 on siblings."""
@@ -3365,948 +4035,11 @@ def test_indexed_sheet_override_does_not_force_sibling_channel():
     assert by_des["J1.2"][0].current == pytest.approx(0.5)
     assert not any("missing" in e and "PDN2" in e for e in result.errors)
 
-
-def test_hierpath_bound_override_no_orphan_warning():
-    """Hierpath-only binding must not emit UniqueID orphan warnings."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+5V")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Port.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SINK",
-                    "PDN_I": "100mA",
-                    "PDN_P_NET": "+5V",
-                    "PDN_N_NET": "GND",
-                },
-                pin_designators=("1", "2"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-A",
-                child_filename="Port.SchDoc",
-                unique_id="SYMA",
-                parameters={"PDN_J1_I": "2.5A"},
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id="",
-                source_hierarchical_path=r"main\CON-A",
-            ),
-        ),
-        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    assert not any("not bound to any PCB placement" in w for w in result.warnings)
-    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
-    assert len(sinks) == 1
-    assert sinks[0].current == pytest.approx(2.5)
-
-
-def test_ambiguous_hierpath_sheet_name_warns():
-    """Two symbols with the same sheet_name → one used, others ignored."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+5V")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Port.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SINK",
-                    "PDN_I": "100mA",
-                    "PDN_P_NET": "+5V",
-                    "PDN_N_NET": "GND",
-                },
-                pin_designators=("1", "2"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-A",
-                child_filename="Port.SchDoc",
-                unique_id="SYMA",
-                parameters={"PDN_J1_I": "1A"},
-            ),
-            RawSchSheetSymbol(
-                parent_schdoc="Other.SchDoc",
-                sheet_name="CON-A",
-                child_filename="Port.SchDoc",
-                unique_id="SYMB",
-                parameters={"PDN_J1_I": "2A"},
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id="",
-                source_hierarchical_path=r"main\CON-A",
-            ),
-        ),
-        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    assert any(
-        "SOURCEHIERARCHICALPATH matches" in w
-        and "using 'SYMA'" in w
-        and "ignoring" in w
-        for w in result.warnings
-    )
-    assert not any(
-        "not bound to any PCB placement" in w and "SYMB" in w
-        for w in result.warnings
-    )
-    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
-    assert len(sinks) == 1
-    assert sinks[0].current == pytest.approx(1.0)  # SYMA wins over SYMB
-
-
-def test_sheet_override_designator_with_trailing_letter():
-    """PDN_U12A_I targets designator U12A, not U12 + suffix A_I."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+5V")),
-        sch_components=(
-            RawSchComponent(
-                designator="U12A", schdoc_name="Port.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SINK",
-                    "PDN_I": "100mA",
-                    "PDN_P_NET": "+5V",
-                    "PDN_N_NET": "GND",
-                },
-                pin_designators=("1", "2"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-A",
-                child_filename="Port.SchDoc",
-                unique_id="SYMA",
-                parameters={"PDN_U12A_I": "1.8A"},
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="U12A.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="SOIC", source_designator="U12A",
-                source_unique_id=r"\SYMA\COMP",
-            ),
-        ),
-        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
-    assert len(sinks) == 1
-    assert sinks[0].current == pytest.approx(1.8)
-
-
-def test_sheet_override_role_changes_parser_per_instance():
-    """Per-placement PDN_J1_ROLE must dispatch SOURCE vs SINK correctly."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+5V")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Port.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SINK",
-                    "PDN_I": "100mA",
-                    "PDN_P_NET": "+5V",
-                    "PDN_N_NET": "GND",
-                },
-                pin_designators=("1", "2"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-A",
-                child_filename="Port.SchDoc",
-                unique_id="SYMA",
-                parameters={"PDN_J1_I": "1A"},
-            ),
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-B",
-                child_filename="Port.SchDoc",
-                unique_id="SYMB",
-                parameters={
-                    "PDN_J1_ROLE": "SOURCE",
-                    "PDN_J1_V": "5V",
-                    "PDN_J1_P_NET": "+5V",
-                    "PDN_J1_N_NET": "GND",
-                },
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMA\COMP",
-            ),
-            RawPcbComponent(
-                designator="J1.2", center=Pt2D(5, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMB\COMP",
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 1), _pad(0, "2", 0, 1),
-            _pad(1, "1", 1, 5), _pad(1, "2", 0, 6),
-        ),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    assert not any("unknown PDN parameter 'PDN_I'" in w for w in result.warnings)
-    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
-    sources = [d for d in result.directives if isinstance(d, SourceSpec)]
-    assert len(sinks) == 1 and sinks[0].designator == "J1.1"
-    assert sinks[0].current == pytest.approx(1.0)
-    assert len(sources) == 1 and sources[0].designator == "J1.2"
-    assert sources[0].voltage == pytest.approx(5.0)
-
-
-def test_duplicate_sch_designator_with_sheet_symbols_not_multiplied():
-    """Two SchDocs with same J1 + sheet binding → one warning, no dup sinks."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+5V")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Port.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SINK",
-                    "PDN_I": "100mA",
-                    "PDN_P_NET": "+5V",
-                    "PDN_N_NET": "GND",
-                },
-                pin_designators=("1", "2"),
-            ),
-            RawSchComponent(
-                designator="J1", schdoc_name="AltPort.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SINK",
-                    "PDN_I": "9A",
-                    "PDN_P_NET": "+5V",
-                    "PDN_N_NET": "GND",
-                },
-                pin_designators=("1", "2"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-A",
-                child_filename="Port.SchDoc",
-                unique_id="SYMA",
-                parameters={"PDN_J1_I": "1.5A"},
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMA\COMP",
-            ),
-        ),
-        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    assert any(
-        "appears in multiple schdocs with PDN_ROLE" in w
-        for w in result.warnings
-    )
-    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
-    assert len(sinks) == 1
-    assert sinks[0].current == pytest.approx(1.5)
-
-
-def test_sheet_symbol_only_partial_coverage_warns():
-    """Full sheet-only on one placement, sibling unbound → warning."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+5V")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Port.SchDoc",
-                parameters={"Comment": "USB"},
-                pin_designators=("1", "2"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-A",
-                child_filename="Port.SchDoc",
-                unique_id="SYMA",
-                parameters={
-                    "PDN_J1_ROLE": "SINK",
-                    "PDN_J1_I": "1.5A",
-                    "PDN_J1_P_NET": "+5V",
-                    "PDN_J1_N_NET": "GND",
-                },
-            ),
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-B",
-                child_filename="Port.SchDoc",
-                unique_id="SYMB",
-                parameters={},  # no PDN — sibling uncovered
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMA\COMP",
-            ),
-            RawPcbComponent(
-                designator="J1.2", center=Pt2D(5, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMB\COMP",
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 1), _pad(0, "2", 0, 1),
-            _pad(1, "1", 1, 5), _pad(1, "2", 0, 6),
-        ),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert any(
-        "PDN covers" in w
-        and "J1.1 (sheet symbol)" in w
-        and "but not J1.2" in w
-        for w in result.warnings
-    )
-    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
-    assert len(sinks) == 1
-    assert sinks[0].designator == "J1.1"
-
-
-def test_partial_coverage_warning_labels_pcb_eco_separately():
-    """Mixed PCB-ECO + sheet-only partial coverage names sources explicitly."""
-    pcb_pdn = {
-        "PDN_ROLE": "SINK",
-        "PDN_I": "1A",
-        "PDN_P_NET": "+5V",
-        "PDN_N_NET": "GND",
-    }
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+5V")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Port.SchDoc",
-                parameters={"Comment": "USB"},
-                pin_designators=("1", "2"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-A",
-                child_filename="Port.SchDoc",
-                unique_id="SYMA",
-                parameters={},
-            ),
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-B",
-                child_filename="Port.SchDoc",
-                unique_id="SYMB",
-                parameters={
-                    "PDN_J1_ROLE": "SINK",
-                    "PDN_J1_I": "2A",
-                    "PDN_J1_P_NET": "+5V",
-                    "PDN_J1_N_NET": "GND",
-                },
-            ),
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-C",
-                child_filename="Port.SchDoc",
-                unique_id="SYMC",
-                parameters={},
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMA\COMP",
-                parameters=dict(pcb_pdn),
-            ),
-            RawPcbComponent(
-                designator="J1.2", center=Pt2D(10, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMB\COMP",
-            ),
-            RawPcbComponent(
-                designator="J1.3", center=Pt2D(20, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMC\COMP",
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 1), _pad(0, "2", 0, 1),
-            _pad(1, "1", 1, 10), _pad(1, "2", 0, 11),
-            _pad(2, "1", 1, 20), _pad(2, "2", 0, 21),
-        ),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert any(
-        "J1.2 (sheet symbol)" in w
-        and "J1.1 (PCB-ECO)" in w
-        and "but not J1.3" in w
-        for w in result.warnings
-    )
-
-
-def test_hierpath_skips_root_sheet_segment():
-    """A sheet symbol named like the root path segment must not bind."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+5V")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Port.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SINK",
-                    "PDN_I": "100mA",
-                    "PDN_P_NET": "+5V",
-                    "PDN_N_NET": "GND",
-                },
-                pin_designators=("1", "2"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Top.SchDoc",
-                sheet_name="main",  # same as root segment
-                child_filename="Other.SchDoc",
-                unique_id="ROOTISH",
-                parameters={"PDN_J1_I": "9A"},
-            ),
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-A",
-                child_filename="Port.SchDoc",
-                unique_id="SYMA",
-                parameters={"PDN_J1_I": "1.2A"},
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id="",
-                source_hierarchical_path=r"main\CON-A",
-            ),
-        ),
-        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
-    assert len(sinks) == 1
-    assert sinks[0].current == pytest.approx(1.2)
-
-
-def test_hierpath_single_segment_binds():
-    """Path with only the sheet-symbol name (no root) still binds."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+5V")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Port.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SINK",
-                    "PDN_I": "100mA",
-                    "PDN_P_NET": "+5V",
-                    "PDN_N_NET": "GND",
-                },
-                pin_designators=("1", "2"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-A",
-                child_filename="Port.SchDoc",
-                unique_id="SYMA",
-                parameters={"PDN_J1_I": "1.7A"},
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id="",
-                source_hierarchical_path="CON-A",
-            ),
-        ),
-        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
-    assert len(sinks) == 1
-    assert sinks[0].current == pytest.approx(1.7)
-
-
-def test_hierpath_nested_sheet_symbol_first_segment():
-    """Path CON-A\\INNER (first segment is a sheet symbol) binds both; deeper wins."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+5V")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Port.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SINK",
-                    "PDN_I": "100mA",
-                    "PDN_P_NET": "+5V",
-                    "PDN_N_NET": "GND",
-                },
-                pin_designators=("1", "2"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-A",
-                child_filename="Mid.SchDoc",
-                unique_id="OUTER",
-                parameters={"PDN_J1_I": "1A"},
-            ),
-            RawSchSheetSymbol(
-                parent_schdoc="Mid.SchDoc",
-                sheet_name="INNER",
-                child_filename="Port.SchDoc",
-                unique_id="INNER",
-                parameters={"PDN_J1_I": "2.5A"},
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id="",
-                source_hierarchical_path=r"CON-A\INNER",
-            ),
-        ),
-        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
-    assert len(sinks) == 1
-    assert sinks[0].current == pytest.approx(2.5)
-
-
-def test_ambiguous_hierpath_loser_still_warns_missing_designator():
-    """Name-loser skips unbound warn but still flags unknown PDN designator."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+5V")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Port.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SINK",
-                    "PDN_I": "100mA",
-                    "PDN_P_NET": "+5V",
-                    "PDN_N_NET": "GND",
-                },
-                pin_designators=("1", "2"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-A",
-                child_filename="Port.SchDoc",
-                unique_id="SYMA",
-                parameters={"PDN_J1_I": "1A"},
-            ),
-            RawSchSheetSymbol(
-                parent_schdoc="Other.SchDoc",
-                sheet_name="CON-A",
-                child_filename="Port.SchDoc",
-                unique_id="SYMB",
-                parameters={
-                    "PDN_J1_I": "2A",
-                    "PDN_J99_I": "9A",  # no such PCB designator
-                },
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id="",
-                source_hierarchical_path=r"main\CON-A",
-            ),
-        ),
-        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    assert not any(
-        "not bound to any PCB placement" in w and "SYMB" in w
-        for w in result.warnings
-    )
-    assert any(
-        "PDN_J99_I" in w
-        and "no PCB component with source designator 'J99'" in w
-        and "Other.SchDoc" in w
-        for w in result.warnings
-    )
-
-
-def test_sheet_override_role_strips_regulator_terminal_keys():
-    """Leaving REGULATOR via sheet ROLE drops OUT_/IN_ keys without noise."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+5V"), RawNet("VIN")),
-        sch_components=(
-            RawSchComponent(
-                designator="U1", schdoc_name="Pwr.SchDoc",
-                parameters={
-                    "PDN_ROLE": "REGULATOR",
-                    "PDN_V": "3.3",
-                    "PDN_OUT_P_NET": "+5V",
-                    "PDN_OUT_N_NET": "GND",
-                    "PDN_IN_P_NET": "VIN",
-                    "PDN_IN_N_NET": "GND",
-                },
-                pin_designators=("1", "2", "3", "4"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="REG-A",
-                child_filename="Pwr.SchDoc",
-                unique_id="SYMA",
-                parameters={
-                    "PDN_U1_ROLE": "SINK",
-                    "PDN_U1_I": "0.5A",
-                    "PDN_U1_P_NET": "+5V",
-                    "PDN_U1_N_NET": "GND",
-                },
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="U1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="SOIC", source_designator="U1",
-                source_unique_id=r"\SYMA\COMP",
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 1), _pad(0, "2", 0, 1),
-            _pad(0, "3", 2, 2), _pad(0, "4", 0, 3),
-        ),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    assert not any("OUT_P_NET" in w or "IN_P_NET" in w for w in result.warnings)
-    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
-    assert len(sinks) == 1
-    assert sinks[0].current == pytest.approx(0.5)
-
-
-def test_sheet_override_pdn_v_on_pcb_eco_regulator():
-    """PCB-ECO REGULATOR without PDN_V still takes PDN_<Des>_V from sheet symbol.
-
-    Matches the common pattern where ROLE/nets were ECO'd to the PCB and only
-    the per-instance output voltage lives on the parent sheet symbol.
-    """
-    pcb_pdn = {
-        "PDN_ROLE": "REGULATOR",
-        "PDN_GAIN": "1",
-        "PDN_OUT_P_NET": "VOUT",
-        "PDN_OUT_N_NET": "GND",
-        "PDN_IN_P_NET": "VIN",
-        "PDN_IN_N_NET": "GND",
-    }
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("VIN"), RawNet("VOUT.1"), RawNet("VOUT.2")),
-        sch_components=(
-            RawSchComponent(
-                designator="U1", schdoc_name="Pwr.SchDoc",
-                parameters={"Comment": "buck"},
-                pin_designators=("1", "2", "3", "4"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="PWR_5V",
-                child_filename="Pwr.SchDoc",
-                unique_id="SYM5V",
-                parameters={"PDN_U1_V": "5V"},
-            ),
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="PWR_12V",
-                child_filename="Pwr.SchDoc",
-                unique_id="SYM12V",
-                parameters={"PDN_U1_V": "12 V"},
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="U1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="QFN", source_designator="U1",
-                source_unique_id=r"\SYM5V\COMP",
-                parameters=dict(pcb_pdn),
-            ),
-            RawPcbComponent(
-                designator="U1.2", center=Pt2D(10, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="QFN", source_designator="U1",
-                source_unique_id=r"\SYM12V\COMP",
-                parameters=dict(pcb_pdn),
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 2), _pad(0, "2", 0, 1),
-            _pad(0, "3", 1, 2), _pad(0, "4", 0, 3),
-            _pad(1, "1", 3, 10), _pad(1, "2", 0, 11),
-            _pad(1, "3", 1, 12), _pad(1, "4", 0, 13),
-        ),
-        compiled_netlist=_FakeNetlist(nets=[
-            _FakeNet(
-                name="VOUT.1", aliases=["VOUT"],
-                source_sheets=["pwr.schdoc"],
-                terminals=[_FakeTerminal("U1.1", "1")],
-            ),
-            _FakeNet(
-                name="VOUT.2", aliases=["VOUT"],
-                source_sheets=["pwr.schdoc"],
-                terminals=[_FakeTerminal("U1.2", "1")],
-            ),
-            _FakeNet(
-                name="VIN",
-                source_sheets=["pwr.schdoc"],
-                terminals=[
-                    _FakeTerminal("U1.1", "3"),
-                    _FakeTerminal("U1.2", "3"),
-                ],
-            ),
-            _FakeNet(
-                name="GND",
-                source_sheets=["pwr.schdoc"],
-                terminals=[
-                    _FakeTerminal("U1.1", "2"),
-                    _FakeTerminal("U1.1", "4"),
-                    _FakeTerminal("U1.2", "2"),
-                    _FakeTerminal("U1.2", "4"),
-                ],
-            ),
-        ]),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    regs = {
-        d.designator: d
-        for d in result.directives if isinstance(d, RegulatorSpec)
-    }
-    assert set(regs) == {"U1.1", "U1.2"}
-    assert regs["U1.1"].voltage == pytest.approx(5.0)
-    assert regs["U1.2"].voltage == pytest.approx(12.0)
-
-
-def test_pcb_eco_and_full_sheet_directive_deduped():
-    """PCB-ECO ROLE + full sheet-symbol ROLE must not double-parse one placement."""
-    pcb_pdn = {
-        "PDN_ROLE": "REGULATOR",
-        "PDN_GAIN": "1",
-        "PDN_OUT_P_NET": "VOUT",
-        "PDN_OUT_N_NET": "GND",
-        "PDN_IN_P_NET": "VIN",
-        "PDN_IN_N_NET": "GND",
-    }
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("VIN"), RawNet("VOUT")),
-        sch_components=(
-            RawSchComponent(
-                designator="U1", schdoc_name="Pwr.SchDoc",
-                parameters={"Comment": "buck"},
-                pin_designators=("1", "2", "3", "4"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="PWR",
-                child_filename="Pwr.SchDoc",
-                unique_id="SYM",
-                parameters={
-                    "PDN_U1_ROLE": "REGULATOR",
-                    "PDN_U1_V": "5V",
-                    "PDN_U1_GAIN": "1",
-                    "PDN_U1_OUT_P_NET": "VOUT",
-                    "PDN_U1_OUT_N_NET": "GND",
-                    "PDN_U1_IN_P_NET": "VIN",
-                    "PDN_U1_IN_N_NET": "GND",
-                },
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="U1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="QFN", source_designator="U1",
-                source_unique_id=r"\SYM\COMP",
-                parameters=dict(pcb_pdn),
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 2), _pad(0, "2", 0, 1),
-            _pad(0, "3", 1, 2), _pad(0, "4", 0, 3),
-        ),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    regs = [d for d in result.directives if isinstance(d, RegulatorSpec)]
-    assert len(regs) == 1
-    assert regs[0].designator == "U1.1"
-    assert regs[0].voltage == pytest.approx(5.0)
-
-
-def test_pcb_eco_counts_toward_sheet_only_partial_coverage():
-    """Sibling covered by PCB-ECO is not flagged as missing sheet-only ROLE."""
-    pcb_pdn = {
-        "PDN_ROLE": "SINK",
-        "PDN_I": "100mA",
-        "PDN_P_NET": "+5V",
-        "PDN_N_NET": "GND",
-    }
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+5V")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Port.SchDoc",
-                parameters={"Comment": "USB"},
-                pin_designators=("1", "2"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-A",
-                child_filename="Port.SchDoc",
-                unique_id="SYMA",
-                parameters={
-                    # Value-only override on the PCB-ECO instance.
-                    "PDN_J1_I": "1.5A",
-                },
-            ),
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-B",
-                child_filename="Port.SchDoc",
-                unique_id="SYMB",
-                parameters={
-                    "PDN_J1_ROLE": "SINK",
-                    "PDN_J1_I": "2A",
-                    "PDN_J1_P_NET": "+5V",
-                    "PDN_J1_N_NET": "GND",
-                },
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMA\COMP",
-                parameters=dict(pcb_pdn),
-            ),
-            RawPcbComponent(
-                designator="J1.2", center=Pt2D(10, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMB\COMP",
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 1), _pad(0, "2", 0, 1),
-            _pad(1, "1", 1, 10), _pad(1, "2", 0, 11),
-        ),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    assert not any("PDN covers" in w and "but not" in w for w in result.warnings)
-    sinks = {
-        d.designator: d
-        for d in result.directives if isinstance(d, SinkSpec)
-    }
-    assert set(sinks) == {"J1.1", "J1.2"}
-    assert sinks["J1.1"].current == pytest.approx(1.5)
-    assert sinks["J1.2"].current == pytest.approx(2.0)
-
-
-def test_pcb_eco_value_override_no_false_partial_coverage_warning():
-    """PCB-ECO + value-only sheet override must not warn about a bare sibling."""
-    pcb_pdn = {
-        "PDN_ROLE": "SINK",
-        "PDN_I": "100mA",
-        "PDN_P_NET": "+5V",
-        "PDN_N_NET": "GND",
-    }
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("+5V")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Port.SchDoc",
-                parameters={"Comment": "USB"},
-                pin_designators=("1", "2"),
-            ),
-        ),
-        sch_sheet_symbols=(
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-A",
-                child_filename="Port.SchDoc",
-                unique_id="SYMA",
-                parameters={"PDN_J1_I": "1.5A"},
-            ),
-            RawSchSheetSymbol(
-                parent_schdoc="Main.SchDoc",
-                sheet_name="CON-B",
-                child_filename="Port.SchDoc",
-                unique_id="SYMB",
-                parameters={},
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMA\COMP",
-                parameters=dict(pcb_pdn),
-            ),
-            RawPcbComponent(
-                designator="J1.2", center=Pt2D(10, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="USB", source_designator="J1",
-                source_unique_id=r"\SYMB\COMP",
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 1), _pad(0, "2", 0, 1),
-            _pad(1, "1", 1, 10), _pad(1, "2", 0, 11),
-        ),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    assert not any("PDN covers" in w and "but not" in w for w in result.warnings)
-    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
-    assert len(sinks) == 1
-    assert sinks[0].designator == "J1.1"
-    assert sinks[0].current == pytest.approx(1.5)
-
+def test_lookup_inferred_vin_ignores_series_bridge_groups():
+    """Sense paths through GND must not make Vin ambiguous (project_a / PDN5_R)."""
+    supply_map = {"VDD_48V": 48.0, "VDD_12V": 12.0}
+    assert _lookup_inferred_vin("VDD_48V", supply_map)[0] == 48.0
+    assert _lookup_inferred_vin("VDD_12V", supply_map)[0] == 12.0
 
 def test_multi_instance_lx_supply_map_infers_downstream_smps_vin():
     """Shared local OUT=LX with different PDN_V must not drop Vin for rails.
@@ -4488,7 +4221,7 @@ def test_multi_instance_lx_supply_map_infers_downstream_smps_vin():
     sources = _expand_sheet_bound_parameter_sources(
         proj, _iter_pdn_parameter_sources(proj, result), result,
     )
-    supply_map = _collect_supply_voltages_by_net(sources, proj)
+    supply_map, _ = _collect_supply_voltages_by_net(sources, proj)
     assert "LX" not in supply_map  # ambiguous shared local dropped
     assert supply_map.get("LX.1") == pytest.approx(5.0)
     assert supply_map.get("LX.2") == pytest.approx(12.0)
@@ -4506,1013 +4239,431 @@ def test_multi_instance_lx_supply_map_infers_downstream_smps_vin():
     assert "U2" in regs
     # Vin=12, Vout=3.3, eta=0.85 -> gain = 3.3/(12*0.85)
     assert regs["U2"].gain == pytest.approx(3.3 / (12.0 * 0.85))
-def test_a_failed_page_map_does_not_discard_a_good_netlist():
 
-    from fypa.altium.extract import _compile_schematic_netlist
-
-    sentinel = object()
-
-    class _Compiled:
-        def to_netlist(self):
-            return sentinel
-
-        @property
-        def physical_documents(self):
-            raise RuntimeError("field renamed upstream")
-
-    class _Design:
-        schdocs = ["a.SchDoc"]
-        project = None
-
-        def compile(self):
-            return _Compiled()
-
-        def to_netlist(self):
-            raise AssertionError("must not recompile after a good compile()")
-
-    netlist, sheet_names = _compile_schematic_netlist(_Design())
-    assert netlist is sentinel
-    assert sheet_names == ()
-
-
-# --- P/N arbitration follow-ups ------------------------------------------------
-
-
-
-# --- P/N arbitration follow-ups ------------------------------------------------
-
-
-
-# --- P/N arbitration follow-ups ------------------------------------------------
-
-
-
-# --- P/N arbitration follow-ups ------------------------------------------------
-
-
-def test_alias_fallback_does_not_outrank_a_name_level_match():
-    """"The pad's PCB net is on the row" is the criterion the PCB tier
-    explicitly rejects, so an alias-only hit must not be stamped tier 0 and
-    strip a genuine net.name match on the other terminal."""
-    from fypa.altium.annotations import (
-        _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_NAME, _LOCAL_NET_TIER_PCB,
-    )
-
-    assert _LOCAL_NET_TIER_ALIAS > _LOCAL_NET_TIER_NAME > _LOCAL_NET_TIER_PCB
-
-
-
-
-def test_arbitrate_overlapping_terminals_drops_weaker_side():
-    p = TerminalSpec(
-        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),
-              TerminalPin("2", 1, 1, Pt2D(1, 0))),
-        requested_net="VIN",
-        resolved_via_local=True,
-    )
-    n = TerminalSpec(
-        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),),
-        requested_net="VIN_L",
-        resolved_via_local=True,
-    )
-    result = AnnotationResult()
-    p2, n2 = _arbitrate_overlapping_terminals(
-        p, n, _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_NAME, "SERIES on R1.1", result,
-    )
-    assert p2 is not None and n2 is not None
-    assert {pin.pad_designator for pin in p2.pins} == {"2"}
-    assert {pin.pad_designator for pin in n2.pins} == {"1"}
-    assert any("both matched pin(s)" in w for w in result.warnings)
-    # The pad designator, not the internal "R1.1:1" arbitration key: the
-    # message tells the user to set PDN_*_PINS, which matches on pad names.
-    assert any("kept on N" in w and "dropped from P" in w
-               for w in result.warnings)
-    assert not result.errors
-
-
-
-
-def test_arbitrate_overlapping_terminals_equal_tier_errors():
-    p = TerminalSpec(
-        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),),
-        requested_net="VIN",
-    )
-    n = TerminalSpec(
-        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),),
-        requested_net="VIN_L",
-    )
-    result = AnnotationResult()
-    p2, n2 = _arbitrate_overlapping_terminals(
-        p, n, _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_ALIAS, "SERIES on R1", result,
-    )
-    assert p2 is None and n2 is None
-    assert any("PDN_P_PINS" in e for e in result.errors)
-
-
-
-
-def test_arbitrate_overlapping_terminals_ignores_same_pad_on_other_parts():
-    """Banana-jack style: pad '1' on J2 vs pad '1' on J3 is not an overlap."""
-    p = TerminalSpec(
-        pins=(TerminalPin(
-            "1", 1, 0, Pt2D(0, 0), component_designator="J2",
-        ),),
-        requested_net="+5V",
-    )
-    n = TerminalSpec(
-        pins=(TerminalPin(
-            "1", 1, 1, Pt2D(10, 0), component_designator="J3",
-        ),),
-        requested_net="GND",
-    )
-    result = AnnotationResult()
-    p2, n2 = _arbitrate_overlapping_terminals(
-        p, n, _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_ALIAS, "SOURCE on J2", result,
-    )
-    assert p2 is p and n2 is n
-    assert not result.errors
-    assert not result.warnings
-
-
-
-
-def test_channel_token_must_come_from_flattening():
-    """A part merely NAMED FB_2 is not channel 2 of FB, so an unrelated
-    repeated sheet's VIN.2 must not match it."""
-    # Genuine channel instance: the placed designator is the schematic one
-    # plus the channel token, so the separators may legitimately disagree.
-    assert _local_net_label_matches("VIN_1", "VIN", {"R1", "R1.1"})
-    assert _local_net_label_matches("VIN.1", "VIN", {"R1", "R1_1"})
-    # Not a channel: nothing in the candidate set is "FB" + sep + "2".
-    assert not _local_net_label_matches("VIN.2", "VIN", {"FB_2"})
-    assert not _local_net_label_matches("VIN_3", "VIN", {"SW_3"})
-    # An exact label still matches regardless.
-    assert _local_net_label_matches("VIN", "VIN", {"FB_2"})
-
-# --- Sheet-symbol per-instance overrides ---
-
-# --- Sheet-symbol per-instance overrides --------------------------------------
-
-
-# --- Sheet-symbol per-instance overrides ---
-
-# --- Sheet-symbol per-instance overrides --------------------------------------
-
-
-
-def test_compile_falls_back_to_to_netlist_with_the_designs_own_options():
-    """Rebuilding NetlistOptions.from_prjpcb() drops the merged per-sheet
-    parameters that net labels substitute — only AltiumDesign.from_prjpcb adds
-    them — so a fallback that does so silently renames nets."""
-
-    from fypa.altium.extract import _compile_schematic_netlist
-
-    sentinel = object()
-    calls = []
-
-    class _Design:
-        schdocs = ["a.SchDoc"]
-        project = None
-
-        def to_netlist(self):
-            calls.append("to_netlist")
-            return sentinel
-
-    netlist, sheet_names = _compile_schematic_netlist(_Design())
-    assert netlist is sentinel
-    assert sheet_names == ()
-    assert calls == ["to_netlist"]
-
-
-
-
-def test_empty_side_errors_without_a_contradictory_warning():
-    """Warning that pins were "dropped from N" and then that N is empty and
-    the directive discarded reads as two contradictory log lines."""
-    shared = TerminalPin("1", 1, 0, Pt2D(0, 0))
-    p = TerminalSpec(pins=(shared,), requested_net="VIN")
-    n = TerminalSpec(pins=(shared,), requested_net="VIN_L")
-    result = AnnotationResult()
-    p2, n2 = _arbitrate_overlapping_terminals(
-        p, n, _LOCAL_NET_TIER_NAME, _LOCAL_NET_TIER_ALIAS,
-        "SERIES on R5", result,
-    )
-    assert p2 is not None and n2 is None
-    assert result.errors and "would be empty" in result.errors[0]
-    assert result.warnings == []
-
-
-
-
-def test_equal_tier_error_points_at_the_remedy_that_works():
-    shared = TerminalPin("1", 1, 0, Pt2D(0, 0))
-    p = TerminalSpec(pins=(shared,), requested_net="VIN")
-    n = TerminalSpec(pins=(shared,), requested_net="VIN")
-    result = AnnotationResult()
-    p2, n2 = _arbitrate_overlapping_terminals(
-        p, n, _LOCAL_NET_TIER_NAME, _LOCAL_NET_TIER_NAME,
-        "SERIES on R5", result,
-    )
-    assert p2 is None and n2 is None
-    assert "outranks a net-name match" in result.errors[0]
-
-
-
-
-def test_explicit_pin_override_outranks_a_net_name_match():
-    """The overlap error tells the user to set PDN_*_PINS. That advice only
-    works if an explicit pin list actually breaks the tie."""
-    from fypa.altium.annotations import (
-        _LOCAL_NET_TIER_DIRECT, _LOCAL_NET_TIER_OVERRIDE,
-    )
-
-    assert _LOCAL_NET_TIER_OVERRIDE < _LOCAL_NET_TIER_DIRECT
-
-
-
-
-def test_harvest_falls_back_to_file_name_when_source_path_is_absent():
-    from types import SimpleNamespace
-
-    from fypa.altium.extract import _harvest_physical_sheet_names
-
-    compiled = SimpleNamespace(physical_documents=[
-        SimpleNamespace(id="physical:0", file_name="Power.SchDoc"),
-    ])
-    assert _harvest_physical_sheet_names(compiled) == (
-        ("physical:0", "Power.SchDoc"),
-    )
-
-
-
-
-def test_harvest_is_empty_on_a_release_without_physical_documents():
-    """The installed library may predate the compiled model entirely; that
-    must yield an empty map, not an exception."""
-    from types import SimpleNamespace
-
-    from fypa.altium.extract import _harvest_physical_sheet_names
-
-    assert _harvest_physical_sheet_names(SimpleNamespace()) == ()
-    assert _harvest_physical_sheet_names(
-        SimpleNamespace(physical_documents=None)) == ()
-    # Entries missing either half are skipped rather than half-recorded.
-    assert _harvest_physical_sheet_names(SimpleNamespace(physical_documents=[
-        SimpleNamespace(id=None, source_path="A.SchDoc"),
-        SimpleNamespace(id="physical:0", source_path=None, file_name=None),
-    ])) == ()
-
-
-
-# --- physical-page-map harvesting ---------------------------------------------
-
-
-
-
-# --- physical-page-map harvesting ---------------------------------------------
-
-
-def test_harvest_prefers_source_path_over_bare_file_name():
-    """file_name is the bare leaf, so harvesting it collapses same-named
-    sheets in different directories onto one map value."""
-    from types import SimpleNamespace
-
-    from fypa.altium.extract import _harvest_physical_sheet_names
-
-    compiled = SimpleNamespace(physical_documents=[
-        SimpleNamespace(id="physical:0", source_path="SubA/Power.SchDoc",
-                        file_name="Power.SchDoc"),
-        SimpleNamespace(id="physical:1", source_path="SubB/Power.SchDoc",
-                        file_name="Power.SchDoc"),
-    ])
-    assert _harvest_physical_sheet_names(compiled) == (
-        ("physical:0", "SubA/Power.SchDoc"),
-        ("physical:1", "SubB/Power.SchDoc"),
-    )
-
-
-
-
-def test_local_net_label_matches_separator_agnostic_channel_token():
-    """Net VIN_1 must match local VIN on designator R1.1 (._ separators differ)."""
-    assert _local_net_label_matches("VIN_1", "VIN", {"R1", "R1.1"})
-    assert _local_net_label_matches("VIN.1", "VIN", {"R1", "R1_1"})
-    assert not _local_net_label_matches("VIN_L.1", "VIN", {"R1", "R1.1"})
-    assert _local_net_label_matches("VIN_L.1", "VIN_L", {"R1", "R1.1"})
-
-
-
-
-def test_lookup_inferred_vin_bounds_chain_length():
-    """A chain longer than the hop cap errors instead of walking on."""
-    chain = {f"N{i}": f"N{i + 1}" for i in range(_SERIES_VIN_MAX_HOPS + 3)}
-    vin, failure, _hops = _lookup_inferred_vin(
-        "N0", {"N99": 48.0}, graph=_SeriesVinGraph(upstream=chain),
-    )
-    assert vin is None
-    assert failure == "too_deep"
-
-
-
-
-def test_lookup_inferred_vin_crosses_single_undirected_link():
-    """An auto-inferred 2-pin element has no P/N direction, so it is crossed
-    only when it is the one unvisited way out of the net."""
-    supply_map = {"VDD_48V_IN": 48.0}
-    one_way = _SeriesVinGraph(
-        undirected={
-            "VDD_48V": frozenset({"VDD_48V_IN"}),
-            "VDD_48V_IN": frozenset({"VDD_48V"}),
-        },
-    )
-    assert _lookup_inferred_vin("VDD_48V", supply_map, graph=one_way) == (
-        48.0, None, 1,
-    )
-    forked = _SeriesVinGraph(
-        undirected={"VDD_48V": frozenset({"VDD_48V_IN", "VDD_SENSE"})},
-    )
-    assert _lookup_inferred_vin("VDD_48V", supply_map, graph=forked) == (
-        None, "undirected", 0,
-    )
-
-
-
-
-def test_lookup_inferred_vin_declared_rail_beats_series_ambiguity():
-    """A rail whose voltage is declared resolves even when SERIES links to it
-    disagree — parallel ferrites / ORing FETs / fuse+bypass all land here."""
-    assert _lookup_inferred_vin(
-        "VDD_12V", {"VDD_12V": 12.0},
-        graph=_SeriesVinGraph(ambiguous=frozenset({"VDD_12V"})),
-    ) == (12.0, None, 0)
-
-
-
-
-def test_lookup_inferred_vin_exact_match_without_series_walk():
-    """Without a SERIES graph, only direct supply_map hits resolve."""
-    supply_map = {"VDD_48V": 48.0, "VDD_12V": 12.0}
-    assert _lookup_inferred_vin("VDD_48V", supply_map) == (48.0, None, 0)
-    assert _lookup_inferred_vin("VDD_12V", supply_map) == (12.0, None, 0)
-    assert _lookup_inferred_vin("VDD_48V_RP", supply_map) == (None, None, 0)
-
-
-
-
-def test_lookup_inferred_vin_series_ambiguous_and_cycle():
-    supply_map = {"VDD_48V_IN": 48.0}
-    assert _lookup_inferred_vin(
-        "VDD_48V_RP", supply_map,
-        graph=_SeriesVinGraph(ambiguous=frozenset({"VDD_48V_RP"})),
-    ) == (None, "ambiguous", 0)
-    assert _lookup_inferred_vin(
-        "VDD_48V_RP", supply_map,
-        graph=_SeriesVinGraph(
-            upstream={"VDD_48V_RP": "VDD_48V", "VDD_48V": "VDD_48V_RP"},
-        ),
-    ) == (None, "cycle", 1)
-
-
-
-
-def test_lookup_inferred_vin_walks_series_upstream():
-    supply_map = {"VDD_48V_IN": 48.0}
-    graph = _SeriesVinGraph(
-        upstream={"VDD_48V_RP": "VDD_48V", "VDD_48V": "VDD_48V_IN"},
-    )
-    # Two hops from the named rail — the caller warns on any non-zero hop count.
-    assert _lookup_inferred_vin(
-        "VDD_48V_RP", supply_map, graph=graph,
-    ) == (48.0, None, 2)
-
-
-
-
-def test_overlap_messages_name_pads_not_arbitration_keys():
-    """The keys are composite ("R5:1") but PDN_*_PINS matches bare pad names,
-    so printing the key sent the user to an error about an unknown pin."""
-    p = TerminalSpec(
-        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0), component_designator="R5"),
-              TerminalPin("2", 1, 0, Pt2D(0, 0), component_designator="R5")),
-        requested_net="VIN",
-    )
-    n = TerminalSpec(
-        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0), component_designator="R5"),),
-        requested_net="VIN_L",
-    )
-    result = AnnotationResult()
-    _arbitrate_overlapping_terminals(
-        p, n, _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_NAME,
-        "SERIES on R5", result,
-    )
-    text = " ".join(result.warnings + result.errors)
-    assert "R5:1" not in text
-    assert "pin(s) 1" in text
-
-
-
-
-def test_plain_sheet_names_are_unaffected_by_the_page_id_path():
-    assert _sheet_name_matches("Power.SchDoc", ["Power.SchDoc"])
-    assert _sheet_name_matches("Power.SchDoc", ["SubA/Power.SchDoc"])
-    assert not _sheet_name_matches("SubA/Power.SchDoc", ["SubB/Power.SchDoc"])
-
-
-
-
-def test_regulator_smps_vin_does_not_warn_on_directly_declared_rail():
-    proj = _series_vin_proj(
-        {
-            "PDN_ROLE": "SERIES", "PDN_R": "50m",
-            "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
-        },
-        in_p_net="VDD_48V_IN",
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert not any("SERIES hop(s) upstream" in w for w in result.warnings)
-
-
-
-
-def test_regulator_smps_vin_resolves_under_merged_net_name():
-    """The user may write either merged name. Both the supply map and the
-    lookup key are canonicalised, so IN_P_NET on the folded name still lands."""
-    proj = _series_vin_proj(
-        {
-            "PDN_ROLE": "SERIES", "PDN_R": "50m",
-            "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
-        },
-        in_p_net="VDD_48V_F",   # the name the user wrote
-        in_p_pad_net=2,         # ...folded into VDD_48V by the merge pre-pass
-    )
-    result = parse_annotations(proj, enabled_layers=[1], net_remap={4: 2})
-    reg = next(d for d in result.directives if d.designator == "U5")
-    assert abs(reg.gain - (12.0 / (48.0 * 0.8))) < 1e-6, result.errors
-
-
-
-
-def test_regulator_smps_vin_series_ambiguous_fork():
+def test_multi_instance_missing_net_reports_once():
+    """Missing PDN_P_NET on every instance → one logical error."""
     proj = _minimal_proj(
-        nets=(
-            RawNet("GND"), RawNet("VDD_48V_IN"), RawNet("VDD_48V"),
-            RawNet("VDD_48V_RP"), RawNet("VDD_12V"), RawNet("ALT_48V"),
-        ),
+        nets=(RawNet("GND"), RawNet("+5V")),
         sch_components=(
             RawSchComponent(
-                designator="J7", schdoc_name="Pwr.SchDoc",
+                designator="J1", schdoc_name="Port.SchDoc",
                 parameters={
-                    "PDN_ROLE": "SOURCE", "PDN_V": "48",
-                    "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "GND",
-                },
-                pin_designators=("1", "2"),
-            ),
-            RawSchComponent(
-                designator="J8", schdoc_name="Pwr.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SERIES", "PDN_R": "50m",
-                    "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
-                },
-                pin_designators=("1", "2"),
-            ),
-            RawSchComponent(
-                designator="Q3a", schdoc_name="Pwr.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SERIES", "PDN_R": "100m",
-                    "PDN_P_NET": "VDD_48V", "PDN_N_NET": "VDD_48V_RP",
-                },
-                pin_designators=("1", "2"),
-            ),
-            RawSchComponent(
-                designator="Q3b", schdoc_name="Pwr.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SERIES", "PDN_R": "200m",
-                    "PDN_P_NET": "ALT_48V", "PDN_N_NET": "VDD_48V_RP",
-                },
-                pin_designators=("1", "2"),
-            ),
-            RawSchComponent(
-                designator="U5", schdoc_name="Pwr.SchDoc",
-                parameters={
-                    "PDN_ROLE": "REGULATOR",
-                    "PDN_REGULATOR_TYPE": "SMPS",
-                    "PDN_REGULATOR_EFFICIENCY": "0.8",
-                    "PDN_V": "12",
-                    "PDN_OUT_P_NET": "VDD_12V",
-                    "PDN_OUT_N_NET": "GND",
-                    "PDN_IN_P_NET": "VDD_48V_RP",
-                    "PDN_IN_N_NET": "GND",
-                },
-                pin_designators=("1", "2", "3", "4"),
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J7", center=Pt2D(-15, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="CONN", source_designator="J7",
-            ),
-            RawPcbComponent(
-                designator="J8", center=Pt2D(-10, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="FUSE", source_designator="J8",
-            ),
-            RawPcbComponent(
-                designator="Q3a", center=Pt2D(-5, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="SOT", source_designator="Q3a",
-            ),
-            RawPcbComponent(
-                designator="Q3b", center=Pt2D(-4, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="SOT", source_designator="Q3b",
-            ),
-            RawPcbComponent(
-                designator="U5", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="SOT", source_designator="U5",
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 1, -15), _pad(0, "2", 0, -14),
-            _pad(1, "1", 1, -10), _pad(1, "2", 2, -9),
-            _pad(2, "1", 2, -5), _pad(2, "2", 3, -4),
-            _pad(3, "1", 5, -4), _pad(3, "2", 3, -3),
-            _pad(4, "1", 4, 0), _pad(4, "2", 0, 1),
-            _pad(4, "3", 3, 2), _pad(4, "4", 0, 3),
-        ),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert not result.ok
-    assert any("ambiguous SERIES upstream" in e for e in result.errors)
-
-
-# --- SERIES Vin graph construction --------------------------------------------
-
-_SERIES_VIN_NETS = {
-    "GND": 0, "VDD_48V_IN": 1, "VDD_48V": 2, "VDD_12V": 3, "VDD_48V_F": 4,
-}
-
-
-
-
-def test_regulator_smps_vin_through_series_chain():
-    """VIP-style: SOURCE -> SERIES -> SERIES -> SMPS on downstream net."""
-    proj = _minimal_proj(
-        nets=(
-            RawNet("GND"), RawNet("VDD_48V_IN"), RawNet("VDD_48V"),
-            RawNet("VDD_48V_RP"), RawNet("VDD_12V"),
-        ),
-        sch_components=(
-            RawSchComponent(
-                designator="J7", schdoc_name="Pwr.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SOURCE",
-                    "PDN_V": "48",
-                    "PDN_P_NET": "VDD_48V_IN",
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "1A",
                     "PDN_N_NET": "GND",
                 },
                 pin_designators=("1", "2"),
             ),
-            RawSchComponent(
-                designator="J8", schdoc_name="Pwr.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SERIES",
-                    "PDN_R": "50m",
-                    "PDN_P_NET": "VDD_48V_IN",
-                    "PDN_N_NET": "VDD_48V",
-                },
-                pin_designators=("1", "2"),
-            ),
-            RawSchComponent(
-                designator="Q3", schdoc_name="Pwr.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SERIES",
-                    "PDN_R": "300m",
-                    "PDN_P_NET": "VDD_48V",
-                    "PDN_N_NET": "VDD_48V_RP",
-                },
-                pin_designators=("1", "2"),
-            ),
-            RawSchComponent(
-                designator="U5", schdoc_name="Pwr.SchDoc",
-                parameters={
-                    "PDN_ROLE": "REGULATOR",
-                    "PDN_REGULATOR_TYPE": "SMPS",
-                    "PDN_REGULATOR_EFFICIENCY": "0.8",
-                    "PDN_V": "12",
-                    "PDN_OUT_P_NET": "VDD_12V",
-                    "PDN_OUT_N_NET": "GND",
-                    "PDN_IN_P_NET": "VDD_48V_RP",
-                    "PDN_IN_N_NET": "GND",
-                },
-                pin_designators=("1", "2", "3", "4"),
-            ),
         ),
         pcb_components=(
             RawPcbComponent(
-                designator="J7", center=Pt2D(-15, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="CONN", source_designator="J7",
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
             ),
             RawPcbComponent(
-                designator="J8", center=Pt2D(-10, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="FUSE", source_designator="J8",
-            ),
-            RawPcbComponent(
-                designator="Q3", center=Pt2D(-5, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="SOT", source_designator="Q3",
-            ),
-            RawPcbComponent(
-                designator="U5", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="SOT", source_designator="U5",
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 1, -15), _pad(0, "2", 0, -14),
-            _pad(1, "1", 1, -10), _pad(1, "2", 2, -9),
-            _pad(2, "1", 2, -5), _pad(2, "2", 3, -4),
-            _pad(3, "1", 4, 0), _pad(3, "2", 0, 1),
-            _pad(3, "3", 3, 2), _pad(3, "4", 0, 3),
-        ),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    reg = next(d for d in result.directives if d.designator == "U5")
-    assert isinstance(reg, RegulatorSpec)
-    assert reg.regulator_type == "SMPS"
-    assert abs(reg.gain - (12.0 / (48.0 * 0.8))) < 1e-6
-    assert not any("cannot infer input voltage" in e for e in result.errors)
-
-
-
-
-def test_regulator_smps_vin_warns_when_inferred_through_series_chain():
-    """Vin taken from a walked chain is a guess about which leg is the power
-    path — a sense or bleed resistor produces a silently wrong gain, so say so."""
-    proj = _series_vin_proj({
-        "PDN_ROLE": "SERIES", "PDN_R": "50m",
-        "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
-    })
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert any(
-        "was inferred 1 SERIES hop(s) upstream" in w for w in result.warnings
-    ), result.warnings
-
-
-
-
-def test_resolve_local_net_pins_pcb_confirmed_beats_name():
-    """When PCB net confirms a row, prefer that tier over bare name matches."""
-    netlist = _FakeNetlist(nets=[
-        _FakeNet(
-            name="OTHER",
-            aliases=["VIN"],
-            source_sheets=["Supply.SchDoc"],
-            terminals=[_FakeTerminal("R1.1", "2")],
-        ),
-        _FakeNet(
-            name="VIN_1",
-            aliases=["VIN"],
-            source_sheets=["Supply.SchDoc"],
-            terminals=[_FakeTerminal("R1.1", "1")],
-        ),
-    ])
-    pins, tier = _resolve_local_net_pins(
-        netlist, "R1", "Supply.SchDoc", "VIN",
-        pcb_designator="R1.1",
-        routed_pin_keys={"1", "2"},
-        pcb_net_by_pin={"1": "VIN_1", "2": "VOUT"},
-    )
-    # Pin 1 is PCB-confirmed (VIN_1 on the row); pin 2 is alias-only → drop it.
-    assert pins == ["1"]
-    assert tier == _LOCAL_NET_TIER_PCB
-
-
-
-
-def test_resolve_local_net_pins_physical_source_sheet():
-    physical = (
-        "physical:0:logical:0:main.SchDoc:child:1:sheet_symbol:U_PWR"
-        ":sheet:power.SchDoc"
-    )
-    netlist = _FakeNetlist(nets=[
-        _FakeNet(
-            name="Sheet1_+3V3",
-            aliases=["+3V3"],
-            source_sheets=[physical],
-            terminals=[_FakeTerminal("U1", "14"), _FakeTerminal("C1", "1")],
-        ),
-    ])
-    proj = _minimal_proj(
-        physical_sheet_names=((physical, "Power.SchDoc"),),
-        compiled_netlist=netlist,
-    )
-    pins, _tier = _resolve_local_net_pins(
-        netlist, "U1", "Power.SchDoc", "+3V3", sheet_map=_sheet_map(proj),
-    )
-    assert pins == ["14"]
-
-
-
-
-def test_resolve_local_net_pins_prefers_name_over_shared_alias():
-    """Two nets sharing bare alias VIN: keep only the channel name-level match.
-
-    Models the multi-channel case where both sides of a SERIES element carry
-    the same local alias in the compiled netlist. The P label VIN must resolve
-    to pin 2 (net VIN_1) and not also claim pin 1 (net VIN_L.1).
-    """
-    netlist = _FakeNetlist(nets=[
-        _FakeNet(
-            name="VIN_1",
-            aliases=["VIN", "VIN.1"],
-            source_sheets=["Supply.SchDoc"],
-            terminals=[_FakeTerminal("R1.1", "2")],
-        ),
-        _FakeNet(
-            name="VIN_L.1",
-            aliases=["VIN", "VIN.1", "VIN.2"],
-            source_sheets=["Supply.SchDoc"],
-            terminals=[_FakeTerminal("R1.1", "1")],
-        ),
-    ])
-    pins, tier = _resolve_local_net_pins(
-        netlist, "R1", "Supply.SchDoc", "VIN",
-        pcb_designator="R1.1",
-        routed_pin_keys={"1", "2"},
-    )
-    assert pins == ["2"]
-    assert tier == _LOCAL_NET_TIER_NAME
-
-    n_pins, n_tier = _resolve_local_net_pins(
-        netlist, "R1", "Supply.SchDoc", "VIN_L",
-        pcb_designator="R1.1",
-        routed_pin_keys={"1", "2"},
-    )
-    assert n_pins == ["1"]
-    assert n_tier == _LOCAL_NET_TIER_NAME
-
-
-
-
-def test_series_shared_alias_resolves_disjoint_p_n():
-    """SERIES with local VIN / VIN_L must not short both pads of a 2-pin part."""
-    netlist = _FakeNetlist(nets=[
-        _FakeNet(
-            name="VIN_1",
-            aliases=["VIN", "VIN.1"],
-            source_sheets=["Supply.SchDoc"],
-            terminals=[_FakeTerminal("R1.1", "2")],
-        ),
-        _FakeNet(
-            name="VIN_L.1",
-            aliases=["VIN", "VIN.1"],
-            source_sheets=["Supply.SchDoc"],
-            terminals=[_FakeTerminal("R1.1", "1")],
-        ),
-    ])
-    proj = _minimal_proj(
-        nets=(RawNet("VIN_1"), RawNet("VIN_L.1")),
-        pcb_components=(
-            RawPcbComponent(
-                designator="R1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="1005R", source_designator="R1",
-                parameters={
-                    "PDN_ROLE": "SERIES",
-                    "PDN_R": "10m",
-                    "PDN_P_NET": "VIN",
-                    "PDN_N_NET": "VIN_L",
-                },
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 1, 0),  # VIN_L.1
-            _pad(0, "2", 0, 1),  # VIN_1
-        ),
-        compiled_netlist=netlist,
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    series = [d for d in result.directives if isinstance(d, ResistorSpec)]
-    assert len(series) == 1
-    r = series[0]
-    p_nets = {p.net_index for p in r.p.pins}
-    n_nets = {p.net_index for p in r.n.pins}
-    assert p_nets == {0}
-    assert n_nets == {1}
-    assert p_nets.isdisjoint(n_nets)
-
-
-
-
-def test_series_upstream_map_auto_inferred_link_is_direction_agnostic():
-    """_autoinfer_2pin_nets takes P/N from raw pad order, so the Vin result must
-    not change when the two RawPad entries are swapped."""
-    params = {"PDN_ROLE": "SERIES", "PDN_R": "50m"}
-    forward = _series_vin_proj(params, series_pads=(("1", 1), ("2", 2)))
-    reversed_ = _series_vin_proj(params, series_pads=(("2", 2), ("1", 1)))
-    expected = 12.0 / (48.0 * 0.8)
-    for proj in (forward, reversed_):
-        graph = _collect_series_upstream_map(
-            _iter_pdn_parameter_sources(proj), proj,
-        )
-        # Recorded as an undirected pair — pad order states no power flow.
-        assert not graph.upstream
-        assert graph.undirected["VDD_48V"] == frozenset({"VDD_48V_IN"})
-        result = parse_annotations(proj, enabled_layers=[1])
-        reg = next(d for d in result.directives if d.designator == "U5")
-        assert abs(reg.gain - expected) < 1e-6, result.errors
-
-
-
-
-def test_series_upstream_map_reads_indexed_role_only_channels():
-    """A part whose SERIES channels come only from PDN<n>_ROLE overrides still
-    contributes its links — _is_pdn_annotated admits it, so the graph must too."""
-    proj = _series_vin_proj({
-        "PDN1_ROLE": "SERIES", "PDN1_R": "50m",
-        "PDN1_P_NET": "VDD_48V_IN", "PDN1_N_NET": "VDD_48V",
-        "PDN2_ROLE": "SERIES", "PDN2_R": "50m",
-        "PDN2_P_NET": "VDD_48V", "PDN2_N_NET": "VDD_12V",
-    })
-    graph = _collect_series_upstream_map(_iter_pdn_parameter_sources(proj), proj)
-    assert graph.upstream == {
-        "VDD_48V": "VDD_48V_IN", "VDD_12V": "VDD_48V",
-    }
-
-
-
-
-def test_series_upstream_map_reads_pin_specified_channels():
-    """PDN_P_PINS / PDN_N_PINS is a supported way to state a SERIES element's
-    two sides, so it must produce the same edge PDN_P_NET / PDN_N_NET would."""
-    proj = _series_vin_proj(
-        {
-            "PDN_ROLE": "SERIES", "PDN_R": "50m",
-            "PDN_P_PINS": "1", "PDN_N_PINS": "2,3",
-        },
-        # pin 1 on VDD_48V_IN, pins 2+3 both on VDD_48V.
-        series_pads=(("1", 1), ("2", 2), ("3", 2)),
-    )
-    graph = _collect_series_upstream_map(_iter_pdn_parameter_sources(proj), proj)
-    assert graph.upstream == {"VDD_48V": "VDD_48V_IN"}
-
-    result = parse_annotations(proj, enabled_layers=[1])
-    reg = next(d for d in result.directives if d.designator == "U5")
-    assert abs(reg.gain - (12.0 / (48.0 * 0.8))) < 1e-6
-
-
-
-
-def test_series_upstream_map_skips_merged_short_self_edges():
-    """A 0 Ω the merge pre-pass absorbed has both ends on one net now. Neither
-    the skip list nor the self-edge guard may let it shadow the real edge."""
-    proj = _series_vin_proj(
-        {
-            "PDN_ROLE": "SERIES", "PDN_R": "50m",
-            "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
-        },
-        extra_series={
-            "PDN_ROLE": "SERIES", "PDN_R": "0.001",
-            "PDN_P_NET": "VDD_48V", "PDN_N_NET": "VDD_48V_F",
-        },
-    )
-    # VDD_48V_F (index 4) merged into VDD_48V (index 2).
-    net_remap = {4: 2}
-    graph = _collect_series_upstream_map(
-        _iter_pdn_parameter_sources(proj), proj,
-        net_remap=net_remap, skip_designators={"R9"},
-    )
-    assert graph.upstream == {"VDD_48V": "VDD_48V_IN"}
-    assert not graph.ambiguous
-
-    # Even without the skip list, the self-edge guard must hold the line.
-    unskipped = _collect_series_upstream_map(
-        _iter_pdn_parameter_sources(proj), proj, net_remap=net_remap,
-    )
-    assert unskipped.upstream == {"VDD_48V": "VDD_48V_IN"}
-    assert not unskipped.ambiguous
-
-
-
-
-def test_sheet_map_keeps_same_named_sheets_in_different_directories_apart():
-    """Harvesting the bare leaf would collapse these onto one name, which is
-    the collision _sheet_name_matches exists to prevent."""
-    page_a = "physical:0:logical:0:SubA/Power.SchDoc"
-    page_b = "physical:1:logical:1:SubB/Power.SchDoc"
-    proj = _minimal_proj(physical_sheet_names=(
-        (page_a, "SubA/Power.SchDoc"),
-        (page_b, "SubB/Power.SchDoc"),
-    ))
-    smap = _sheet_map(proj)
-    assert _sheet_name_matches("SubA/Power.SchDoc", [page_a], sheet_map=smap)
-    assert not _sheet_name_matches("SubA/Power.SchDoc", [page_b], sheet_map=smap)
-
-
-
-
-def test_sheet_name_matches_physical_page_id_via_map():
-    """altium_monkey ≥ 2026.7 emits physical page ids in source_sheets."""
-    physical = (
-        "physical:0:logical:0:main.SchDoc:child:1:sheet_symbol:U_PWR"
-        ":sheet:power.SchDoc"
-    )
-    proj = _minimal_proj(
-        physical_sheet_names=((physical, "Power.SchDoc"),),
-    )
-    smap = _sheet_map(proj)
-    assert _sheet_name_matches("Power.SchDoc", [physical], sheet_map=smap)
-    assert not _sheet_name_matches("Other.SchDoc", [physical], sheet_map=smap)
-
-
-
-
-def test_unmapped_physical_page_id_is_unknown_not_guessed():
-    """A child page id embeds its PARENT's logical id, so scanning it for a
-    ``*.SchDoc`` token yields the root sheet — which both hides real matches
-    and invents false ones. An unmapped id must read as unknown provenance,
-    degrading to the permissive path rather than binding to a guess."""
-    from fypa.altium.annotations import _logical_schdoc_name
-
-    child = (
-        "physical:0:logical:0:main.SchDoc:child:logical:0:main.SchDoc"
-        ":sheet_symbol:UID-ABC:1"
-    )
-    assert _logical_schdoc_name(child, {}) is None
-    # Not "matches the root sheet", and not a hard reject either: with no
-    # usable provenance the net is accepted the same way one with no
-    # source_sheets at all is.
-    assert _sheet_name_matches("Power.SchDoc", [child])
-    assert _sheet_name_matches("main.SchDoc", [child])
-    # …but a page the map DOES cover still discriminates.
-    proj = _minimal_proj(physical_sheet_names=((child, "Power.SchDoc"),))
-    smap = _sheet_map(proj)
-    assert _sheet_name_matches("Power.SchDoc", [child], sheet_map=smap)
-    assert not _sheet_name_matches("main.SchDoc", [child], sheet_map=smap)
-
-def test_autoinfer_series_propagates_supply_voltage_for_smps_vin():
-    """2-pin SERIES without P/N nets still forwards Vin via pad autoinfer."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("VIN"), RawNet("VIN_L"), RawNet("VOUT")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Main.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SOURCE",
-                    "PDN_V": "12",
-                    "PDN_P_NET": "VIN",
-                    "PDN_N_NET": "GND",
-                },
-                pin_designators=("1", "2"),
-            ),
-            RawSchComponent(
-                designator="L1", schdoc_name="Main.SchDoc",
-                parameters={"PDN_ROLE": "SERIES", "PDN_R": "5m"},
-                pin_designators=("1", "2"),
-            ),
-            RawSchComponent(
-                designator="U1", schdoc_name="Main.SchDoc",
-                parameters={
-                    "PDN_ROLE": "REGULATOR",
-                    "PDN_V": "3.3",
-                    "PDN_REGULATOR_TYPE": "SMPS",
-                    "PDN_REGULATOR_EFFICIENCY": "0.9",
-                    "PDN_OUT_P_NET": "VOUT",
-                    "PDN_OUT_N_NET": "GND",
-                    "PDN_IN_P_NET": "VIN_L",
-                    "PDN_IN_N_NET": "GND",
-                },
-                pin_designators=("1", "2", "3", "4"),
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="CONN", source_designator="J1",
-            ),
-            RawPcbComponent(
-                designator="L1", center=Pt2D(5, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="IND", source_designator="L1",
-            ),
-            RawPcbComponent(
-                designator="U1", center=Pt2D(10, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="QFN", source_designator="U1",
+                designator="J1.2", center=Pt2D(5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
             ),
         ),
         pads=(
             _pad(0, "1", 1), _pad(0, "2", 0, 1),
-            # L1 autoinfer: pad1 VIN (upstream), pad2 VIN_L (downstream)
-            _pad(1, "1", 1, 5), _pad(1, "2", 2, 6),
-            _pad(2, "1", 3, 10), _pad(2, "2", 0, 11),
-            _pad(2, "3", 2, 12), _pad(2, "4", 0, 13),
+            _pad(1, "1", 1, 5), _pad(1, "2", 0, 6),
         ),
     )
-    supply_map = _collect_supply_voltages_by_net(
-        _iter_pdn_parameter_sources(proj), proj,
-    )
-    assert supply_map.get("VIN") == pytest.approx(12.0)
-    assert supply_map.get("VIN_L") == pytest.approx(12.0)
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert not result.ok
+    missing = [e for e in result.errors if "missing PDN_P_NET" in e]
+    assert len(missing) == 1
+    assert "SINK on J1:" in missing[0]
 
-    ann = parse_annotations(proj, enabled_layers=[1])
-    assert ann.ok, ann.errors
-    reg = next(d for d in ann.directives if isinstance(d, RegulatorSpec))
-    assert reg.gain == pytest.approx(3.3 / (12.0 * 0.9))
+def test_multi_instance_missing_value_reports_once():
+    """Missing PDN_I after expand → one logical error, not one per instance.
+
+    A bound sheet symbol carries only a REPEAT slot that matches no PCB
+    designator (``.99``). Discovery still sees ``PDN_I``, but no instance
+    receives the override.
+    """
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={"PDN_J1_I.99": "1A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+            RawPcbComponent(
+                designator="J1.3", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 1, 5), _pad(1, "2", 0, 6),
+            _pad(2, "1", 1, 10), _pad(2, "2", 0, 11),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert not result.ok
+    missing = [e for e in result.errors if "missing PDN_I" in e]
+    assert len(missing) == 1
+    assert "SINK on J1:" in missing[0]
+
+def test_orphan_sheet_override_does_not_invent_discovery_channel():
+    """Unbound sheet-symbol PDN_I must not make a child channel 'present'."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="ORPHAN",
+                child_filename="Port.SchDoc",
+                unique_id="NOTONPCB",
+                parameters={"PDN_J1_I": "1A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\OTHER\COMP",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert not result.ok
+    assert any(
+        "missing PDN_I" in e and "SINK on J1" in e
+        for e in result.errors
+    )
+    assert not any("missing required parameter PDN_I" in e for e in result.errors)
+
+def test_orphan_sheet_override_warnings_consolidated():
+    """Multiple orphan PDN keys on one symbol → one warning listing them."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"),),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="ORPHAN",
+                child_filename="Port.SchDoc",
+                unique_id="NOSUCHUID",
+                parameters={
+                    "PDN_J1_I": "1A",
+                    "PDN_J1_ROLE": "SINK",
+                    "PDN_J1_P_NET": "+5V",
+                },
+            ),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    uid_warns = [
+        w for w in result.warnings
+        if "NOSUCHUID" in w and "not bound to any PCB placement" in w
+    ]
+    assert len(uid_warns) == 1
+    assert "PDN_J1_I" in uid_warns[0]
+    assert "PDN_J1_ROLE" in uid_warns[0]
+    assert "PDN_J1_P_NET" in uid_warns[0]
+
+def test_partial_coverage_warning_labels_pcb_eco_separately():
+    """Mixed PCB-ECO + sheet-only partial coverage names sources explicitly."""
+    pcb_pdn = {
+        "PDN_ROLE": "SINK",
+        "PDN_I": "1A",
+        "PDN_P_NET": "+5V",
+        "PDN_N_NET": "GND",
+    }
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={"Comment": "USB"},
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={},
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-B",
+                child_filename="Port.SchDoc",
+                unique_id="SYMB",
+                parameters={
+                    "PDN_J1_ROLE": "SINK",
+                    "PDN_J1_I": "2A",
+                    "PDN_J1_P_NET": "+5V",
+                    "PDN_J1_N_NET": "GND",
+                },
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-C",
+                child_filename="Port.SchDoc",
+                unique_id="SYMC",
+                parameters={},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+                parameters=dict(pcb_pdn),
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMB\COMP",
+            ),
+            RawPcbComponent(
+                designator="J1.3", center=Pt2D(20, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMC\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 1, 10), _pad(1, "2", 0, 11),
+            _pad(2, "1", 1, 20), _pad(2, "2", 0, 21),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert any(
+        "J1.2 (sheet symbol)" in w
+        and "J1.1 (PCB-ECO)" in w
+        and "but not J1.3" in w
+        for w in result.warnings
+    )
+
+def test_pcb_eco_and_full_sheet_directive_deduped():
+    """PCB-ECO ROLE + full sheet-symbol ROLE must not double-parse one placement."""
+    pcb_pdn = {
+        "PDN_ROLE": "REGULATOR",
+        "PDN_GAIN": "1",
+        "PDN_OUT_P_NET": "VOUT",
+        "PDN_OUT_N_NET": "GND",
+        "PDN_IN_P_NET": "VIN",
+        "PDN_IN_N_NET": "GND",
+    }
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("VIN"), RawNet("VOUT")),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={"Comment": "buck"},
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="PWR",
+                child_filename="Pwr.SchDoc",
+                unique_id="SYM",
+                parameters={
+                    "PDN_U1_ROLE": "REGULATOR",
+                    "PDN_U1_V": "5V",
+                    "PDN_U1_GAIN": "1",
+                    "PDN_U1_OUT_P_NET": "VOUT",
+                    "PDN_U1_OUT_N_NET": "GND",
+                    "PDN_U1_IN_P_NET": "VIN",
+                    "PDN_U1_IN_N_NET": "GND",
+                },
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+                source_unique_id=r"\SYM\COMP",
+                parameters=dict(pcb_pdn),
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 2), _pad(0, "2", 0, 1),
+            _pad(0, "3", 1, 2), _pad(0, "4", 0, 3),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    regs = [d for d in result.directives if isinstance(d, RegulatorSpec)]
+    assert len(regs) == 1
+    assert regs[0].designator == "U1.1"
+    assert regs[0].voltage == pytest.approx(5.0)
+
+def test_pcb_eco_counts_toward_sheet_only_partial_coverage():
+    """Sibling covered by PCB-ECO is not flagged as missing sheet-only ROLE."""
+    pcb_pdn = {
+        "PDN_ROLE": "SINK",
+        "PDN_I": "100mA",
+        "PDN_P_NET": "+5V",
+        "PDN_N_NET": "GND",
+    }
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={"Comment": "USB"},
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={
+                    # Value-only override on the PCB-ECO instance.
+                    "PDN_J1_I": "1.5A",
+                },
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-B",
+                child_filename="Port.SchDoc",
+                unique_id="SYMB",
+                parameters={
+                    "PDN_J1_ROLE": "SINK",
+                    "PDN_J1_I": "2A",
+                    "PDN_J1_P_NET": "+5V",
+                    "PDN_J1_N_NET": "GND",
+                },
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+                parameters=dict(pcb_pdn),
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMB\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 1, 10), _pad(1, "2", 0, 11),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    assert not any("PDN covers" in w and "but not" in w for w in result.warnings)
+    sinks = {
+        d.designator: d
+        for d in result.directives if isinstance(d, SinkSpec)
+    }
+    assert set(sinks) == {"J1.1", "J1.2"}
+    assert sinks["J1.1"].current == pytest.approx(1.5)
+    assert sinks["J1.2"].current == pytest.approx(2.0)
+
+def test_pcb_eco_value_override_no_false_partial_coverage_warning():
+    """PCB-ECO + value-only sheet override must not warn about a bare sibling."""
+    pcb_pdn = {
+        "PDN_ROLE": "SINK",
+        "PDN_I": "100mA",
+        "PDN_P_NET": "+5V",
+        "PDN_N_NET": "GND",
+    }
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={"Comment": "USB"},
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={"PDN_J1_I": "1.5A"},
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-B",
+                child_filename="Port.SchDoc",
+                unique_id="SYMB",
+                parameters={},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+                parameters=dict(pcb_pdn),
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMB\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 1, 10), _pad(1, "2", 0, 11),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    assert not any("PDN covers" in w and "but not" in w for w in result.warnings)
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].designator == "J1.1"
+    assert sinks[0].current == pytest.approx(1.5)
 
 def test_series_supply_flow_uses_primary_net_not_alias_cross_product():
     """SERIES edges pair one primary expand per side (no alias fan-out)."""
@@ -5562,6 +4713,909 @@ def test_series_supply_flow_uses_primary_net_not_alias_cross_product():
         _iter_pdn_parameter_sources(proj), proj,
     ))
     assert edges == [(True, "LX.2", "VDD_12V")]
+
+def test_sheet_override_designator_with_trailing_letter():
+    """PDN_U12A_I targets designator U12A, not U12 + suffix A_I."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="U12A", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={"PDN_U12A_I": "1.8A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U12A.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOIC", source_designator="U12A",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].current == pytest.approx(1.8)
+
+def test_sheet_override_pdn_v_on_pcb_eco_regulator():
+    """PCB-ECO REGULATOR without PDN_V still takes PDN_<Des>_V from sheet symbol.
+
+    Matches the common pattern where ROLE/nets were ECO'd to the PCB and only
+    the per-instance output voltage lives on the parent sheet symbol.
+    """
+    pcb_pdn = {
+        "PDN_ROLE": "REGULATOR",
+        "PDN_GAIN": "1",
+        "PDN_OUT_P_NET": "VOUT",
+        "PDN_OUT_N_NET": "GND",
+        "PDN_IN_P_NET": "VIN",
+        "PDN_IN_N_NET": "GND",
+    }
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("VIN"), RawNet("VOUT.1"), RawNet("VOUT.2")),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={"Comment": "buck"},
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="PWR_5V",
+                child_filename="Pwr.SchDoc",
+                unique_id="SYM5V",
+                parameters={"PDN_U1_V": "5V"},
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="PWR_12V",
+                child_filename="Pwr.SchDoc",
+                unique_id="SYM12V",
+                parameters={"PDN_U1_V": "12 V"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+                source_unique_id=r"\SYM5V\COMP",
+                parameters=dict(pcb_pdn),
+            ),
+            RawPcbComponent(
+                designator="U1.2", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+                source_unique_id=r"\SYM12V\COMP",
+                parameters=dict(pcb_pdn),
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 2), _pad(0, "2", 0, 1),
+            _pad(0, "3", 1, 2), _pad(0, "4", 0, 3),
+            _pad(1, "1", 3, 10), _pad(1, "2", 0, 11),
+            _pad(1, "3", 1, 12), _pad(1, "4", 0, 13),
+        ),
+        compiled_netlist=_FakeNetlist(nets=[
+            _FakeNet(
+                name="VOUT.1", aliases=["VOUT"],
+                source_sheets=["pwr.schdoc"],
+                terminals=[_FakeTerminal("U1.1", "1")],
+            ),
+            _FakeNet(
+                name="VOUT.2", aliases=["VOUT"],
+                source_sheets=["pwr.schdoc"],
+                terminals=[_FakeTerminal("U1.2", "1")],
+            ),
+            _FakeNet(
+                name="VIN",
+                source_sheets=["pwr.schdoc"],
+                terminals=[
+                    _FakeTerminal("U1.1", "3"),
+                    _FakeTerminal("U1.2", "3"),
+                ],
+            ),
+            _FakeNet(
+                name="GND",
+                source_sheets=["pwr.schdoc"],
+                terminals=[
+                    _FakeTerminal("U1.1", "2"),
+                    _FakeTerminal("U1.1", "4"),
+                    _FakeTerminal("U1.2", "2"),
+                    _FakeTerminal("U1.2", "4"),
+                ],
+            ),
+        ]),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    regs = {
+        d.designator: d
+        for d in result.directives if isinstance(d, RegulatorSpec)
+    }
+    assert set(regs) == {"U1.1", "U1.2"}
+    assert regs["U1.1"].voltage == pytest.approx(5.0)
+    assert regs["U1.2"].voltage == pytest.approx(12.0)
+
+def test_sheet_override_role_changes_parser_per_instance():
+    """Per-placement PDN_J1_ROLE must dispatch SOURCE vs SINK correctly."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={"PDN_J1_I": "1A"},
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-B",
+                child_filename="Port.SchDoc",
+                unique_id="SYMB",
+                parameters={
+                    "PDN_J1_ROLE": "SOURCE",
+                    "PDN_J1_V": "5V",
+                    "PDN_J1_P_NET": "+5V",
+                    "PDN_J1_N_NET": "GND",
+                },
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMB\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 1, 5), _pad(1, "2", 0, 6),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    assert not any("unknown PDN parameter 'PDN_I'" in w for w in result.warnings)
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    sources = [d for d in result.directives if isinstance(d, SourceSpec)]
+    assert len(sinks) == 1 and sinks[0].designator == "J1.1"
+    assert sinks[0].current == pytest.approx(1.0)
+    assert len(sources) == 1 and sources[0].designator == "J1.2"
+    assert sources[0].voltage == pytest.approx(5.0)
+
+def test_sheet_override_role_strips_regulator_terminal_keys():
+    """Leaving REGULATOR via sheet ROLE drops OUT_/IN_ keys without noise."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V"), RawNet("VIN")),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_V": "3.3",
+                    "PDN_OUT_P_NET": "+5V",
+                    "PDN_OUT_N_NET": "GND",
+                    "PDN_IN_P_NET": "VIN",
+                    "PDN_IN_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="REG-A",
+                child_filename="Pwr.SchDoc",
+                unique_id="SYMA",
+                parameters={
+                    "PDN_U1_ROLE": "SINK",
+                    "PDN_U1_I": "0.5A",
+                    "PDN_U1_P_NET": "+5V",
+                    "PDN_U1_N_NET": "GND",
+                },
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOIC", source_designator="U1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(0, "3", 2, 2), _pad(0, "4", 0, 3),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    assert not any("OUT_P_NET" in w or "IN_P_NET" in w for w in result.warnings)
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].current == pytest.approx(0.5)
+
+def test_sheet_symbol_extract_to_parse_round_trip():
+    """OwnerIndex extract → RawSchSheetSymbol → parse_annotations."""
+    from fypa.altium.extract import _extract_sch_sheet_symbol
+
+    @dataclass
+    class _Param:
+        name: str
+        text: str
+        owner_index: int
+
+    @dataclass
+    class _Record:
+        unique_id: str = "SYMA"
+        index_in_sheet: int = 7
+        children: tuple = ()
+
+    @dataclass
+    class _Info:
+        record: _Record
+        designator: str = "CON-A"
+        file_name: str = "Port.SchDoc"
+        unique_id: str = "SYMA"
+
+    @dataclass
+    class _SchDoc:
+        parameters: list
+
+    sym = _extract_sch_sheet_symbol(
+        _Info(record=_Record()),
+        "Main.SchDoc",
+        schdoc=_SchDoc(parameters=[
+            _Param("PDN_J1_I", "1.5A", 7),
+            _Param("Manufacturer", "ACME", 7),
+        ]),
+    )
+    assert sym is not None
+    assert sym.parameters == {"PDN_J1_I": "1.5A"}
+
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(sym,),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].current == pytest.approx(1.5)
+
+def test_sheet_symbol_indexed_channel_override():
+    """``PDN_U1_1_I`` overrides only the indexed PDN channel on the child."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+3V3"), RawNet("+1V8")),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Chip.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "50mA",
+                    "PDN_P_NET": "+3V3",
+                    "PDN_N_NET": "GND",
+                    "PDN1_I": "10mA",
+                    "PDN1_P_NET": "+1V8",
+                    "PDN1_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CH",
+                child_filename="Chip.SchDoc",
+                unique_id="CHIPSYM",
+                parameters={"PDN_U1_1_I": "80mA"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+                source_unique_id=r"\CHIPSYM\U1UID",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 2, 1), _pad(0, "3", 0, 2),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = {
+        d.channel_index: d
+        for d in result.directives if isinstance(d, SinkSpec)
+    }
+    assert sinks[None].current == pytest.approx(0.05)
+    assert sinks[1].current == pytest.approx(0.08)
+
+def test_sheet_symbol_nested_uid_deepest_wins():
+    """Deeper UniqueID in SOURCEUNIQUEID overrides a shallower symbol."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="OUTER",
+                child_filename="Mid.SchDoc",
+                unique_id="OUTERUID",
+                parameters={"PDN_J1_I": "1A"},
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Mid.SchDoc",
+                sheet_name="INNER",
+                child_filename="Port.SchDoc",
+                unique_id="INNERUID",
+                parameters={"PDN_J1_I": "2A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\OUTERUID\INNERUID\COMP",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].current == pytest.approx(2.0)
+
+def test_sheet_symbol_only_directive_without_child_pdn_role():
+    """Full SINK directive can live entirely on the sheet symbol."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={"Comment": "USB"},
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={
+                    "PDN_J1_ROLE": "SINK",
+                    "PDN_J1_I": "1.2A",
+                    "PDN_J1_P_NET": "+5V",
+                    "PDN_J1_N_NET": "GND",
+                },
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].designator == "J1.1"
+    assert sinks[0].current == pytest.approx(1.2)
+
+def test_sheet_symbol_only_multi_instance_different_currents():
+    """Full sheet-symbol-only directive with different I per placement."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={"Comment": "USB"},
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={
+                    "PDN_J1_ROLE": "SINK",
+                    "PDN_J1_I": "1.5A",
+                    "PDN_J1_P_NET": "+5V",
+                    "PDN_J1_N_NET": "GND",
+                },
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-B",
+                child_filename="Port.SchDoc",
+                unique_id="SYMB",
+                parameters={
+                    "PDN_J1_ROLE": "SINK",
+                    "PDN_J1_I": "3A",
+                    "PDN_J1_P_NET": "+5V",
+                    "PDN_J1_N_NET": "GND",
+                },
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMB\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 1, 5), _pad(1, "2", 0, 6),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = {d.designator: d for d in result.directives if isinstance(d, SinkSpec)}
+    assert sinks["J1.1"].current == pytest.approx(1.5)
+    assert sinks["J1.2"].current == pytest.approx(3.0)
+
+def test_sheet_symbol_only_partial_coverage_warns():
+    """Full sheet-only on one placement, sibling unbound → warning."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={"Comment": "USB"},
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={
+                    "PDN_J1_ROLE": "SINK",
+                    "PDN_J1_I": "1.5A",
+                    "PDN_J1_P_NET": "+5V",
+                    "PDN_J1_N_NET": "GND",
+                },
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-B",
+                child_filename="Port.SchDoc",
+                unique_id="SYMB",
+                parameters={},  # no PDN — sibling uncovered
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMB\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 1, 5), _pad(1, "2", 0, 6),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert any(
+        "PDN covers" in w
+        and "J1.1 (sheet symbol)" in w
+        and "but not J1.2" in w
+        for w in result.warnings
+    )
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].designator == "J1.1"
+
+def test_sheet_symbol_override_absent_keeps_shared_child_current():
+    """Without sheet overrides, every instance inherits the child PDN_I."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "500mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMB\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 1, 5), _pad(1, "2", 0, 6),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 2
+    assert all(d.current == pytest.approx(0.5) for d in sinks)
+
+def test_sheet_symbol_override_different_currents_per_instance():
+    """Two sheet symbols override PDN_J1_I differently for J1.1 / J1.2."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("VBUS.1"), RawNet("VBUS.2")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "500mA",
+                    "PDN_P_NET": "VBUS",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("A4", "A1"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMAAAAA",
+                parameters={"PDN_J1_I": "1.5A"},
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-B",
+                child_filename="Port.SchDoc",
+                unique_id="SYMBBBBB",
+                parameters={"PDN_J1_I": "3A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMAAAAA\COMPUID1",
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMBBBBB\COMPUID1",
+            ),
+        ),
+        pads=(
+            _pad(0, "A4", 1), _pad(0, "A1", 0, 1),
+            _pad(1, "A4", 2, 10), _pad(1, "A1", 0, 11),
+        ),
+        compiled_netlist=_FakeNetlist(nets=[
+            _FakeNet(
+                name="VBUS.1", aliases=["VBUS"],
+                source_sheets=["port.schdoc"],
+                terminals=[_FakeTerminal("J1.1", "A4")],
+            ),
+            _FakeNet(
+                name="VBUS.2", aliases=["VBUS"],
+                source_sheets=["port.schdoc"],
+                terminals=[_FakeTerminal("J1.2", "A4")],
+            ),
+            _FakeNet(
+                name="GND",
+                source_sheets=["port.schdoc"],
+                terminals=[
+                    _FakeTerminal("J1.1", "A1"),
+                    _FakeTerminal("J1.2", "A1"),
+                ],
+            ),
+        ]),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = {d.designator: d for d in result.directives if isinstance(d, SinkSpec)}
+    assert set(sinks) == {"J1.1", "J1.2"}
+    assert sinks["J1.1"].current == pytest.approx(1.5)
+    assert sinks["J1.2"].current == pytest.approx(3.0)
+
+def test_sheet_symbol_override_via_hierarchical_path_fallback():
+    """When SOURCEUNIQUEID is empty, match sheet symbols via hierarchy path."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={"PDN_J1_I": "2.5A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id="",  # force fallback
+                source_hierarchical_path=r"main\CON-A",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].current == pytest.approx(2.5)
+
+def test_sheet_symbol_params_via_owner_index():
+    """Sheet-symbol PDN_* must be read from schdoc.parameters OwnerIndex.
+
+    altium_monkey does not put sheet-symbol parameters on ``symbol.children``.
+    """
+    from fypa.altium.extract import (
+        _extract_sch_sheet_symbol,
+        _parameters_owned_by_index,
+    )
+
+    @dataclass
+    class _Param:
+        name: str
+        text: str
+        owner_index: int
+
+    @dataclass
+    class _Record:
+        unique_id: str = "SYMUID"
+        index_in_sheet: int = 42
+        children: tuple = ()
+        sheet_name: object = None
+        file_name: object = None
+
+    @dataclass
+    class _Info:
+        record: _Record
+        designator: str = "CON-A"
+        file_name: str = "Port.SchDoc"
+        unique_id: str = "SYMUID"
+
+    @dataclass
+    class _SchDoc:
+        parameters: list
+
+    schdoc = _SchDoc(parameters=[
+        _Param("PDN_J1_I", "1.5A", 42),
+        _Param("PDN_J1_ROLE", "SINK", 42),
+        _Param("Design Item Id", "BOM-PART", 42),  # filtered out
+        _Param("Other", "x", 99),  # different owner — ignored
+    ])
+    owned = _parameters_owned_by_index(schdoc, 42)
+    assert owned["PDN_J1_I"] == "1.5A"
+    assert "Design Item Id" in owned  # raw owner lookup keeps all
+
+    info = _Info(record=_Record())
+    sym = _extract_sch_sheet_symbol(info, "Main.SchDoc", schdoc=schdoc)
+    assert sym is not None
+    assert sym.parameters == {"PDN_J1_I": "1.5A", "PDN_J1_ROLE": "SINK"}
+    assert "Design Item Id" not in sym.parameters
+    assert "Other" not in sym.parameters
+
+def test_sheet_symbol_repeat_slot_qualified_override():
+    """One REPEAT sheet symbol: ``PDN_J1_I.1`` / ``PDN_J1_I.2`` per channel."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("VBUS.1"), RawNet("VBUS.2")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "VBUS",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="Repeat(PORT,1,2)",
+                child_filename="Port.SchDoc",
+                unique_id="REPEATSYM",
+                parameters={
+                    "PDN_J1_I.1": "1A",
+                    "PDN_J1_I.2": "2A",
+                },
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\REPEATSYM\COMP",
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\REPEATSYM\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 2, 10), _pad(1, "2", 0, 11),
+        ),
+        compiled_netlist=_FakeNetlist(nets=[
+            _FakeNet(
+                name="VBUS.1", aliases=["VBUS"],
+                source_sheets=["port.schdoc"],
+                terminals=[_FakeTerminal("J1.1", "1")],
+            ),
+            _FakeNet(
+                name="VBUS.2", aliases=["VBUS"],
+                source_sheets=["port.schdoc"],
+                terminals=[_FakeTerminal("J1.2", "1")],
+            ),
+            _FakeNet(
+                name="GND",
+                source_sheets=["port.schdoc"],
+                terminals=[
+                    _FakeTerminal("J1.1", "2"),
+                    _FakeTerminal("J1.2", "2"),
+                ],
+            ),
+        ]),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = {d.designator: d for d in result.directives if isinstance(d, SinkSpec)}
+    assert sinks["J1.1"].current == pytest.approx(1.0)
+    assert sinks["J1.2"].current == pytest.approx(2.0)
+
+def test_sheet_symbol_repeat_slot_skipped_for_non_numeric_designator():
+    """Slot-qualified override warns when PCB designator has no .N suffix."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+5V",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="Repeat(PORT,1,2)",
+                child_filename="Port.SchDoc",
+                unique_id="REPEATSYM",
+                parameters={"PDN_J1_I.1": "2A"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1_CH1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\REPEATSYM\COMP",
+            ),
+        ),
+        pads=(_pad(0, "1", 1), _pad(0, "2", 0, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    # Override not applied — falls back to child default.
+    assert sinks[0].current == pytest.approx(0.1)
+    assert any(
+        "PDN_J1_I.1" in w and "no numeric channel suffix" in w
+        for w in result.warnings
+    )
 
 def test_smps_vin_expands_local_in_p_net_per_instance():
     """Local PDN_IN_P_NET (VDD_OUT) must resolve via instance expansion to Vin."""
@@ -5687,75 +5741,6 @@ def test_smps_vin_expands_local_in_p_net_per_instance():
     assert "U2.2" in regs
     assert regs["U2.2"].gain == pytest.approx(3.3 / (12.0 * 0.85))
 
-def test_autoinfer_series_vin_ignores_reversed_pad_order():
-    """Autoinfer SERIES copies Vin even when pad0 is the downstream net."""
-    proj = _minimal_proj(
-        nets=(RawNet("GND"), RawNet("VIN"), RawNet("VIN_L"), RawNet("VOUT")),
-        sch_components=(
-            RawSchComponent(
-                designator="J1", schdoc_name="Main.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SOURCE",
-                    "PDN_V": "12",
-                    "PDN_P_NET": "VIN",
-                    "PDN_N_NET": "GND",
-                },
-                pin_designators=("1", "2"),
-            ),
-            RawSchComponent(
-                designator="L1", schdoc_name="Main.SchDoc",
-                parameters={"PDN_ROLE": "SERIES", "PDN_R": "5m"},
-                pin_designators=("1", "2"),
-            ),
-            RawSchComponent(
-                designator="U1", schdoc_name="Main.SchDoc",
-                parameters={
-                    "PDN_ROLE": "REGULATOR",
-                    "PDN_V": "3.3",
-                    "PDN_REGULATOR_TYPE": "SMPS",
-                    "PDN_REGULATOR_EFFICIENCY": "0.9",
-                    "PDN_OUT_P_NET": "VOUT",
-                    "PDN_OUT_N_NET": "GND",
-                    "PDN_IN_P_NET": "VIN_L",
-                    "PDN_IN_N_NET": "GND",
-                },
-                pin_designators=("1", "2", "3", "4"),
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="CONN", source_designator="J1",
-            ),
-            RawPcbComponent(
-                designator="L1", center=Pt2D(5, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="IND", source_designator="L1",
-            ),
-            RawPcbComponent(
-                designator="U1", center=Pt2D(10, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="QFN", source_designator="U1",
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 1), _pad(0, "2", 0, 1),
-            # Reversed vs power flow: pad1=VIN_L (downstream), pad2=VIN (upstream)
-            _pad(1, "1", 2, 5), _pad(1, "2", 1, 6),
-            _pad(2, "1", 3, 10), _pad(2, "2", 0, 11),
-            _pad(2, "3", 2, 12), _pad(2, "4", 0, 13),
-        ),
-    )
-    supply_map = _collect_supply_voltages_by_net(
-        _iter_pdn_parameter_sources(proj), proj,
-    )
-    assert supply_map.get("VIN") == pytest.approx(12.0)
-    assert supply_map.get("VIN_L") == pytest.approx(12.0)
-
-    ann = parse_annotations(proj, enabled_layers=[1])
-    assert ann.ok, ann.errors
-    reg = next(d for d in ann.directives if isinstance(d, RegulatorSpec))
-    assert reg.gain == pytest.approx(3.3 / (12.0 * 0.9))
-
-
 def test_unplaced_series_does_not_emit_global_supply_edges():
     """SERIES without a PCB instance must not copy voltages between rails."""
     from fypa.altium.annotations import _iter_series_supply_flow_edges
@@ -5818,7 +5803,7 @@ def test_unplaced_series_does_not_emit_global_supply_edges():
     )
     sources = _iter_pdn_parameter_sources(proj)
     assert list(_iter_series_supply_flow_edges(sources, proj)) == []
-    supply_map = _collect_supply_voltages_by_net(sources, proj)
+    supply_map, _ = _collect_supply_voltages_by_net(sources, proj)
     assert supply_map.get("VIN") == pytest.approx(12.0)
     # Must not inherit 12 V from the unplaced SERIES VIN→VOUT edge.
     assert supply_map.get("VOUT") == pytest.approx(3.3)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -5754,3 +5754,71 @@ def test_autoinfer_series_vin_ignores_reversed_pad_order():
     assert ann.ok, ann.errors
     reg = next(d for d in ann.directives if isinstance(d, RegulatorSpec))
     assert reg.gain == pytest.approx(3.3 / (12.0 * 0.9))
+
+
+def test_unplaced_series_does_not_emit_global_supply_edges():
+    """SERIES without a PCB instance must not copy voltages between rails."""
+    from fypa.altium.annotations import _iter_series_supply_flow_edges
+
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("VIN"), RawNet("VOUT")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Main.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SOURCE",
+                    "PDN_V": "12",
+                    "PDN_P_NET": "VIN",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="L99", schdoc_name="Main.SchDoc",
+                # Explicit nets, but no PCB placement for L99.
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN_R": "5m",
+                    "PDN_P_NET": "VIN",
+                    "PDN_N_NET": "VOUT",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="U1", schdoc_name="Main.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_V": "3.3",
+                    "PDN_REGULATOR_TYPE": "SMPS",
+                    "PDN_REGULATOR_EFFICIENCY": "1",
+                    "PDN_OUT_P_NET": "VOUT",
+                    "PDN_OUT_N_NET": "GND",
+                    "PDN_IN_P_NET": "VIN",
+                    "PDN_IN_N_NET": "GND",
+                    "PDN_GAIN": "0.5",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="CONN", source_designator="J1",
+            ),
+            RawPcbComponent(
+                designator="U1", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 2, 10), _pad(1, "2", 0, 11),
+            _pad(1, "3", 1, 12), _pad(1, "4", 0, 13),
+        ),
+    )
+    sources = _iter_pdn_parameter_sources(proj)
+    assert list(_iter_series_supply_flow_edges(sources, proj)) == []
+    supply_map = _collect_supply_voltages_by_net(sources, proj)
+    assert supply_map.get("VIN") == pytest.approx(12.0)
+    # Must not inherit 12 V from the unplaced SERIES VIN→VOUT edge.
+    assert supply_map.get("VOUT") == pytest.approx(3.3)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -4341,11 +4341,13 @@ def test_multi_instance_lx_supply_map_infers_downstream_smps_vin():
             ),
             RawSchComponent(
                 designator="L1", schdoc_name="Pwr.SchDoc",
+                # Indexed-only SERIES (no part-wide PDN_ROLE) must still
+                # propagate Vin across the filter inductor.
                 parameters={
-                    "PDN_ROLE": "SERIES",
-                    "PDN_R": "6m",
-                    "PDN_P_NET": "LX",
-                    "PDN_N_NET": "VDD_OUT",
+                    "PDN1_ROLE": "SERIES",
+                    "PDN1_R": "6m",
+                    "PDN1_P_NET": "LX",
+                    "PDN1_N_NET": "VDD_OUT",
                 },
                 pin_designators=("1", "2"),
             ),

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -4307,6 +4307,186 @@ def test_pcb_eco_value_override_no_false_partial_coverage_warning():
     assert sinks[0].designator == "J1.1"
     assert sinks[0].current == pytest.approx(1.5)
 
+
+def test_multi_instance_lx_supply_map_infers_downstream_smps_vin():
+    """Shared local OUT=LX with different PDN_V must not drop Vin for rails.
+
+    Two regulator placements publish LX.1=5 V / LX.2=12 V; SERIES inductors
+    map LX→VDD_OUT to VDD_5V0 / VDD_12V; a downstream SMPS on VDD_12V infers
+    Vin without an explicit PDN_GAIN.
+    """
+    from fypa.altium.annotations import _expand_sheet_bound_parameter_sources
+
+    reg_params = {
+        "PDN_ROLE": "REGULATOR",
+        "PDN_REGULATOR_TYPE": "SMPS",
+        "PDN_REGULATOR_EFFICIENCY": "0.8",
+        "PDN_OUT_P_NET": "LX",
+        "PDN_OUT_N_NET": "GND",
+        "PDN_IN_P_NET": "VIN",
+        "PDN_IN_N_NET": "GND",
+    }
+    # nets: 0 GND, 1 VIN, 2 LX.1, 3 LX.2, 4 VDD_5V0, 5 VDD_12V, 6 VDD_3V3
+    proj = _minimal_proj(
+        nets=(
+            RawNet("GND"), RawNet("VIN"),
+            RawNet("LX.1"), RawNet("LX.2"),
+            RawNet("VDD_5V0"), RawNet("VDD_12V"), RawNet("VDD_3V3"),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={**reg_params, "PDN_V": "5V"},
+                pin_designators=("1", "2", "3", "4"),
+            ),
+            RawSchComponent(
+                designator="L1", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN_R": "6m",
+                    "PDN_P_NET": "LX",
+                    "PDN_N_NET": "VDD_OUT",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="U2", schdoc_name="Load.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_V": "3.3",
+                    "PDN_REGULATOR_TYPE": "SMPS",
+                    "PDN_REGULATOR_EFFICIENCY": "0.85",
+                    "PDN_OUT_P_NET": "VDD_3V3",
+                    "PDN_OUT_N_NET": "GND",
+                    "PDN_IN_P_NET": "VDD_12V",
+                    "PDN_IN_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+            RawSchComponent(
+                designator="J1", schdoc_name="Main.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SOURCE",
+                    "PDN_V": "24",
+                    "PDN_P_NET": "VIN",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="PWR_5V",
+                child_filename="Pwr.SchDoc",
+                unique_id="SYM5",
+                parameters={"PDN_U1_V": "5V"},
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="PWR_12V",
+                child_filename="Pwr.SchDoc",
+                unique_id="SYM12",
+                parameters={"PDN_U1_V": "12 V"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+                source_unique_id=r"\SYM5\COMP",
+                parameters=dict(reg_params),
+            ),
+            RawPcbComponent(
+                designator="U1.2", center=Pt2D(20, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+                source_unique_id=r"\SYM12\COMP",
+                parameters=dict(reg_params),
+            ),
+            RawPcbComponent(
+                designator="L1.1", center=Pt2D(5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="IND", source_designator="L1",
+                source_unique_id=r"\SYM5\L",
+            ),
+            RawPcbComponent(
+                designator="L1.2", center=Pt2D(25, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="IND", source_designator="L1",
+                source_unique_id=r"\SYM12\L",
+            ),
+            RawPcbComponent(
+                designator="U2", center=Pt2D(40, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U2",
+            ),
+            RawPcbComponent(
+                designator="J1", center=Pt2D(-10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="CONN", source_designator="J1",
+            ),
+        ),
+        pads=(
+            # U1.1: OUT on LX.1 (net 2), IN on VIN (1), GND (0)
+            _pad(0, "1", 2), _pad(0, "2", 0, 1),
+            _pad(0, "3", 1, 2), _pad(0, "4", 0, 3),
+            # U1.2: OUT on LX.2 (net 3)
+            _pad(1, "1", 3, 20), _pad(1, "2", 0, 21),
+            _pad(1, "3", 1, 22), _pad(1, "4", 0, 23),
+            # L1.1: LX.1 — VDD_5V0
+            _pad(2, "1", 2, 5), _pad(2, "2", 4, 6),
+            # L1.2: LX.2 — VDD_12V
+            _pad(3, "1", 3, 25), _pad(3, "2", 5, 26),
+            # U2: OUT VDD_3V3, IN VDD_12V
+            _pad(4, "1", 6, 40), _pad(4, "2", 0, 41),
+            _pad(4, "3", 5, 42), _pad(4, "4", 0, 43),
+            # J1 SOURCE
+            _pad(5, "1", 1, -10), _pad(5, "2", 0, -9),
+        ),
+        compiled_netlist=_FakeNetlist(nets=[
+            _FakeNet(
+                name="LX.1", aliases=["LX"],
+                source_sheets=["pwr.schdoc"],
+                terminals=[_FakeTerminal("U1.1", "1"), _FakeTerminal("L1.1", "1")],
+            ),
+            _FakeNet(
+                name="LX.2", aliases=["LX"],
+                source_sheets=["pwr.schdoc"],
+                terminals=[_FakeTerminal("U1.2", "1"), _FakeTerminal("L1.2", "1")],
+            ),
+            _FakeNet(
+                name="VDD_5V0", aliases=["VDD_OUT"],
+                source_sheets=["pwr.schdoc"],
+                terminals=[_FakeTerminal("L1.1", "2")],
+            ),
+            _FakeNet(
+                name="VDD_12V", aliases=["VDD_OUT"],
+                source_sheets=["pwr.schdoc"],
+                terminals=[_FakeTerminal("L1.2", "2")],
+            ),
+        ]),
+    )
+    result = AnnotationResult()
+    sources = _expand_sheet_bound_parameter_sources(
+        proj, _iter_pdn_parameter_sources(proj, result), result,
+    )
+    supply_map = _collect_supply_voltages_by_net(sources, proj)
+    assert "LX" not in supply_map  # ambiguous shared local dropped
+    assert supply_map.get("LX.1") == pytest.approx(5.0)
+    assert supply_map.get("LX.2") == pytest.approx(12.0)
+    assert supply_map.get("VDD_5V0") == pytest.approx(5.0)
+    assert supply_map.get("VDD_12V") == pytest.approx(12.0)
+
+    ann = parse_annotations(proj, enabled_layers=[1])
+    assert ann.ok, ann.errors
+    assert not any("cannot infer input voltage" in e for e in ann.errors)
+    regs = {
+        d.designator: d
+        for d in ann.directives if isinstance(d, RegulatorSpec)
+    }
+    assert "U2" in regs
+    # Vin=12, Vout=3.3, eta=0.85 -> gain = 3.3/(12*0.85)
+    assert regs["U2"].gain == pytest.approx(3.3 / (12.0 * 0.85))
+
+# --- retained from main/rebase base ---
+
+
 # --- retained from main/rebase base ---
 
 
@@ -4347,6 +4527,14 @@ def test_a_failed_page_map_does_not_discard_a_good_netlist():
 # --- P/N arbitration follow-ups ------------------------------------------------
 
 
+
+# --- P/N arbitration follow-ups ------------------------------------------------
+
+
+
+# --- P/N arbitration follow-ups ------------------------------------------------
+
+
 def test_alias_fallback_does_not_outrank_a_name_level_match():
     """"The pad's PCB net is on the row" is the criterion the PCB tier
     explicitly rejects, so an alias-only hit must not be stamped tier 0 and
@@ -4356,6 +4544,7 @@ def test_alias_fallback_does_not_outrank_a_name_level_match():
     )
 
     assert _LOCAL_NET_TIER_ALIAS > _LOCAL_NET_TIER_NAME > _LOCAL_NET_TIER_PCB
+
 
 
 
@@ -4387,6 +4576,7 @@ def test_arbitrate_overlapping_terminals_drops_weaker_side():
 
 
 
+
 def test_arbitrate_overlapping_terminals_equal_tier_errors():
     p = TerminalSpec(
         pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),),
@@ -4402,6 +4592,7 @@ def test_arbitrate_overlapping_terminals_equal_tier_errors():
     )
     assert p2 is None and n2 is None
     assert any("PDN_P_PINS" in e for e in result.errors)
+
 
 
 
@@ -4429,6 +4620,7 @@ def test_arbitrate_overlapping_terminals_ignores_same_pad_on_other_parts():
 
 
 
+
 def test_channel_token_must_come_from_flattening():
     """A part merely NAMED FB_2 is not channel 2 of FB, so an unrelated
     repeated sheet's VIN.2 must not match it."""
@@ -4441,6 +4633,11 @@ def test_channel_token_must_come_from_flattening():
     assert not _local_net_label_matches("VIN_3", "VIN", {"SW_3"})
     # An exact label still matches regardless.
     assert _local_net_label_matches("VIN", "VIN", {"FB_2"})
+
+# --- Sheet-symbol per-instance overrides ---
+
+# --- Sheet-symbol per-instance overrides --------------------------------------
+
 
 # --- Sheet-symbol per-instance overrides ---
 
@@ -4473,6 +4670,7 @@ def test_compile_falls_back_to_to_netlist_with_the_designs_own_options():
 
 
 
+
 def test_empty_side_errors_without_a_contradictory_warning():
     """Warning that pins were "dropped from N" and then that N is empty and
     the directive discarded reads as two contradictory log lines."""
@@ -4490,6 +4688,7 @@ def test_empty_side_errors_without_a_contradictory_warning():
 
 
 
+
 def test_equal_tier_error_points_at_the_remedy_that_works():
     shared = TerminalPin("1", 1, 0, Pt2D(0, 0))
     p = TerminalSpec(pins=(shared,), requested_net="VIN")
@@ -4504,6 +4703,7 @@ def test_equal_tier_error_points_at_the_remedy_that_works():
 
 
 
+
 def test_explicit_pin_override_outranks_a_net_name_match():
     """The overlap error tells the user to set PDN_*_PINS. That advice only
     works if an explicit pin list actually breaks the tie."""
@@ -4512,6 +4712,7 @@ def test_explicit_pin_override_outranks_a_net_name_match():
     )
 
     assert _LOCAL_NET_TIER_OVERRIDE < _LOCAL_NET_TIER_DIRECT
+
 
 
 
@@ -4526,6 +4727,7 @@ def test_harvest_falls_back_to_file_name_when_source_path_is_absent():
     assert _harvest_physical_sheet_names(compiled) == (
         ("physical:0", "Power.SchDoc"),
     )
+
 
 
 
@@ -4544,6 +4746,11 @@ def test_harvest_is_empty_on_a_release_without_physical_documents():
         SimpleNamespace(id=None, source_path="A.SchDoc"),
         SimpleNamespace(id="physical:0", source_path=None, file_name=None),
     ])) == ()
+
+
+
+# --- physical-page-map harvesting ---------------------------------------------
+
 
 
 
@@ -4570,12 +4777,14 @@ def test_harvest_prefers_source_path_over_bare_file_name():
 
 
 
+
 def test_local_net_label_matches_separator_agnostic_channel_token():
     """Net VIN_1 must match local VIN on designator R1.1 (._ separators differ)."""
     assert _local_net_label_matches("VIN_1", "VIN", {"R1", "R1.1"})
     assert _local_net_label_matches("VIN.1", "VIN", {"R1", "R1_1"})
     assert not _local_net_label_matches("VIN_L.1", "VIN", {"R1", "R1.1"})
     assert _local_net_label_matches("VIN_L.1", "VIN_L", {"R1", "R1.1"})
+
 
 
 
@@ -4587,6 +4796,7 @@ def test_lookup_inferred_vin_bounds_chain_length():
     )
     assert vin is None
     assert failure == "too_deep"
+
 
 
 
@@ -4612,6 +4822,7 @@ def test_lookup_inferred_vin_crosses_single_undirected_link():
 
 
 
+
 def test_lookup_inferred_vin_declared_rail_beats_series_ambiguity():
     """A rail whose voltage is declared resolves even when SERIES links to it
     disagree — parallel ferrites / ORing FETs / fuse+bypass all land here."""
@@ -4622,12 +4833,14 @@ def test_lookup_inferred_vin_declared_rail_beats_series_ambiguity():
 
 
 
+
 def test_lookup_inferred_vin_exact_match_without_series_walk():
     """Without a SERIES graph, only direct supply_map hits resolve."""
     supply_map = {"VDD_48V": 48.0, "VDD_12V": 12.0}
     assert _lookup_inferred_vin("VDD_48V", supply_map) == (48.0, None, 0)
     assert _lookup_inferred_vin("VDD_12V", supply_map) == (12.0, None, 0)
     assert _lookup_inferred_vin("VDD_48V_RP", supply_map) == (None, None, 0)
+
 
 
 
@@ -4646,6 +4859,7 @@ def test_lookup_inferred_vin_series_ambiguous_and_cycle():
 
 
 
+
 def test_lookup_inferred_vin_walks_series_upstream():
     supply_map = {"VDD_48V_IN": 48.0}
     graph = _SeriesVinGraph(
@@ -4655,6 +4869,7 @@ def test_lookup_inferred_vin_walks_series_upstream():
     assert _lookup_inferred_vin(
         "VDD_48V_RP", supply_map, graph=graph,
     ) == (48.0, None, 2)
+
 
 
 
@@ -4681,10 +4896,12 @@ def test_overlap_messages_name_pads_not_arbitration_keys():
 
 
 
+
 def test_plain_sheet_names_are_unaffected_by_the_page_id_path():
     assert _sheet_name_matches("Power.SchDoc", ["Power.SchDoc"])
     assert _sheet_name_matches("Power.SchDoc", ["SubA/Power.SchDoc"])
     assert not _sheet_name_matches("SubA/Power.SchDoc", ["SubB/Power.SchDoc"])
+
 
 
 
@@ -4698,6 +4915,7 @@ def test_regulator_smps_vin_does_not_warn_on_directly_declared_rail():
     )
     result = parse_annotations(proj, enabled_layers=[1])
     assert not any("SERIES hop(s) upstream" in w for w in result.warnings)
+
 
 
 
@@ -4715,6 +4933,7 @@ def test_regulator_smps_vin_resolves_under_merged_net_name():
     result = parse_annotations(proj, enabled_layers=[1], net_remap={4: 2})
     reg = next(d for d in result.directives if d.designator == "U5")
     assert abs(reg.gain - (12.0 / (48.0 * 0.8))) < 1e-6, result.errors
+
 
 
 
@@ -4816,6 +5035,7 @@ _SERIES_VIN_NETS = {
 
 
 
+
 def test_regulator_smps_vin_through_series_chain():
     """VIP-style: SOURCE -> SERIES -> SERIES -> SMPS on downstream net."""
     proj = _minimal_proj(
@@ -4905,6 +5125,7 @@ def test_regulator_smps_vin_through_series_chain():
 
 
 
+
 def test_regulator_smps_vin_warns_when_inferred_through_series_chain():
     """Vin taken from a walked chain is a guess about which leg is the power
     path — a sense or bleed resistor produces a silently wrong gain, so say so."""
@@ -4916,6 +5137,7 @@ def test_regulator_smps_vin_warns_when_inferred_through_series_chain():
     assert any(
         "was inferred 1 SERIES hop(s) upstream" in w for w in result.warnings
     ), result.warnings
+
 
 
 
@@ -4947,6 +5169,7 @@ def test_resolve_local_net_pins_pcb_confirmed_beats_name():
 
 
 
+
 def test_resolve_local_net_pins_physical_source_sheet():
     physical = (
         "physical:0:logical:0:main.SchDoc:child:1:sheet_symbol:U_PWR"
@@ -4968,6 +5191,7 @@ def test_resolve_local_net_pins_physical_source_sheet():
         netlist, "U1", "Power.SchDoc", "+3V3", sheet_map=_sheet_map(proj),
     )
     assert pins == ["14"]
+
 
 
 
@@ -5007,6 +5231,7 @@ def test_resolve_local_net_pins_prefers_name_over_shared_alias():
     )
     assert n_pins == ["1"]
     assert n_tier == _LOCAL_NET_TIER_NAME
+
 
 
 
@@ -5059,6 +5284,7 @@ def test_series_shared_alias_resolves_disjoint_p_n():
 
 
 
+
 def test_series_upstream_map_auto_inferred_link_is_direction_agnostic():
     """_autoinfer_2pin_nets takes P/N from raw pad order, so the Vin result must
     not change when the two RawPad entries are swapped."""
@@ -5079,6 +5305,7 @@ def test_series_upstream_map_auto_inferred_link_is_direction_agnostic():
 
 
 
+
 def test_series_upstream_map_reads_indexed_role_only_channels():
     """A part whose SERIES channels come only from PDN<n>_ROLE overrides still
     contributes its links — _is_pdn_annotated admits it, so the graph must too."""
@@ -5092,6 +5319,7 @@ def test_series_upstream_map_reads_indexed_role_only_channels():
     assert graph.upstream == {
         "VDD_48V": "VDD_48V_IN", "VDD_12V": "VDD_48V",
     }
+
 
 
 
@@ -5112,6 +5340,7 @@ def test_series_upstream_map_reads_pin_specified_channels():
     result = parse_annotations(proj, enabled_layers=[1])
     reg = next(d for d in result.directives if d.designator == "U5")
     assert abs(reg.gain - (12.0 / (48.0 * 0.8))) < 1e-6
+
 
 
 
@@ -5146,6 +5375,7 @@ def test_series_upstream_map_skips_merged_short_self_edges():
 
 
 
+
 def test_sheet_map_keeps_same_named_sheets_in_different_directories_apart():
     """Harvesting the bare leaf would collapse these onto one name, which is
     the collision _sheet_name_matches exists to prevent."""
@@ -5161,6 +5391,7 @@ def test_sheet_map_keeps_same_named_sheets_in_different_directories_apart():
 
 
 
+
 def test_sheet_name_matches_physical_page_id_via_map():
     """altium_monkey ≥ 2026.7 emits physical page ids in source_sheets."""
     physical = (
@@ -5173,6 +5404,7 @@ def test_sheet_name_matches_physical_page_id_via_map():
     smap = _sheet_map(proj)
     assert _sheet_name_matches("Power.SchDoc", [physical], sheet_map=smap)
     assert not _sheet_name_matches("Other.SchDoc", [physical], sheet_map=smap)
+
 
 
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -5561,4 +5561,196 @@ def test_series_supply_flow_uses_primary_net_not_alias_cross_product():
     edges = list(_iter_series_supply_flow_edges(
         _iter_pdn_parameter_sources(proj), proj,
     ))
-    assert edges == [("LX.2", "VDD_12V")]
+    assert edges == [(True, "LX.2", "VDD_12V")]
+
+def test_smps_vin_expands_local_in_p_net_per_instance():
+    """Local PDN_IN_P_NET (VDD_OUT) must resolve via instance expansion to Vin."""
+    from fypa.altium.annotations import _expand_sheet_bound_parameter_sources
+
+    reg_params = {
+        "PDN_ROLE": "REGULATOR",
+        "PDN_REGULATOR_TYPE": "SMPS",
+        "PDN_REGULATOR_EFFICIENCY": "0.8",
+        "PDN_OUT_P_NET": "LX",
+        "PDN_OUT_N_NET": "GND",
+        "PDN_IN_P_NET": "VIN",
+        "PDN_IN_N_NET": "GND",
+    }
+    proj = _minimal_proj(
+        nets=(
+            RawNet("GND"), RawNet("VIN"),
+            RawNet("LX.2"), RawNet("VDD_12V"), RawNet("VDD_3V3"),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={**reg_params, "PDN_V": "12V"},
+                pin_designators=("1", "2", "3", "4"),
+            ),
+            RawSchComponent(
+                designator="L1", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN_R": "6m",
+                    "PDN_P_NET": "LX",
+                    "PDN_N_NET": "VDD_OUT",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="U2", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_V": "3.3",
+                    "PDN_REGULATOR_TYPE": "SMPS",
+                    "PDN_REGULATOR_EFFICIENCY": "0.85",
+                    "PDN_OUT_P_NET": "VDD_3V3",
+                    "PDN_OUT_N_NET": "GND",
+                    # Local child-sheet label — must expand to VDD_12V for Vin.
+                    "PDN_IN_P_NET": "VDD_OUT",
+                    "PDN_IN_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+            RawSchComponent(
+                designator="J1", schdoc_name="Main.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SOURCE",
+                    "PDN_V": "24",
+                    "PDN_P_NET": "VIN",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="PWR_12V",
+                child_filename="Pwr.SchDoc",
+                unique_id="SYM12",
+                parameters={"PDN_U1_V": "12 V"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1.2", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+                source_unique_id=r"\SYM12\COMP",
+                parameters=dict(reg_params),
+            ),
+            RawPcbComponent(
+                designator="L1.2", center=Pt2D(5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="IND", source_designator="L1",
+                source_unique_id=r"\SYM12\L",
+            ),
+            RawPcbComponent(
+                designator="U2.2", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U2",
+                source_unique_id=r"\SYM12\U2",
+            ),
+            RawPcbComponent(
+                designator="J1", center=Pt2D(-10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="CONN", source_designator="J1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 2), _pad(0, "2", 0, 1),
+            _pad(0, "3", 1, 2), _pad(0, "4", 0, 3),
+            _pad(1, "1", 2, 5), _pad(1, "2", 3, 6),
+            _pad(2, "1", 4, 10), _pad(2, "2", 0, 11),
+            _pad(2, "3", 3, 12), _pad(2, "4", 0, 13),
+            _pad(3, "1", 1, -10), _pad(3, "2", 0, -9),
+        ),
+        compiled_netlist=_FakeNetlist(nets=[
+            _FakeNet(
+                name="LX.2", aliases=["LX"],
+                source_sheets=["pwr.schdoc"],
+                terminals=[_FakeTerminal("U1.2", "1"), _FakeTerminal("L1.2", "1")],
+            ),
+            _FakeNet(
+                name="VDD_12V", aliases=["VDD_OUT"],
+                source_sheets=["pwr.schdoc"],
+                terminals=[
+                    _FakeTerminal("L1.2", "2"), _FakeTerminal("U2.2", "3"),
+                ],
+            ),
+        ]),
+    )
+    ann = parse_annotations(proj, enabled_layers=[1])
+    assert ann.ok, ann.errors
+    assert not any("cannot infer input voltage" in e for e in ann.errors)
+    regs = {
+        d.designator: d
+        for d in ann.directives if isinstance(d, RegulatorSpec)
+    }
+    assert "U2.2" in regs
+    assert regs["U2.2"].gain == pytest.approx(3.3 / (12.0 * 0.85))
+
+def test_autoinfer_series_vin_ignores_reversed_pad_order():
+    """Autoinfer SERIES copies Vin even when pad0 is the downstream net."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("VIN"), RawNet("VIN_L"), RawNet("VOUT")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Main.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SOURCE",
+                    "PDN_V": "12",
+                    "PDN_P_NET": "VIN",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="L1", schdoc_name="Main.SchDoc",
+                parameters={"PDN_ROLE": "SERIES", "PDN_R": "5m"},
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="U1", schdoc_name="Main.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_V": "3.3",
+                    "PDN_REGULATOR_TYPE": "SMPS",
+                    "PDN_REGULATOR_EFFICIENCY": "0.9",
+                    "PDN_OUT_P_NET": "VOUT",
+                    "PDN_OUT_N_NET": "GND",
+                    "PDN_IN_P_NET": "VIN_L",
+                    "PDN_IN_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="CONN", source_designator="J1",
+            ),
+            RawPcbComponent(
+                designator="L1", center=Pt2D(5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="IND", source_designator="L1",
+            ),
+            RawPcbComponent(
+                designator="U1", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            # Reversed vs power flow: pad1=VIN_L (downstream), pad2=VIN (upstream)
+            _pad(1, "1", 2, 5), _pad(1, "2", 1, 6),
+            _pad(2, "1", 3, 10), _pad(2, "2", 0, 11),
+            _pad(2, "3", 2, 12), _pad(2, "4", 0, 13),
+        ),
+    )
+    supply_map = _collect_supply_voltages_by_net(
+        _iter_pdn_parameter_sources(proj), proj,
+    )
+    assert supply_map.get("VIN") == pytest.approx(12.0)
+    assert supply_map.get("VIN_L") == pytest.approx(12.0)
+
+    ann = parse_annotations(proj, enabled_layers=[1])
+    assert ann.ok, ann.errors
+    reg = next(d for d in ann.directives if isinstance(d, RegulatorSpec))
+    assert reg.gain == pytest.approx(3.3 / (12.0 * 0.9))

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -23,19 +23,11 @@ from fypa.altium.annotations import (
     SourceSpec,
     TerminalPin,
     TerminalSpec,
-    _LOCAL_NET_TIER_ALIAS,
-    _LOCAL_NET_TIER_NAME,
-    _LOCAL_NET_TIER_PCB,
-    _arbitrate_overlapping_terminals,
-    _collect_series_upstream_map,
     _collect_supply_voltages_by_net,
     _iter_pdn_parameter_sources,
     _iter_series_bridge_pairs,
     _union_series_bridge_net_indices,
     _lookup_inferred_vin,
-    _local_net_label_matches,
-    _SeriesVinGraph,
-    _SERIES_VIN_MAX_HOPS,
     _require_value,
     _resolve_local_net_pins,
     _resolve_terminal,
@@ -378,7 +370,7 @@ def test_resolve_local_net_pins_finds_alias_on_sheet():
             terminals=[_FakeTerminal("U1", "14"), _FakeTerminal("C1", "1")],
         ),
     ])
-    pins, _tier = _resolve_local_net_pins(netlist, "U1", "Power.SchDoc", "+3V3")
+    pins = _resolve_local_net_pins(netlist, "U1", "Power.SchDoc", "+3V3")
     assert pins == ["14"]
 
 
@@ -402,7 +394,7 @@ def test_resolve_local_net_pins_matches_multichannel_mangled_alias():
             ],
         ),
     ])
-    pins, _tier = _resolve_local_net_pins(
+    pins = _resolve_local_net_pins(
         netlist, "J3", "SL8_Module.SchDoc", "S00A",
         pcb_designator="J3_SL8M7",
     )
@@ -421,7 +413,7 @@ def test_resolve_local_net_pins_mangled_alias_is_channel_scoped():
             terminals=[_FakeTerminal("J3_SL8M7", "29")],
         ),
     ])
-    pins, _tier = _resolve_local_net_pins(
+    pins = _resolve_local_net_pins(
         netlist, "J3", "SL8_Module.SchDoc", "S00A",
         pcb_designator="J3_SL8M7",
     )
@@ -466,12 +458,12 @@ def test_resolve_terminal_local_net_per_channel_instance():
         compiled_netlist=netlist,
     )
     warnings: list[str] = []
-    spec0, err0, _t0 = _resolve_terminal(
+    spec0, err0 = _resolve_terminal(
         proj, 0, "+3V3", None, [1], "SINK P",
         warnings=warnings,
         sch_lookup_designator="U1", schdoc_name="Child.SchDoc",
     )
-    spec1, err1, _t1 = _resolve_terminal(
+    spec1, err1 = _resolve_terminal(
         proj, 1, "+3V3", None, [1], "SINK P",
         warnings=warnings,
         sch_lookup_designator="U1", schdoc_name="Child.SchDoc",
@@ -870,10 +862,7 @@ def test_bridge_pairs_indexed_series_nets():
             ),
         ),
     )
-    pairs = {
-        (p, n) for _idx, p, n, _directed
-        in _iter_series_bridge_pairs([source], proj)
-    }
+    pairs = {(p, n) for _idx, p, n in _iter_series_bridge_pairs([source], proj)}
     assert pairs == {("RAIL_A", "RAIL_B"), ("RAIL_C", "RAIL_D")}
 
 
@@ -890,92 +879,6 @@ def test_sheet_name_matches_full_path_not_basename_collision():
         "Power.SchDoc",
         ["SubB/Power.SchDoc"],
     )
-
-
-def _sheet_map(proj):
-    from fypa.altium.annotations import _physical_sheet_file_map
-    return _physical_sheet_file_map(proj)
-
-
-def test_sheet_name_matches_physical_page_id_via_map():
-    """altium_monkey ≥ 2026.7 emits physical page ids in source_sheets."""
-    physical = (
-        "physical:0:logical:0:main.SchDoc:child:1:sheet_symbol:U_PWR"
-        ":sheet:power.SchDoc"
-    )
-    proj = _minimal_proj(
-        physical_sheet_names=((physical, "Power.SchDoc"),),
-    )
-    smap = _sheet_map(proj)
-    assert _sheet_name_matches("Power.SchDoc", [physical], sheet_map=smap)
-    assert not _sheet_name_matches("Other.SchDoc", [physical], sheet_map=smap)
-
-
-def test_sheet_map_keeps_same_named_sheets_in_different_directories_apart():
-    """Harvesting the bare leaf would collapse these onto one name, which is
-    the collision _sheet_name_matches exists to prevent."""
-    page_a = "physical:0:logical:0:SubA/Power.SchDoc"
-    page_b = "physical:1:logical:1:SubB/Power.SchDoc"
-    proj = _minimal_proj(physical_sheet_names=(
-        (page_a, "SubA/Power.SchDoc"),
-        (page_b, "SubB/Power.SchDoc"),
-    ))
-    smap = _sheet_map(proj)
-    assert _sheet_name_matches("SubA/Power.SchDoc", [page_a], sheet_map=smap)
-    assert not _sheet_name_matches("SubA/Power.SchDoc", [page_b], sheet_map=smap)
-
-
-def test_unmapped_physical_page_id_is_unknown_not_guessed():
-    """A child page id embeds its PARENT's logical id, so scanning it for a
-    ``*.SchDoc`` token yields the root sheet — which both hides real matches
-    and invents false ones. An unmapped id must read as unknown provenance,
-    degrading to the permissive path rather than binding to a guess."""
-    from fypa.altium.annotations import _logical_schdoc_name
-
-    child = (
-        "physical:0:logical:0:main.SchDoc:child:logical:0:main.SchDoc"
-        ":sheet_symbol:UID-ABC:1"
-    )
-    assert _logical_schdoc_name(child, {}) is None
-    # Not "matches the root sheet", and not a hard reject either: with no
-    # usable provenance the net is accepted the same way one with no
-    # source_sheets at all is.
-    assert _sheet_name_matches("Power.SchDoc", [child])
-    assert _sheet_name_matches("main.SchDoc", [child])
-    # …but a page the map DOES cover still discriminates.
-    proj = _minimal_proj(physical_sheet_names=((child, "Power.SchDoc"),))
-    smap = _sheet_map(proj)
-    assert _sheet_name_matches("Power.SchDoc", [child], sheet_map=smap)
-    assert not _sheet_name_matches("main.SchDoc", [child], sheet_map=smap)
-
-
-def test_plain_sheet_names_are_unaffected_by_the_page_id_path():
-    assert _sheet_name_matches("Power.SchDoc", ["Power.SchDoc"])
-    assert _sheet_name_matches("Power.SchDoc", ["SubA/Power.SchDoc"])
-    assert not _sheet_name_matches("SubA/Power.SchDoc", ["SubB/Power.SchDoc"])
-
-
-def test_resolve_local_net_pins_physical_source_sheet():
-    physical = (
-        "physical:0:logical:0:main.SchDoc:child:1:sheet_symbol:U_PWR"
-        ":sheet:power.SchDoc"
-    )
-    netlist = _FakeNetlist(nets=[
-        _FakeNet(
-            name="Sheet1_+3V3",
-            aliases=["+3V3"],
-            source_sheets=[physical],
-            terminals=[_FakeTerminal("U1", "14"), _FakeTerminal("C1", "1")],
-        ),
-    ])
-    proj = _minimal_proj(
-        physical_sheet_names=((physical, "Power.SchDoc"),),
-        compiled_netlist=netlist,
-    )
-    pins, _tier = _resolve_local_net_pins(
-        netlist, "U1", "Power.SchDoc", "+3V3", sheet_map=_sheet_map(proj),
-    )
-    assert pins == ["14"]
 
 
 def test_pcb_sourced_local_net_scoped_per_instance():
@@ -1131,7 +1034,7 @@ def test_resolve_local_net_pins_dot_channel_alias():
             ],
         ),
     ])
-    pins, _tier = _resolve_local_net_pins(
+    pins = _resolve_local_net_pins(
         netlist, "J3", "Child.SchDoc", "S00A",
         pcb_designator="J3.4",
     )
@@ -1147,7 +1050,7 @@ def test_resolve_local_net_pins_dot_channel_alias_scoped():
             terminals=[_FakeTerminal("J3.4", "29")],
         ),
     ])
-    pins, _tier = _resolve_local_net_pins(
+    pins = _resolve_local_net_pins(
         netlist, "J3", "Child.SchDoc", "S00A",
         pcb_designator="J3.4",
     )
@@ -1241,7 +1144,7 @@ def test_variant_alias_pattern_via_pad_netlist():
         pads=(_pad(0, "1", 0, 0), _pad(0, "2", 1, 1)),
         compiled_netlist=netlist,
     )
-    spec, errors, _tier = _resolve_terminal(
+    spec, errors = _resolve_terminal(
         proj, 0, "MDI.TD_P", None, [1], "SERIES P",
         sch_lookup_designator="R1", schdoc_name="eth.schdoc",
     )
@@ -1286,9 +1189,9 @@ def test_alias_fallback_no_cross_channel_family_leak():
     )
     with patch(
         "fypa.altium.annotations._resolve_local_net_pins",
-        return_value=([], 2),
+        return_value=[],
     ):
-        spec, errors, _tier = _resolve_terminal(
+        spec, errors = _resolve_terminal(
             proj, 0, "+3V3", None, [1], "SINK P",
             sch_lookup_designator="U1", schdoc_name="child2.schdoc",
         )
@@ -1322,9 +1225,9 @@ def test_alias_fallback_flattened_terminal_designator():
     )
     with patch(
         "fypa.altium.annotations._resolve_local_net_pins",
-        return_value=([], 2),
+        return_value=[],
     ):
-        spec, errors, _tier = _resolve_terminal(
+        spec, errors = _resolve_terminal(
             proj, 0, "S00A", None, [1], "SINK P",
             sch_lookup_designator="J3", schdoc_name="Child.SchDoc",
         )
@@ -1532,7 +1435,7 @@ def test_resolve_terminal_no_double_suffix_on_qualified_net():
         pads=(_pad(0, "2", 0, 0),),
         compiled_netlist=None,
     )
-    spec, errors, _tier = _resolve_terminal(
+    spec, errors = _resolve_terminal(
         proj, 0, "VCC_EFUSE.4", None, [1], "SERIES N",
     )
     assert not errors
@@ -1554,7 +1457,7 @@ def test_resolve_terminal_degraded_suffix_guess_warns():
         compiled_netlist=None,
     )
     warnings: list[str] = []
-    spec, errors, _tier = _resolve_terminal(
+    spec, errors = _resolve_terminal(
         proj, 0, "VCC_EFUSE", None, [1], "SERIES N", warnings=warnings,
     )
     assert not errors
@@ -1594,7 +1497,7 @@ def test_local_fallback_skips_no_net_pad():
         ),
         compiled_netlist=netlist,
     )
-    spec, errors, _tier = _resolve_terminal(
+    spec, errors = _resolve_terminal(
         proj, 0, "+3V3", None, [1], "SINK P",
         sch_lookup_designator="U1", schdoc_name="Power.SchDoc",
     )
@@ -1603,194 +1506,6 @@ def test_local_fallback_skips_no_net_pad():
     assert len(spec.pins) == 1
     assert spec.pins[0].pad_designator == "2"
     assert spec.pins[0].net_index == 1
-
-
-def test_local_net_label_matches_separator_agnostic_channel_token():
-    """Net VIN_1 must match local VIN on designator R1.1 (._ separators differ)."""
-    assert _local_net_label_matches("VIN_1", "VIN", {"R1", "R1.1"})
-    assert _local_net_label_matches("VIN.1", "VIN", {"R1", "R1_1"})
-    assert not _local_net_label_matches("VIN_L.1", "VIN", {"R1", "R1.1"})
-    assert _local_net_label_matches("VIN_L.1", "VIN_L", {"R1", "R1.1"})
-
-
-def test_resolve_local_net_pins_prefers_name_over_shared_alias():
-    """Two nets sharing bare alias VIN: keep only the channel name-level match.
-
-    Models the multi-channel case where both sides of a SERIES element carry
-    the same local alias in the compiled netlist. The P label VIN must resolve
-    to pin 2 (net VIN_1) and not also claim pin 1 (net VIN_L.1).
-    """
-    netlist = _FakeNetlist(nets=[
-        _FakeNet(
-            name="VIN_1",
-            aliases=["VIN", "VIN.1"],
-            source_sheets=["Supply.SchDoc"],
-            terminals=[_FakeTerminal("R1.1", "2")],
-        ),
-        _FakeNet(
-            name="VIN_L.1",
-            aliases=["VIN", "VIN.1", "VIN.2"],
-            source_sheets=["Supply.SchDoc"],
-            terminals=[_FakeTerminal("R1.1", "1")],
-        ),
-    ])
-    pins, tier = _resolve_local_net_pins(
-        netlist, "R1", "Supply.SchDoc", "VIN",
-        pcb_designator="R1.1",
-        routed_pin_keys={"1", "2"},
-    )
-    assert pins == ["2"]
-    assert tier == _LOCAL_NET_TIER_NAME
-
-    n_pins, n_tier = _resolve_local_net_pins(
-        netlist, "R1", "Supply.SchDoc", "VIN_L",
-        pcb_designator="R1.1",
-        routed_pin_keys={"1", "2"},
-    )
-    assert n_pins == ["1"]
-    assert n_tier == _LOCAL_NET_TIER_NAME
-
-
-def test_resolve_local_net_pins_pcb_confirmed_beats_name():
-    """When PCB net confirms a row, prefer that tier over bare name matches."""
-    netlist = _FakeNetlist(nets=[
-        _FakeNet(
-            name="OTHER",
-            aliases=["VIN"],
-            source_sheets=["Supply.SchDoc"],
-            terminals=[_FakeTerminal("R1.1", "2")],
-        ),
-        _FakeNet(
-            name="VIN_1",
-            aliases=["VIN"],
-            source_sheets=["Supply.SchDoc"],
-            terminals=[_FakeTerminal("R1.1", "1")],
-        ),
-    ])
-    pins, tier = _resolve_local_net_pins(
-        netlist, "R1", "Supply.SchDoc", "VIN",
-        pcb_designator="R1.1",
-        routed_pin_keys={"1", "2"},
-        pcb_net_by_pin={"1": "VIN_1", "2": "VOUT"},
-    )
-    # Pin 1 is PCB-confirmed (VIN_1 on the row); pin 2 is alias-only → drop it.
-    assert pins == ["1"]
-    assert tier == _LOCAL_NET_TIER_PCB
-
-
-def test_series_shared_alias_resolves_disjoint_p_n():
-    """SERIES with local VIN / VIN_L must not short both pads of a 2-pin part."""
-    netlist = _FakeNetlist(nets=[
-        _FakeNet(
-            name="VIN_1",
-            aliases=["VIN", "VIN.1"],
-            source_sheets=["Supply.SchDoc"],
-            terminals=[_FakeTerminal("R1.1", "2")],
-        ),
-        _FakeNet(
-            name="VIN_L.1",
-            aliases=["VIN", "VIN.1"],
-            source_sheets=["Supply.SchDoc"],
-            terminals=[_FakeTerminal("R1.1", "1")],
-        ),
-    ])
-    proj = _minimal_proj(
-        nets=(RawNet("VIN_1"), RawNet("VIN_L.1")),
-        pcb_components=(
-            RawPcbComponent(
-                designator="R1.1", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="1005R", source_designator="R1",
-                parameters={
-                    "PDN_ROLE": "SERIES",
-                    "PDN_R": "10m",
-                    "PDN_P_NET": "VIN",
-                    "PDN_N_NET": "VIN_L",
-                },
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 1, 0),  # VIN_L.1
-            _pad(0, "2", 0, 1),  # VIN_1
-        ),
-        compiled_netlist=netlist,
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    series = [d for d in result.directives if isinstance(d, ResistorSpec)]
-    assert len(series) == 1
-    r = series[0]
-    p_nets = {p.net_index for p in r.p.pins}
-    n_nets = {p.net_index for p in r.n.pins}
-    assert p_nets == {0}
-    assert n_nets == {1}
-    assert p_nets.isdisjoint(n_nets)
-
-
-def test_arbitrate_overlapping_terminals_drops_weaker_side():
-    p = TerminalSpec(
-        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),
-              TerminalPin("2", 1, 1, Pt2D(1, 0))),
-        requested_net="VIN",
-        resolved_via_local=True,
-    )
-    n = TerminalSpec(
-        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),),
-        requested_net="VIN_L",
-        resolved_via_local=True,
-    )
-    result = AnnotationResult()
-    p2, n2 = _arbitrate_overlapping_terminals(
-        p, n, _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_NAME, "SERIES on R1.1", result,
-    )
-    assert p2 is not None and n2 is not None
-    assert {pin.pad_designator for pin in p2.pins} == {"2"}
-    assert {pin.pad_designator for pin in n2.pins} == {"1"}
-    assert any("both matched pin(s)" in w for w in result.warnings)
-    # The pad designator, not the internal "R1.1:1" arbitration key: the
-    # message tells the user to set PDN_*_PINS, which matches on pad names.
-    assert any("kept on N" in w and "dropped from P" in w
-               for w in result.warnings)
-    assert not result.errors
-
-
-def test_arbitrate_overlapping_terminals_equal_tier_errors():
-    p = TerminalSpec(
-        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),),
-        requested_net="VIN",
-    )
-    n = TerminalSpec(
-        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),),
-        requested_net="VIN_L",
-    )
-    result = AnnotationResult()
-    p2, n2 = _arbitrate_overlapping_terminals(
-        p, n, _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_ALIAS, "SERIES on R1", result,
-    )
-    assert p2 is None and n2 is None
-    assert any("PDN_P_PINS" in e for e in result.errors)
-
-
-def test_arbitrate_overlapping_terminals_ignores_same_pad_on_other_parts():
-    """Banana-jack style: pad '1' on J2 vs pad '1' on J3 is not an overlap."""
-    p = TerminalSpec(
-        pins=(TerminalPin(
-            "1", 1, 0, Pt2D(0, 0), component_designator="J2",
-        ),),
-        requested_net="+5V",
-    )
-    n = TerminalSpec(
-        pins=(TerminalPin(
-            "1", 1, 1, Pt2D(10, 0), component_designator="J3",
-        ),),
-        requested_net="GND",
-    )
-    result = AnnotationResult()
-    p2, n2 = _arbitrate_overlapping_terminals(
-        p, n, _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_ALIAS, "SOURCE on J2", result,
-    )
-    assert p2 is p and n2 is n
-    assert not result.errors
-    assert not result.warnings
 
 
 def _regulator_proj_with_source(**extra_regulator_params):
@@ -1885,478 +1600,11 @@ def test_regulator_explicit_gain_overrides_type():
     assert any("overrides" in w for w in result.warnings)
 
 
-def test_lookup_inferred_vin_exact_match_without_series_walk():
-    """Without a SERIES graph, only direct supply_map hits resolve."""
+def test_lookup_inferred_vin_ignores_series_bridge_groups():
+    """Sense paths through GND must not make Vin ambiguous (project_a / PDN5_R)."""
     supply_map = {"VDD_48V": 48.0, "VDD_12V": 12.0}
-    assert _lookup_inferred_vin("VDD_48V", supply_map) == (48.0, None, 0)
-    assert _lookup_inferred_vin("VDD_12V", supply_map) == (12.0, None, 0)
-    assert _lookup_inferred_vin("VDD_48V_RP", supply_map) == (None, None, 0)
-
-
-def test_lookup_inferred_vin_walks_series_upstream():
-    supply_map = {"VDD_48V_IN": 48.0}
-    graph = _SeriesVinGraph(
-        upstream={"VDD_48V_RP": "VDD_48V", "VDD_48V": "VDD_48V_IN"},
-    )
-    # Two hops from the named rail — the caller warns on any non-zero hop count.
-    assert _lookup_inferred_vin(
-        "VDD_48V_RP", supply_map, graph=graph,
-    ) == (48.0, None, 2)
-
-
-def test_lookup_inferred_vin_series_ambiguous_and_cycle():
-    supply_map = {"VDD_48V_IN": 48.0}
-    assert _lookup_inferred_vin(
-        "VDD_48V_RP", supply_map,
-        graph=_SeriesVinGraph(ambiguous=frozenset({"VDD_48V_RP"})),
-    ) == (None, "ambiguous", 0)
-    assert _lookup_inferred_vin(
-        "VDD_48V_RP", supply_map,
-        graph=_SeriesVinGraph(
-            upstream={"VDD_48V_RP": "VDD_48V", "VDD_48V": "VDD_48V_RP"},
-        ),
-    ) == (None, "cycle", 1)
-
-
-def test_lookup_inferred_vin_declared_rail_beats_series_ambiguity():
-    """A rail whose voltage is declared resolves even when SERIES links to it
-    disagree — parallel ferrites / ORing FETs / fuse+bypass all land here."""
-    assert _lookup_inferred_vin(
-        "VDD_12V", {"VDD_12V": 12.0},
-        graph=_SeriesVinGraph(ambiguous=frozenset({"VDD_12V"})),
-    ) == (12.0, None, 0)
-
-
-def test_lookup_inferred_vin_crosses_single_undirected_link():
-    """An auto-inferred 2-pin element has no P/N direction, so it is crossed
-    only when it is the one unvisited way out of the net."""
-    supply_map = {"VDD_48V_IN": 48.0}
-    one_way = _SeriesVinGraph(
-        undirected={
-            "VDD_48V": frozenset({"VDD_48V_IN"}),
-            "VDD_48V_IN": frozenset({"VDD_48V"}),
-        },
-    )
-    assert _lookup_inferred_vin("VDD_48V", supply_map, graph=one_way) == (
-        48.0, None, 1,
-    )
-    forked = _SeriesVinGraph(
-        undirected={"VDD_48V": frozenset({"VDD_48V_IN", "VDD_SENSE"})},
-    )
-    assert _lookup_inferred_vin("VDD_48V", supply_map, graph=forked) == (
-        None, "undirected", 0,
-    )
-
-
-def test_lookup_inferred_vin_bounds_chain_length():
-    """A chain longer than the hop cap errors instead of walking on."""
-    chain = {f"N{i}": f"N{i + 1}" for i in range(_SERIES_VIN_MAX_HOPS + 3)}
-    vin, failure, _hops = _lookup_inferred_vin(
-        "N0", {"N99": 48.0}, graph=_SeriesVinGraph(upstream=chain),
-    )
-    assert vin is None
-    assert failure == "too_deep"
-
-
-def test_regulator_smps_vin_through_series_chain():
-    """VIP-style: SOURCE -> SERIES -> SERIES -> SMPS on downstream net."""
-    proj = _minimal_proj(
-        nets=(
-            RawNet("GND"), RawNet("VDD_48V_IN"), RawNet("VDD_48V"),
-            RawNet("VDD_48V_RP"), RawNet("VDD_12V"),
-        ),
-        sch_components=(
-            RawSchComponent(
-                designator="J7", schdoc_name="Pwr.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SOURCE",
-                    "PDN_V": "48",
-                    "PDN_P_NET": "VDD_48V_IN",
-                    "PDN_N_NET": "GND",
-                },
-                pin_designators=("1", "2"),
-            ),
-            RawSchComponent(
-                designator="J8", schdoc_name="Pwr.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SERIES",
-                    "PDN_R": "50m",
-                    "PDN_P_NET": "VDD_48V_IN",
-                    "PDN_N_NET": "VDD_48V",
-                },
-                pin_designators=("1", "2"),
-            ),
-            RawSchComponent(
-                designator="Q3", schdoc_name="Pwr.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SERIES",
-                    "PDN_R": "300m",
-                    "PDN_P_NET": "VDD_48V",
-                    "PDN_N_NET": "VDD_48V_RP",
-                },
-                pin_designators=("1", "2"),
-            ),
-            RawSchComponent(
-                designator="U5", schdoc_name="Pwr.SchDoc",
-                parameters={
-                    "PDN_ROLE": "REGULATOR",
-                    "PDN_REGULATOR_TYPE": "SMPS",
-                    "PDN_REGULATOR_EFFICIENCY": "0.8",
-                    "PDN_V": "12",
-                    "PDN_OUT_P_NET": "VDD_12V",
-                    "PDN_OUT_N_NET": "GND",
-                    "PDN_IN_P_NET": "VDD_48V_RP",
-                    "PDN_IN_N_NET": "GND",
-                },
-                pin_designators=("1", "2", "3", "4"),
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J7", center=Pt2D(-15, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="CONN", source_designator="J7",
-            ),
-            RawPcbComponent(
-                designator="J8", center=Pt2D(-10, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="FUSE", source_designator="J8",
-            ),
-            RawPcbComponent(
-                designator="Q3", center=Pt2D(-5, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="SOT", source_designator="Q3",
-            ),
-            RawPcbComponent(
-                designator="U5", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="SOT", source_designator="U5",
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 1, -15), _pad(0, "2", 0, -14),
-            _pad(1, "1", 1, -10), _pad(1, "2", 2, -9),
-            _pad(2, "1", 2, -5), _pad(2, "2", 3, -4),
-            _pad(3, "1", 4, 0), _pad(3, "2", 0, 1),
-            _pad(3, "3", 3, 2), _pad(3, "4", 0, 3),
-        ),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert result.ok, result.errors
-    reg = next(d for d in result.directives if d.designator == "U5")
-    assert isinstance(reg, RegulatorSpec)
-    assert reg.regulator_type == "SMPS"
-    assert abs(reg.gain - (12.0 / (48.0 * 0.8))) < 1e-6
-    assert not any("cannot infer input voltage" in e for e in result.errors)
-
-
-def test_regulator_smps_vin_series_ambiguous_fork():
-    proj = _minimal_proj(
-        nets=(
-            RawNet("GND"), RawNet("VDD_48V_IN"), RawNet("VDD_48V"),
-            RawNet("VDD_48V_RP"), RawNet("VDD_12V"), RawNet("ALT_48V"),
-        ),
-        sch_components=(
-            RawSchComponent(
-                designator="J7", schdoc_name="Pwr.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SOURCE", "PDN_V": "48",
-                    "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "GND",
-                },
-                pin_designators=("1", "2"),
-            ),
-            RawSchComponent(
-                designator="J8", schdoc_name="Pwr.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SERIES", "PDN_R": "50m",
-                    "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
-                },
-                pin_designators=("1", "2"),
-            ),
-            RawSchComponent(
-                designator="Q3a", schdoc_name="Pwr.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SERIES", "PDN_R": "100m",
-                    "PDN_P_NET": "VDD_48V", "PDN_N_NET": "VDD_48V_RP",
-                },
-                pin_designators=("1", "2"),
-            ),
-            RawSchComponent(
-                designator="Q3b", schdoc_name="Pwr.SchDoc",
-                parameters={
-                    "PDN_ROLE": "SERIES", "PDN_R": "200m",
-                    "PDN_P_NET": "ALT_48V", "PDN_N_NET": "VDD_48V_RP",
-                },
-                pin_designators=("1", "2"),
-            ),
-            RawSchComponent(
-                designator="U5", schdoc_name="Pwr.SchDoc",
-                parameters={
-                    "PDN_ROLE": "REGULATOR",
-                    "PDN_REGULATOR_TYPE": "SMPS",
-                    "PDN_REGULATOR_EFFICIENCY": "0.8",
-                    "PDN_V": "12",
-                    "PDN_OUT_P_NET": "VDD_12V",
-                    "PDN_OUT_N_NET": "GND",
-                    "PDN_IN_P_NET": "VDD_48V_RP",
-                    "PDN_IN_N_NET": "GND",
-                },
-                pin_designators=("1", "2", "3", "4"),
-            ),
-        ),
-        pcb_components=(
-            RawPcbComponent(
-                designator="J7", center=Pt2D(-15, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="CONN", source_designator="J7",
-            ),
-            RawPcbComponent(
-                designator="J8", center=Pt2D(-10, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="FUSE", source_designator="J8",
-            ),
-            RawPcbComponent(
-                designator="Q3a", center=Pt2D(-5, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="SOT", source_designator="Q3a",
-            ),
-            RawPcbComponent(
-                designator="Q3b", center=Pt2D(-4, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="SOT", source_designator="Q3b",
-            ),
-            RawPcbComponent(
-                designator="U5", center=Pt2D(0, 0), rotation_deg=0.0,
-                layer_name="TOP", footprint="SOT", source_designator="U5",
-            ),
-        ),
-        pads=(
-            _pad(0, "1", 1, -15), _pad(0, "2", 0, -14),
-            _pad(1, "1", 1, -10), _pad(1, "2", 2, -9),
-            _pad(2, "1", 2, -5), _pad(2, "2", 3, -4),
-            _pad(3, "1", 5, -4), _pad(3, "2", 3, -3),
-            _pad(4, "1", 4, 0), _pad(4, "2", 0, 1),
-            _pad(4, "3", 3, 2), _pad(4, "4", 0, 3),
-        ),
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert not result.ok
-    assert any("ambiguous SERIES upstream" in e for e in result.errors)
-
-
-# --- SERIES Vin graph construction --------------------------------------------
-
-_SERIES_VIN_NETS = {
-    "GND": 0, "VDD_48V_IN": 1, "VDD_48V": 2, "VDD_12V": 3, "VDD_48V_F": 4,
-}
-
-
-def _series_vin_proj(
-    series_params: dict[str, str],
-    *,
-    in_p_net: str = "VDD_48V",
-    in_p_pad_net: int | None = None,
-    series_pads: tuple[tuple[str, int], ...] = (("1", 1), ("2", 2)),
-    extra_series: dict[str, str] | None = None,
-) -> ExtractedProject:
-    """SOURCE(48 V on VDD_48V_IN) → one SERIES part → SMPS on ``in_p_net``.
-
-    ``series_params`` is the SERIES component's parameter dict, so each test can
-    vary only how that one part declares its two nets. ``series_pads`` is its
-    ``(pin, net_index)`` list *in file order* — the order 2-pin auto-inference
-    reads P/N off. ``in_p_pad_net`` overrides the net the regulator's IN_P pad
-    sits on, modelling the state ``_apply_net_remap`` leaves behind: the pad
-    carries the canonical index while the annotation still names the folded one.
-    """
-    sch = [
-        RawSchComponent(
-            designator="J7", schdoc_name="Pwr.SchDoc",
-            parameters={
-                "PDN_ROLE": "SOURCE", "PDN_V": "48",
-                "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "GND",
-            },
-            pin_designators=("1", "2"),
-        ),
-        RawSchComponent(
-            designator="F1", schdoc_name="Pwr.SchDoc",
-            parameters=series_params,
-            pin_designators=("1", "2", "3"),
-        ),
-        RawSchComponent(
-            designator="U5", schdoc_name="Pwr.SchDoc",
-            parameters={
-                "PDN_ROLE": "REGULATOR", "PDN_REGULATOR_TYPE": "SMPS",
-                "PDN_REGULATOR_EFFICIENCY": "0.8", "PDN_V": "12",
-                "PDN_OUT_P_NET": "VDD_12V", "PDN_OUT_N_NET": "GND",
-                "PDN_IN_P_NET": in_p_net, "PDN_IN_N_NET": "GND",
-            },
-            pin_designators=("1", "2", "3", "4"),
-        ),
-    ]
-    pcb = [
-        RawPcbComponent(
-            designator="J7", center=Pt2D(-15, 0), rotation_deg=0.0,
-            layer_name="TOP", footprint="CONN", source_designator="J7",
-        ),
-        RawPcbComponent(
-            designator="F1", center=Pt2D(-10, 0), rotation_deg=0.0,
-            layer_name="TOP", footprint="FUSE", source_designator="F1",
-        ),
-        RawPcbComponent(
-            designator="U5", center=Pt2D(0, 0), rotation_deg=0.0,
-            layer_name="TOP", footprint="SOT", source_designator="U5",
-        ),
-    ]
-    # J7 = pcb 0, F1 = pcb 1, [R9 = pcb 2], U5 last.
-    pads = [_pad(0, "1", 1, -15), _pad(0, "2", 0, -14)]
-    pads += [_pad(1, pin, net, -10) for pin, net in series_pads]
-    u5_index = 2
-    if extra_series is not None:
-        sch.insert(2, RawSchComponent(
-            designator="R9", schdoc_name="Pwr.SchDoc",
-            parameters=extra_series, pin_designators=("1", "2"),
-        ))
-        pcb.insert(2, RawPcbComponent(
-            designator="R9", center=Pt2D(-7, 0), rotation_deg=0.0,
-            layer_name="TOP", footprint="0402", source_designator="R9",
-        ))
-        pads += [_pad(2, "1", 2, -7), _pad(2, "2", 4, -6)]
-        u5_index = 3
-    pads += [
-        _pad(u5_index, "1", 3, 0),                              # OUT_P
-        _pad(u5_index, "2", 0, 1),                              # OUT_N
-        _pad(
-            u5_index, "3",
-            _SERIES_VIN_NETS[in_p_net] if in_p_pad_net is None else in_p_pad_net,
-            2,
-        ),                                                      # IN_P
-        _pad(u5_index, "4", 0, 3),                              # IN_N
-    ]
-    return _minimal_proj(
-        nets=(
-            RawNet("GND"), RawNet("VDD_48V_IN"), RawNet("VDD_48V"),
-            RawNet("VDD_12V"), RawNet("VDD_48V_F"),
-        ),
-        sch_components=tuple(sch),
-        pcb_components=tuple(pcb),
-        pads=tuple(pads),
-    )
-
-
-def test_series_upstream_map_reads_indexed_role_only_channels():
-    """A part whose SERIES channels come only from PDN<n>_ROLE overrides still
-    contributes its links — _is_pdn_annotated admits it, so the graph must too."""
-    proj = _series_vin_proj({
-        "PDN1_ROLE": "SERIES", "PDN1_R": "50m",
-        "PDN1_P_NET": "VDD_48V_IN", "PDN1_N_NET": "VDD_48V",
-        "PDN2_ROLE": "SERIES", "PDN2_R": "50m",
-        "PDN2_P_NET": "VDD_48V", "PDN2_N_NET": "VDD_12V",
-    })
-    graph = _collect_series_upstream_map(_iter_pdn_parameter_sources(proj), proj)
-    assert graph.upstream == {
-        "VDD_48V": "VDD_48V_IN", "VDD_12V": "VDD_48V",
-    }
-
-
-def test_series_upstream_map_reads_pin_specified_channels():
-    """PDN_P_PINS / PDN_N_PINS is a supported way to state a SERIES element's
-    two sides, so it must produce the same edge PDN_P_NET / PDN_N_NET would."""
-    proj = _series_vin_proj(
-        {
-            "PDN_ROLE": "SERIES", "PDN_R": "50m",
-            "PDN_P_PINS": "1", "PDN_N_PINS": "2,3",
-        },
-        # pin 1 on VDD_48V_IN, pins 2+3 both on VDD_48V.
-        series_pads=(("1", 1), ("2", 2), ("3", 2)),
-    )
-    graph = _collect_series_upstream_map(_iter_pdn_parameter_sources(proj), proj)
-    assert graph.upstream == {"VDD_48V": "VDD_48V_IN"}
-
-    result = parse_annotations(proj, enabled_layers=[1])
-    reg = next(d for d in result.directives if d.designator == "U5")
-    assert abs(reg.gain - (12.0 / (48.0 * 0.8))) < 1e-6
-
-
-def test_series_upstream_map_auto_inferred_link_is_direction_agnostic():
-    """_autoinfer_2pin_nets takes P/N from raw pad order, so the Vin result must
-    not change when the two RawPad entries are swapped."""
-    params = {"PDN_ROLE": "SERIES", "PDN_R": "50m"}
-    forward = _series_vin_proj(params, series_pads=(("1", 1), ("2", 2)))
-    reversed_ = _series_vin_proj(params, series_pads=(("2", 2), ("1", 1)))
-    expected = 12.0 / (48.0 * 0.8)
-    for proj in (forward, reversed_):
-        graph = _collect_series_upstream_map(
-            _iter_pdn_parameter_sources(proj), proj,
-        )
-        # Recorded as an undirected pair — pad order states no power flow.
-        assert not graph.upstream
-        assert graph.undirected["VDD_48V"] == frozenset({"VDD_48V_IN"})
-        result = parse_annotations(proj, enabled_layers=[1])
-        reg = next(d for d in result.directives if d.designator == "U5")
-        assert abs(reg.gain - expected) < 1e-6, result.errors
-
-
-def test_series_upstream_map_skips_merged_short_self_edges():
-    """A 0 Ω the merge pre-pass absorbed has both ends on one net now. Neither
-    the skip list nor the self-edge guard may let it shadow the real edge."""
-    proj = _series_vin_proj(
-        {
-            "PDN_ROLE": "SERIES", "PDN_R": "50m",
-            "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
-        },
-        extra_series={
-            "PDN_ROLE": "SERIES", "PDN_R": "0.001",
-            "PDN_P_NET": "VDD_48V", "PDN_N_NET": "VDD_48V_F",
-        },
-    )
-    # VDD_48V_F (index 4) merged into VDD_48V (index 2).
-    net_remap = {4: 2}
-    graph = _collect_series_upstream_map(
-        _iter_pdn_parameter_sources(proj), proj,
-        net_remap=net_remap, skip_designators={"R9"},
-    )
-    assert graph.upstream == {"VDD_48V": "VDD_48V_IN"}
-    assert not graph.ambiguous
-
-    # Even without the skip list, the self-edge guard must hold the line.
-    unskipped = _collect_series_upstream_map(
-        _iter_pdn_parameter_sources(proj), proj, net_remap=net_remap,
-    )
-    assert unskipped.upstream == {"VDD_48V": "VDD_48V_IN"}
-    assert not unskipped.ambiguous
-
-
-def test_regulator_smps_vin_resolves_under_merged_net_name():
-    """The user may write either merged name. Both the supply map and the
-    lookup key are canonicalised, so IN_P_NET on the folded name still lands."""
-    proj = _series_vin_proj(
-        {
-            "PDN_ROLE": "SERIES", "PDN_R": "50m",
-            "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
-        },
-        in_p_net="VDD_48V_F",   # the name the user wrote
-        in_p_pad_net=2,         # ...folded into VDD_48V by the merge pre-pass
-    )
-    result = parse_annotations(proj, enabled_layers=[1], net_remap={4: 2})
-    reg = next(d for d in result.directives if d.designator == "U5")
-    assert abs(reg.gain - (12.0 / (48.0 * 0.8))) < 1e-6, result.errors
-
-
-def test_regulator_smps_vin_warns_when_inferred_through_series_chain():
-    """Vin taken from a walked chain is a guess about which leg is the power
-    path — a sense or bleed resistor produces a silently wrong gain, so say so."""
-    proj = _series_vin_proj({
-        "PDN_ROLE": "SERIES", "PDN_R": "50m",
-        "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
-    })
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert any(
-        "was inferred 1 SERIES hop(s) upstream" in w for w in result.warnings
-    ), result.warnings
-
-
-def test_regulator_smps_vin_does_not_warn_on_directly_declared_rail():
-    proj = _series_vin_proj(
-        {
-            "PDN_ROLE": "SERIES", "PDN_R": "50m",
-            "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
-        },
-        in_p_net="VDD_48V_IN",
-    )
-    result = parse_annotations(proj, enabled_layers=[1])
-    assert not any("SERIES hop(s) upstream" in w for w in result.warnings)
+    assert _lookup_inferred_vin("VDD_48V", supply_map) == 48.0
+    assert _lookup_inferred_vin("VDD_12V", supply_map) == 12.0
 
 
 def test_regulator_smps_vin_not_ambiguous_through_sense_bridges():
@@ -3215,9 +2463,7 @@ def test_indexed_roles_only_source_channel_contributes_supply_voltage():
     assert sources[0].channel_index == 1
     assert sources[0].voltage == pytest.approx(5.0)
 
-    supply_map = _collect_supply_voltages_by_net(
-        _iter_pdn_parameter_sources(proj), proj,
-    )
+    supply_map = _collect_supply_voltages_by_net(_iter_pdn_parameter_sources(proj))
     assert supply_map == {"+5V": 5.0}
 
 
@@ -3282,205 +2528,6 @@ def test_format_solve_blockers_lists_errors():
     assert "no SOURCE or REGULATOR" in text
     assert "fypa.log" in text
 
-
-# --- physical-page-map harvesting ---------------------------------------------
-
-
-def test_harvest_prefers_source_path_over_bare_file_name():
-    """file_name is the bare leaf, so harvesting it collapses same-named
-    sheets in different directories onto one map value."""
-    from types import SimpleNamespace
-
-    from fypa.altium.extract import _harvest_physical_sheet_names
-
-    compiled = SimpleNamespace(physical_documents=[
-        SimpleNamespace(id="physical:0", source_path="SubA/Power.SchDoc",
-                        file_name="Power.SchDoc"),
-        SimpleNamespace(id="physical:1", source_path="SubB/Power.SchDoc",
-                        file_name="Power.SchDoc"),
-    ])
-    assert _harvest_physical_sheet_names(compiled) == (
-        ("physical:0", "SubA/Power.SchDoc"),
-        ("physical:1", "SubB/Power.SchDoc"),
-    )
-
-
-def test_harvest_falls_back_to_file_name_when_source_path_is_absent():
-    from types import SimpleNamespace
-
-    from fypa.altium.extract import _harvest_physical_sheet_names
-
-    compiled = SimpleNamespace(physical_documents=[
-        SimpleNamespace(id="physical:0", file_name="Power.SchDoc"),
-    ])
-    assert _harvest_physical_sheet_names(compiled) == (
-        ("physical:0", "Power.SchDoc"),
-    )
-
-
-def test_harvest_is_empty_on_a_release_without_physical_documents():
-    """The installed library may predate the compiled model entirely; that
-    must yield an empty map, not an exception."""
-    from types import SimpleNamespace
-
-    from fypa.altium.extract import _harvest_physical_sheet_names
-
-    assert _harvest_physical_sheet_names(SimpleNamespace()) == ()
-    assert _harvest_physical_sheet_names(
-        SimpleNamespace(physical_documents=None)) == ()
-    # Entries missing either half are skipped rather than half-recorded.
-    assert _harvest_physical_sheet_names(SimpleNamespace(physical_documents=[
-        SimpleNamespace(id=None, source_path="A.SchDoc"),
-        SimpleNamespace(id="physical:0", source_path=None, file_name=None),
-    ])) == ()
-
-
-def test_compile_falls_back_to_to_netlist_with_the_designs_own_options():
-    """Rebuilding NetlistOptions.from_prjpcb() drops the merged per-sheet
-    parameters that net labels substitute — only AltiumDesign.from_prjpcb adds
-    them — so a fallback that does so silently renames nets."""
-
-    from fypa.altium.extract import _compile_schematic_netlist
-
-    sentinel = object()
-    calls = []
-
-    class _Design:
-        schdocs = ["a.SchDoc"]
-        project = None
-
-        def to_netlist(self):
-            calls.append("to_netlist")
-            return sentinel
-
-    netlist, sheet_names = _compile_schematic_netlist(_Design())
-    assert netlist is sentinel
-    assert sheet_names == ()
-    assert calls == ["to_netlist"]
-
-
-def test_a_failed_page_map_does_not_discard_a_good_netlist():
-
-    from fypa.altium.extract import _compile_schematic_netlist
-
-    sentinel = object()
-
-    class _Compiled:
-        def to_netlist(self):
-            return sentinel
-
-        @property
-        def physical_documents(self):
-            raise RuntimeError("field renamed upstream")
-
-    class _Design:
-        schdocs = ["a.SchDoc"]
-        project = None
-
-        def compile(self):
-            return _Compiled()
-
-        def to_netlist(self):
-            raise AssertionError("must not recompile after a good compile()")
-
-    netlist, sheet_names = _compile_schematic_netlist(_Design())
-    assert netlist is sentinel
-    assert sheet_names == ()
-
-
-# --- P/N arbitration follow-ups ------------------------------------------------
-
-
-def test_alias_fallback_does_not_outrank_a_name_level_match():
-    """"The pad's PCB net is on the row" is the criterion the PCB tier
-    explicitly rejects, so an alias-only hit must not be stamped tier 0 and
-    strip a genuine net.name match on the other terminal."""
-    from fypa.altium.annotations import (
-        _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_NAME, _LOCAL_NET_TIER_PCB,
-    )
-
-    assert _LOCAL_NET_TIER_ALIAS > _LOCAL_NET_TIER_NAME > _LOCAL_NET_TIER_PCB
-
-
-def test_explicit_pin_override_outranks_a_net_name_match():
-    """The overlap error tells the user to set PDN_*_PINS. That advice only
-    works if an explicit pin list actually breaks the tie."""
-    from fypa.altium.annotations import (
-        _LOCAL_NET_TIER_DIRECT, _LOCAL_NET_TIER_OVERRIDE,
-    )
-
-    assert _LOCAL_NET_TIER_OVERRIDE < _LOCAL_NET_TIER_DIRECT
-
-
-def _pin(pad):
-    return TerminalPin(pad, 1, 0, Pt2D(0, 0))
-
-
-def test_overlap_messages_name_pads_not_arbitration_keys():
-    """The keys are composite ("R5:1") but PDN_*_PINS matches bare pad names,
-    so printing the key sent the user to an error about an unknown pin."""
-    p = TerminalSpec(
-        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0), component_designator="R5"),
-              TerminalPin("2", 1, 0, Pt2D(0, 0), component_designator="R5")),
-        requested_net="VIN",
-    )
-    n = TerminalSpec(
-        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0), component_designator="R5"),),
-        requested_net="VIN_L",
-    )
-    result = AnnotationResult()
-    _arbitrate_overlapping_terminals(
-        p, n, _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_NAME,
-        "SERIES on R5", result,
-    )
-    text = " ".join(result.warnings + result.errors)
-    assert "R5:1" not in text
-    assert "pin(s) 1" in text
-
-
-def test_empty_side_errors_without_a_contradictory_warning():
-    """Warning that pins were "dropped from N" and then that N is empty and
-    the directive discarded reads as two contradictory log lines."""
-    shared = TerminalPin("1", 1, 0, Pt2D(0, 0))
-    p = TerminalSpec(pins=(shared,), requested_net="VIN")
-    n = TerminalSpec(pins=(shared,), requested_net="VIN_L")
-    result = AnnotationResult()
-    p2, n2 = _arbitrate_overlapping_terminals(
-        p, n, _LOCAL_NET_TIER_NAME, _LOCAL_NET_TIER_ALIAS,
-        "SERIES on R5", result,
-    )
-    assert p2 is not None and n2 is None
-    assert result.errors and "would be empty" in result.errors[0]
-    assert result.warnings == []
-
-
-def test_equal_tier_error_points_at_the_remedy_that_works():
-    shared = TerminalPin("1", 1, 0, Pt2D(0, 0))
-    p = TerminalSpec(pins=(shared,), requested_net="VIN")
-    n = TerminalSpec(pins=(shared,), requested_net="VIN")
-    result = AnnotationResult()
-    p2, n2 = _arbitrate_overlapping_terminals(
-        p, n, _LOCAL_NET_TIER_NAME, _LOCAL_NET_TIER_NAME,
-        "SERIES on R5", result,
-    )
-    assert p2 is None and n2 is None
-    assert "outranks a net-name match" in result.errors[0]
-
-
-def test_channel_token_must_come_from_flattening():
-    """A part merely NAMED FB_2 is not channel 2 of FB, so an unrelated
-    repeated sheet's VIN.2 must not match it."""
-    # Genuine channel instance: the placed designator is the schematic one
-    # plus the channel token, so the separators may legitimately disagree.
-    assert _local_net_label_matches("VIN_1", "VIN", {"R1", "R1.1"})
-    assert _local_net_label_matches("VIN.1", "VIN", {"R1", "R1_1"})
-    # Not a channel: nothing in the candidate set is "FB" + sep + "2".
-    assert not _local_net_label_matches("VIN.2", "VIN", {"FB_2"})
-    assert not _local_net_label_matches("VIN_3", "VIN", {"SW_3"})
-    # An exact label still matches regardless.
-    assert _local_net_label_matches("VIN", "VIN", {"FB_2"})
-
-# --- Sheet-symbol per-instance overrides ---
 
 # --- Sheet-symbol per-instance overrides --------------------------------------
 
@@ -3561,7 +2608,6 @@ def test_sheet_symbol_override_different_currents_per_instance():
     assert sinks["J1.2"].current == pytest.approx(3.0)
 
 
-
 def test_sheet_symbol_override_absent_keeps_shared_child_current():
     """Without sheet overrides, every instance inherits the child PDN_I."""
     proj = _minimal_proj(
@@ -3600,7 +2646,6 @@ def test_sheet_symbol_override_absent_keeps_shared_child_current():
     sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
     assert len(sinks) == 2
     assert all(d.current == pytest.approx(0.5) for d in sinks)
-
 
 
 def test_sheet_symbol_nested_uid_deepest_wins():
@@ -3651,7 +2696,6 @@ def test_sheet_symbol_nested_uid_deepest_wins():
     assert sinks[0].current == pytest.approx(2.0)
 
 
-
 def test_sheet_symbol_indexed_channel_override():
     """``PDN_U1_1_I`` overrides only the indexed PDN channel on the child."""
     proj = _minimal_proj(
@@ -3699,7 +2743,6 @@ def test_sheet_symbol_indexed_channel_override():
     }
     assert sinks[None].current == pytest.approx(0.05)
     assert sinks[1].current == pytest.approx(0.08)
-
 
 
 def test_sheet_symbol_repeat_slot_qualified_override():
@@ -3774,7 +2817,6 @@ def test_sheet_symbol_repeat_slot_qualified_override():
     assert sinks["J1.2"].current == pytest.approx(2.0)
 
 
-
 def test_sheet_symbol_only_directive_without_child_pdn_role():
     """Full SINK directive can live entirely on the sheet symbol."""
     proj = _minimal_proj(
@@ -3815,7 +2857,6 @@ def test_sheet_symbol_only_directive_without_child_pdn_role():
     assert len(sinks) == 1
     assert sinks[0].designator == "J1.1"
     assert sinks[0].current == pytest.approx(1.2)
-
 
 
 def test_sheet_symbol_params_via_owner_index():
@@ -3871,7 +2912,6 @@ def test_sheet_symbol_params_via_owner_index():
     assert "Other" not in sym.parameters
 
 
-
 def test_sheet_symbol_override_via_hierarchical_path_fallback():
     """When SOURCEUNIQUEID is empty, match sheet symbols via hierarchy path."""
     proj = _minimal_proj(
@@ -3912,7 +2952,6 @@ def test_sheet_symbol_override_via_hierarchical_path_fallback():
     sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
     assert len(sinks) == 1
     assert sinks[0].current == pytest.approx(2.5)
-
 
 
 def test_sheet_symbol_extract_to_parse_round_trip():
@@ -3984,7 +3023,6 @@ def test_sheet_symbol_extract_to_parse_round_trip():
     assert sinks[0].current == pytest.approx(1.5)
 
 
-
 def test_sheet_symbol_repeat_slot_skipped_for_non_numeric_designator():
     """Slot-qualified override warns when PCB designator has no .N suffix."""
     proj = _minimal_proj(
@@ -4029,7 +3067,6 @@ def test_sheet_symbol_repeat_slot_skipped_for_non_numeric_designator():
         "PDN_J1_I.1" in w and "no numeric channel suffix" in w
         for w in result.warnings
     )
-
 
 
 def test_multi_instance_missing_value_reports_once():
@@ -4091,7 +3128,6 @@ def test_multi_instance_missing_value_reports_once():
     assert "SINK on J1:" in missing[0]
 
 
-
 def test_multi_instance_missing_net_reports_once():
     """Missing PDN_P_NET on every instance → one logical error."""
     proj = _minimal_proj(
@@ -4127,7 +3163,6 @@ def test_multi_instance_missing_net_reports_once():
     missing = [e for e in result.errors if "missing PDN_P_NET" in e]
     assert len(missing) == 1
     assert "SINK on J1:" in missing[0]
-
 
 
 def test_orphan_sheet_override_does_not_invent_discovery_channel():
@@ -4172,7 +3207,6 @@ def test_orphan_sheet_override_does_not_invent_discovery_channel():
     assert not any("missing required parameter PDN_I" in e for e in result.errors)
 
 
-
 def test_orphan_sheet_override_warnings_consolidated():
     """Multiple orphan PDN keys on one symbol → one warning listing them."""
     proj = _minimal_proj(
@@ -4200,7 +3234,6 @@ def test_orphan_sheet_override_warnings_consolidated():
     assert "PDN_J1_I" in uid_warns[0]
     assert "PDN_J1_ROLE" in uid_warns[0]
     assert "PDN_J1_P_NET" in uid_warns[0]
-
 
 
 def test_sheet_symbol_only_multi_instance_different_currents():
@@ -4262,7 +3295,6 @@ def test_sheet_symbol_only_multi_instance_different_currents():
     sinks = {d.designator: d for d in result.directives if isinstance(d, SinkSpec)}
     assert sinks["J1.1"].current == pytest.approx(1.5)
     assert sinks["J1.2"].current == pytest.approx(3.0)
-
 
 
 def test_indexed_sheet_override_does_not_force_sibling_channel():
@@ -4334,7 +3366,6 @@ def test_indexed_sheet_override_does_not_force_sibling_channel():
     assert not any("missing" in e and "PDN2" in e for e in result.errors)
 
 
-
 def test_hierpath_bound_override_no_orphan_warning():
     """Hierpath-only binding must not emit UniqueID orphan warnings."""
     proj = _minimal_proj(
@@ -4376,7 +3407,6 @@ def test_hierpath_bound_override_no_orphan_warning():
     sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
     assert len(sinks) == 1
     assert sinks[0].current == pytest.approx(2.5)
-
 
 
 def test_ambiguous_hierpath_sheet_name_warns():
@@ -4438,7 +3468,6 @@ def test_ambiguous_hierpath_sheet_name_warns():
     assert sinks[0].current == pytest.approx(1.0)  # SYMA wins over SYMB
 
 
-
 def test_sheet_override_designator_with_trailing_letter():
     """PDN_U12A_I targets designator U12A, not U12 + suffix A_I."""
     proj = _minimal_proj(
@@ -4478,7 +3507,6 @@ def test_sheet_override_designator_with_trailing_letter():
     sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
     assert len(sinks) == 1
     assert sinks[0].current == pytest.approx(1.8)
-
 
 
 def test_sheet_override_role_changes_parser_per_instance():
@@ -4546,7 +3574,6 @@ def test_sheet_override_role_changes_parser_per_instance():
     assert sources[0].voltage == pytest.approx(5.0)
 
 
-
 def test_duplicate_sch_designator_with_sheet_symbols_not_multiplied():
     """Two SchDocs with same J1 + sheet binding → one warning, no dup sinks."""
     proj = _minimal_proj(
@@ -4602,7 +3629,6 @@ def test_duplicate_sch_designator_with_sheet_symbols_not_multiplied():
     assert sinks[0].current == pytest.approx(1.5)
 
 
-
 def test_sheet_symbol_only_partial_coverage_warns():
     """Full sheet-only on one placement, sibling unbound → warning."""
     proj = _minimal_proj(
@@ -4654,15 +3680,92 @@ def test_sheet_symbol_only_partial_coverage_warns():
     )
     result = parse_annotations(proj, enabled_layers=[1])
     assert any(
-        "sheet-symbol-only PDN directive covers" in w
-        and "J1.1" in w
-        and "J1.2" in w
+        "PDN covers" in w
+        and "J1.1 (sheet symbol)" in w
+        and "but not J1.2" in w
         for w in result.warnings
     )
     sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
     assert len(sinks) == 1
     assert sinks[0].designator == "J1.1"
 
+
+def test_partial_coverage_warning_labels_pcb_eco_separately():
+    """Mixed PCB-ECO + sheet-only partial coverage names sources explicitly."""
+    pcb_pdn = {
+        "PDN_ROLE": "SINK",
+        "PDN_I": "1A",
+        "PDN_P_NET": "+5V",
+        "PDN_N_NET": "GND",
+    }
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={"Comment": "USB"},
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={},
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-B",
+                child_filename="Port.SchDoc",
+                unique_id="SYMB",
+                parameters={
+                    "PDN_J1_ROLE": "SINK",
+                    "PDN_J1_I": "2A",
+                    "PDN_J1_P_NET": "+5V",
+                    "PDN_J1_N_NET": "GND",
+                },
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-C",
+                child_filename="Port.SchDoc",
+                unique_id="SYMC",
+                parameters={},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+                parameters=dict(pcb_pdn),
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMB\COMP",
+            ),
+            RawPcbComponent(
+                designator="J1.3", center=Pt2D(20, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMC\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 1, 10), _pad(1, "2", 0, 11),
+            _pad(2, "1", 1, 20), _pad(2, "2", 0, 21),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert any(
+        "J1.2 (sheet symbol)" in w
+        and "J1.1 (PCB-ECO)" in w
+        and "but not J1.3" in w
+        for w in result.warnings
+    )
 
 
 def test_hierpath_skips_root_sheet_segment():
@@ -4714,7 +3817,6 @@ def test_hierpath_skips_root_sheet_segment():
     assert sinks[0].current == pytest.approx(1.2)
 
 
-
 def test_hierpath_single_segment_binds():
     """Path with only the sheet-symbol name (no root) still binds."""
     proj = _minimal_proj(
@@ -4755,7 +3857,6 @@ def test_hierpath_single_segment_binds():
     sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
     assert len(sinks) == 1
     assert sinks[0].current == pytest.approx(1.7)
-
 
 
 def test_hierpath_nested_sheet_symbol_first_segment():
@@ -4805,7 +3906,6 @@ def test_hierpath_nested_sheet_symbol_first_segment():
     sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
     assert len(sinks) == 1
     assert sinks[0].current == pytest.approx(2.5)
-
 
 
 def test_ambiguous_hierpath_loser_still_warns_missing_designator():
@@ -4867,7 +3967,6 @@ def test_ambiguous_hierpath_loser_still_warns_missing_designator():
     )
 
 
-
 def test_sheet_override_role_strips_regulator_terminal_keys():
     """Leaving REGULATOR via sheet ROLE drops OUT_/IN_ keys without noise."""
     proj = _minimal_proj(
@@ -4918,3 +4017,1184 @@ def test_sheet_override_role_strips_regulator_terminal_keys():
     sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
     assert len(sinks) == 1
     assert sinks[0].current == pytest.approx(0.5)
+
+
+def test_sheet_override_pdn_v_on_pcb_eco_regulator():
+    """PCB-ECO REGULATOR without PDN_V still takes PDN_<Des>_V from sheet symbol.
+
+    Matches the common pattern where ROLE/nets were ECO'd to the PCB and only
+    the per-instance output voltage lives on the parent sheet symbol.
+    """
+    pcb_pdn = {
+        "PDN_ROLE": "REGULATOR",
+        "PDN_GAIN": "1",
+        "PDN_OUT_P_NET": "VOUT",
+        "PDN_OUT_N_NET": "GND",
+        "PDN_IN_P_NET": "VIN",
+        "PDN_IN_N_NET": "GND",
+    }
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("VIN"), RawNet("VOUT.1"), RawNet("VOUT.2")),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={"Comment": "buck"},
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="PWR_5V",
+                child_filename="Pwr.SchDoc",
+                unique_id="SYM5V",
+                parameters={"PDN_U1_V": "5V"},
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="PWR_12V",
+                child_filename="Pwr.SchDoc",
+                unique_id="SYM12V",
+                parameters={"PDN_U1_V": "12 V"},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+                source_unique_id=r"\SYM5V\COMP",
+                parameters=dict(pcb_pdn),
+            ),
+            RawPcbComponent(
+                designator="U1.2", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+                source_unique_id=r"\SYM12V\COMP",
+                parameters=dict(pcb_pdn),
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 2), _pad(0, "2", 0, 1),
+            _pad(0, "3", 1, 2), _pad(0, "4", 0, 3),
+            _pad(1, "1", 3, 10), _pad(1, "2", 0, 11),
+            _pad(1, "3", 1, 12), _pad(1, "4", 0, 13),
+        ),
+        compiled_netlist=_FakeNetlist(nets=[
+            _FakeNet(
+                name="VOUT.1", aliases=["VOUT"],
+                source_sheets=["pwr.schdoc"],
+                terminals=[_FakeTerminal("U1.1", "1")],
+            ),
+            _FakeNet(
+                name="VOUT.2", aliases=["VOUT"],
+                source_sheets=["pwr.schdoc"],
+                terminals=[_FakeTerminal("U1.2", "1")],
+            ),
+            _FakeNet(
+                name="VIN",
+                source_sheets=["pwr.schdoc"],
+                terminals=[
+                    _FakeTerminal("U1.1", "3"),
+                    _FakeTerminal("U1.2", "3"),
+                ],
+            ),
+            _FakeNet(
+                name="GND",
+                source_sheets=["pwr.schdoc"],
+                terminals=[
+                    _FakeTerminal("U1.1", "2"),
+                    _FakeTerminal("U1.1", "4"),
+                    _FakeTerminal("U1.2", "2"),
+                    _FakeTerminal("U1.2", "4"),
+                ],
+            ),
+        ]),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    regs = {
+        d.designator: d
+        for d in result.directives if isinstance(d, RegulatorSpec)
+    }
+    assert set(regs) == {"U1.1", "U1.2"}
+    assert regs["U1.1"].voltage == pytest.approx(5.0)
+    assert regs["U1.2"].voltage == pytest.approx(12.0)
+
+
+def test_pcb_eco_and_full_sheet_directive_deduped():
+    """PCB-ECO ROLE + full sheet-symbol ROLE must not double-parse one placement."""
+    pcb_pdn = {
+        "PDN_ROLE": "REGULATOR",
+        "PDN_GAIN": "1",
+        "PDN_OUT_P_NET": "VOUT",
+        "PDN_OUT_N_NET": "GND",
+        "PDN_IN_P_NET": "VIN",
+        "PDN_IN_N_NET": "GND",
+    }
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("VIN"), RawNet("VOUT")),
+        sch_components=(
+            RawSchComponent(
+                designator="U1", schdoc_name="Pwr.SchDoc",
+                parameters={"Comment": "buck"},
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="PWR",
+                child_filename="Pwr.SchDoc",
+                unique_id="SYM",
+                parameters={
+                    "PDN_U1_ROLE": "REGULATOR",
+                    "PDN_U1_V": "5V",
+                    "PDN_U1_GAIN": "1",
+                    "PDN_U1_OUT_P_NET": "VOUT",
+                    "PDN_U1_OUT_N_NET": "GND",
+                    "PDN_U1_IN_P_NET": "VIN",
+                    "PDN_U1_IN_N_NET": "GND",
+                },
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U1",
+                source_unique_id=r"\SYM\COMP",
+                parameters=dict(pcb_pdn),
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 2), _pad(0, "2", 0, 1),
+            _pad(0, "3", 1, 2), _pad(0, "4", 0, 3),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    regs = [d for d in result.directives if isinstance(d, RegulatorSpec)]
+    assert len(regs) == 1
+    assert regs[0].designator == "U1.1"
+    assert regs[0].voltage == pytest.approx(5.0)
+
+
+def test_pcb_eco_counts_toward_sheet_only_partial_coverage():
+    """Sibling covered by PCB-ECO is not flagged as missing sheet-only ROLE."""
+    pcb_pdn = {
+        "PDN_ROLE": "SINK",
+        "PDN_I": "100mA",
+        "PDN_P_NET": "+5V",
+        "PDN_N_NET": "GND",
+    }
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={"Comment": "USB"},
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={
+                    # Value-only override on the PCB-ECO instance.
+                    "PDN_J1_I": "1.5A",
+                },
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-B",
+                child_filename="Port.SchDoc",
+                unique_id="SYMB",
+                parameters={
+                    "PDN_J1_ROLE": "SINK",
+                    "PDN_J1_I": "2A",
+                    "PDN_J1_P_NET": "+5V",
+                    "PDN_J1_N_NET": "GND",
+                },
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+                parameters=dict(pcb_pdn),
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMB\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 1, 10), _pad(1, "2", 0, 11),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    assert not any("PDN covers" in w and "but not" in w for w in result.warnings)
+    sinks = {
+        d.designator: d
+        for d in result.directives if isinstance(d, SinkSpec)
+    }
+    assert set(sinks) == {"J1.1", "J1.2"}
+    assert sinks["J1.1"].current == pytest.approx(1.5)
+    assert sinks["J1.2"].current == pytest.approx(2.0)
+
+
+def test_pcb_eco_value_override_no_false_partial_coverage_warning():
+    """PCB-ECO + value-only sheet override must not warn about a bare sibling."""
+    pcb_pdn = {
+        "PDN_ROLE": "SINK",
+        "PDN_I": "100mA",
+        "PDN_P_NET": "+5V",
+        "PDN_N_NET": "GND",
+    }
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+5V")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1", schdoc_name="Port.SchDoc",
+                parameters={"Comment": "USB"},
+                pin_designators=("1", "2"),
+            ),
+        ),
+        sch_sheet_symbols=(
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-A",
+                child_filename="Port.SchDoc",
+                unique_id="SYMA",
+                parameters={"PDN_J1_I": "1.5A"},
+            ),
+            RawSchSheetSymbol(
+                parent_schdoc="Main.SchDoc",
+                sheet_name="CON-B",
+                child_filename="Port.SchDoc",
+                unique_id="SYMB",
+                parameters={},
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMA\COMP",
+                parameters=dict(pcb_pdn),
+            ),
+            RawPcbComponent(
+                designator="J1.2", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="USB", source_designator="J1",
+                source_unique_id=r"\SYMB\COMP",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1), _pad(0, "2", 0, 1),
+            _pad(1, "1", 1, 10), _pad(1, "2", 0, 11),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    assert not any("PDN covers" in w and "but not" in w for w in result.warnings)
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].designator == "J1.1"
+    assert sinks[0].current == pytest.approx(1.5)
+
+# --- retained from main/rebase base ---
+
+
+
+def test_a_failed_page_map_does_not_discard_a_good_netlist():
+
+    from fypa.altium.extract import _compile_schematic_netlist
+
+    sentinel = object()
+
+    class _Compiled:
+        def to_netlist(self):
+            return sentinel
+
+        @property
+        def physical_documents(self):
+            raise RuntimeError("field renamed upstream")
+
+    class _Design:
+        schdocs = ["a.SchDoc"]
+        project = None
+
+        def compile(self):
+            return _Compiled()
+
+        def to_netlist(self):
+            raise AssertionError("must not recompile after a good compile()")
+
+    netlist, sheet_names = _compile_schematic_netlist(_Design())
+    assert netlist is sentinel
+    assert sheet_names == ()
+
+
+# --- P/N arbitration follow-ups ------------------------------------------------
+
+
+
+# --- P/N arbitration follow-ups ------------------------------------------------
+
+
+def test_alias_fallback_does_not_outrank_a_name_level_match():
+    """"The pad's PCB net is on the row" is the criterion the PCB tier
+    explicitly rejects, so an alias-only hit must not be stamped tier 0 and
+    strip a genuine net.name match on the other terminal."""
+    from fypa.altium.annotations import (
+        _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_NAME, _LOCAL_NET_TIER_PCB,
+    )
+
+    assert _LOCAL_NET_TIER_ALIAS > _LOCAL_NET_TIER_NAME > _LOCAL_NET_TIER_PCB
+
+
+
+def test_arbitrate_overlapping_terminals_drops_weaker_side():
+    p = TerminalSpec(
+        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),
+              TerminalPin("2", 1, 1, Pt2D(1, 0))),
+        requested_net="VIN",
+        resolved_via_local=True,
+    )
+    n = TerminalSpec(
+        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),),
+        requested_net="VIN_L",
+        resolved_via_local=True,
+    )
+    result = AnnotationResult()
+    p2, n2 = _arbitrate_overlapping_terminals(
+        p, n, _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_NAME, "SERIES on R1.1", result,
+    )
+    assert p2 is not None and n2 is not None
+    assert {pin.pad_designator for pin in p2.pins} == {"2"}
+    assert {pin.pad_designator for pin in n2.pins} == {"1"}
+    assert any("both matched pin(s)" in w for w in result.warnings)
+    # The pad designator, not the internal "R1.1:1" arbitration key: the
+    # message tells the user to set PDN_*_PINS, which matches on pad names.
+    assert any("kept on N" in w and "dropped from P" in w
+               for w in result.warnings)
+    assert not result.errors
+
+
+
+def test_arbitrate_overlapping_terminals_equal_tier_errors():
+    p = TerminalSpec(
+        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),),
+        requested_net="VIN",
+    )
+    n = TerminalSpec(
+        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0)),),
+        requested_net="VIN_L",
+    )
+    result = AnnotationResult()
+    p2, n2 = _arbitrate_overlapping_terminals(
+        p, n, _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_ALIAS, "SERIES on R1", result,
+    )
+    assert p2 is None and n2 is None
+    assert any("PDN_P_PINS" in e for e in result.errors)
+
+
+
+def test_arbitrate_overlapping_terminals_ignores_same_pad_on_other_parts():
+    """Banana-jack style: pad '1' on J2 vs pad '1' on J3 is not an overlap."""
+    p = TerminalSpec(
+        pins=(TerminalPin(
+            "1", 1, 0, Pt2D(0, 0), component_designator="J2",
+        ),),
+        requested_net="+5V",
+    )
+    n = TerminalSpec(
+        pins=(TerminalPin(
+            "1", 1, 1, Pt2D(10, 0), component_designator="J3",
+        ),),
+        requested_net="GND",
+    )
+    result = AnnotationResult()
+    p2, n2 = _arbitrate_overlapping_terminals(
+        p, n, _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_ALIAS, "SOURCE on J2", result,
+    )
+    assert p2 is p and n2 is n
+    assert not result.errors
+    assert not result.warnings
+
+
+
+def test_channel_token_must_come_from_flattening():
+    """A part merely NAMED FB_2 is not channel 2 of FB, so an unrelated
+    repeated sheet's VIN.2 must not match it."""
+    # Genuine channel instance: the placed designator is the schematic one
+    # plus the channel token, so the separators may legitimately disagree.
+    assert _local_net_label_matches("VIN_1", "VIN", {"R1", "R1.1"})
+    assert _local_net_label_matches("VIN.1", "VIN", {"R1", "R1_1"})
+    # Not a channel: nothing in the candidate set is "FB" + sep + "2".
+    assert not _local_net_label_matches("VIN.2", "VIN", {"FB_2"})
+    assert not _local_net_label_matches("VIN_3", "VIN", {"SW_3"})
+    # An exact label still matches regardless.
+    assert _local_net_label_matches("VIN", "VIN", {"FB_2"})
+
+# --- Sheet-symbol per-instance overrides ---
+
+# --- Sheet-symbol per-instance overrides --------------------------------------
+
+
+
+def test_compile_falls_back_to_to_netlist_with_the_designs_own_options():
+    """Rebuilding NetlistOptions.from_prjpcb() drops the merged per-sheet
+    parameters that net labels substitute — only AltiumDesign.from_prjpcb adds
+    them — so a fallback that does so silently renames nets."""
+
+    from fypa.altium.extract import _compile_schematic_netlist
+
+    sentinel = object()
+    calls = []
+
+    class _Design:
+        schdocs = ["a.SchDoc"]
+        project = None
+
+        def to_netlist(self):
+            calls.append("to_netlist")
+            return sentinel
+
+    netlist, sheet_names = _compile_schematic_netlist(_Design())
+    assert netlist is sentinel
+    assert sheet_names == ()
+    assert calls == ["to_netlist"]
+
+
+
+def test_empty_side_errors_without_a_contradictory_warning():
+    """Warning that pins were "dropped from N" and then that N is empty and
+    the directive discarded reads as two contradictory log lines."""
+    shared = TerminalPin("1", 1, 0, Pt2D(0, 0))
+    p = TerminalSpec(pins=(shared,), requested_net="VIN")
+    n = TerminalSpec(pins=(shared,), requested_net="VIN_L")
+    result = AnnotationResult()
+    p2, n2 = _arbitrate_overlapping_terminals(
+        p, n, _LOCAL_NET_TIER_NAME, _LOCAL_NET_TIER_ALIAS,
+        "SERIES on R5", result,
+    )
+    assert p2 is not None and n2 is None
+    assert result.errors and "would be empty" in result.errors[0]
+    assert result.warnings == []
+
+
+
+def test_equal_tier_error_points_at_the_remedy_that_works():
+    shared = TerminalPin("1", 1, 0, Pt2D(0, 0))
+    p = TerminalSpec(pins=(shared,), requested_net="VIN")
+    n = TerminalSpec(pins=(shared,), requested_net="VIN")
+    result = AnnotationResult()
+    p2, n2 = _arbitrate_overlapping_terminals(
+        p, n, _LOCAL_NET_TIER_NAME, _LOCAL_NET_TIER_NAME,
+        "SERIES on R5", result,
+    )
+    assert p2 is None and n2 is None
+    assert "outranks a net-name match" in result.errors[0]
+
+
+
+def test_explicit_pin_override_outranks_a_net_name_match():
+    """The overlap error tells the user to set PDN_*_PINS. That advice only
+    works if an explicit pin list actually breaks the tie."""
+    from fypa.altium.annotations import (
+        _LOCAL_NET_TIER_DIRECT, _LOCAL_NET_TIER_OVERRIDE,
+    )
+
+    assert _LOCAL_NET_TIER_OVERRIDE < _LOCAL_NET_TIER_DIRECT
+
+
+
+def test_harvest_falls_back_to_file_name_when_source_path_is_absent():
+    from types import SimpleNamespace
+
+    from fypa.altium.extract import _harvest_physical_sheet_names
+
+    compiled = SimpleNamespace(physical_documents=[
+        SimpleNamespace(id="physical:0", file_name="Power.SchDoc"),
+    ])
+    assert _harvest_physical_sheet_names(compiled) == (
+        ("physical:0", "Power.SchDoc"),
+    )
+
+
+
+def test_harvest_is_empty_on_a_release_without_physical_documents():
+    """The installed library may predate the compiled model entirely; that
+    must yield an empty map, not an exception."""
+    from types import SimpleNamespace
+
+    from fypa.altium.extract import _harvest_physical_sheet_names
+
+    assert _harvest_physical_sheet_names(SimpleNamespace()) == ()
+    assert _harvest_physical_sheet_names(
+        SimpleNamespace(physical_documents=None)) == ()
+    # Entries missing either half are skipped rather than half-recorded.
+    assert _harvest_physical_sheet_names(SimpleNamespace(physical_documents=[
+        SimpleNamespace(id=None, source_path="A.SchDoc"),
+        SimpleNamespace(id="physical:0", source_path=None, file_name=None),
+    ])) == ()
+
+
+
+# --- physical-page-map harvesting ---------------------------------------------
+
+
+def test_harvest_prefers_source_path_over_bare_file_name():
+    """file_name is the bare leaf, so harvesting it collapses same-named
+    sheets in different directories onto one map value."""
+    from types import SimpleNamespace
+
+    from fypa.altium.extract import _harvest_physical_sheet_names
+
+    compiled = SimpleNamespace(physical_documents=[
+        SimpleNamespace(id="physical:0", source_path="SubA/Power.SchDoc",
+                        file_name="Power.SchDoc"),
+        SimpleNamespace(id="physical:1", source_path="SubB/Power.SchDoc",
+                        file_name="Power.SchDoc"),
+    ])
+    assert _harvest_physical_sheet_names(compiled) == (
+        ("physical:0", "SubA/Power.SchDoc"),
+        ("physical:1", "SubB/Power.SchDoc"),
+    )
+
+
+
+def test_local_net_label_matches_separator_agnostic_channel_token():
+    """Net VIN_1 must match local VIN on designator R1.1 (._ separators differ)."""
+    assert _local_net_label_matches("VIN_1", "VIN", {"R1", "R1.1"})
+    assert _local_net_label_matches("VIN.1", "VIN", {"R1", "R1_1"})
+    assert not _local_net_label_matches("VIN_L.1", "VIN", {"R1", "R1.1"})
+    assert _local_net_label_matches("VIN_L.1", "VIN_L", {"R1", "R1.1"})
+
+
+
+def test_lookup_inferred_vin_bounds_chain_length():
+    """A chain longer than the hop cap errors instead of walking on."""
+    chain = {f"N{i}": f"N{i + 1}" for i in range(_SERIES_VIN_MAX_HOPS + 3)}
+    vin, failure, _hops = _lookup_inferred_vin(
+        "N0", {"N99": 48.0}, graph=_SeriesVinGraph(upstream=chain),
+    )
+    assert vin is None
+    assert failure == "too_deep"
+
+
+
+def test_lookup_inferred_vin_crosses_single_undirected_link():
+    """An auto-inferred 2-pin element has no P/N direction, so it is crossed
+    only when it is the one unvisited way out of the net."""
+    supply_map = {"VDD_48V_IN": 48.0}
+    one_way = _SeriesVinGraph(
+        undirected={
+            "VDD_48V": frozenset({"VDD_48V_IN"}),
+            "VDD_48V_IN": frozenset({"VDD_48V"}),
+        },
+    )
+    assert _lookup_inferred_vin("VDD_48V", supply_map, graph=one_way) == (
+        48.0, None, 1,
+    )
+    forked = _SeriesVinGraph(
+        undirected={"VDD_48V": frozenset({"VDD_48V_IN", "VDD_SENSE"})},
+    )
+    assert _lookup_inferred_vin("VDD_48V", supply_map, graph=forked) == (
+        None, "undirected", 0,
+    )
+
+
+
+def test_lookup_inferred_vin_declared_rail_beats_series_ambiguity():
+    """A rail whose voltage is declared resolves even when SERIES links to it
+    disagree — parallel ferrites / ORing FETs / fuse+bypass all land here."""
+    assert _lookup_inferred_vin(
+        "VDD_12V", {"VDD_12V": 12.0},
+        graph=_SeriesVinGraph(ambiguous=frozenset({"VDD_12V"})),
+    ) == (12.0, None, 0)
+
+
+
+def test_lookup_inferred_vin_exact_match_without_series_walk():
+    """Without a SERIES graph, only direct supply_map hits resolve."""
+    supply_map = {"VDD_48V": 48.0, "VDD_12V": 12.0}
+    assert _lookup_inferred_vin("VDD_48V", supply_map) == (48.0, None, 0)
+    assert _lookup_inferred_vin("VDD_12V", supply_map) == (12.0, None, 0)
+    assert _lookup_inferred_vin("VDD_48V_RP", supply_map) == (None, None, 0)
+
+
+
+def test_lookup_inferred_vin_series_ambiguous_and_cycle():
+    supply_map = {"VDD_48V_IN": 48.0}
+    assert _lookup_inferred_vin(
+        "VDD_48V_RP", supply_map,
+        graph=_SeriesVinGraph(ambiguous=frozenset({"VDD_48V_RP"})),
+    ) == (None, "ambiguous", 0)
+    assert _lookup_inferred_vin(
+        "VDD_48V_RP", supply_map,
+        graph=_SeriesVinGraph(
+            upstream={"VDD_48V_RP": "VDD_48V", "VDD_48V": "VDD_48V_RP"},
+        ),
+    ) == (None, "cycle", 1)
+
+
+
+def test_lookup_inferred_vin_walks_series_upstream():
+    supply_map = {"VDD_48V_IN": 48.0}
+    graph = _SeriesVinGraph(
+        upstream={"VDD_48V_RP": "VDD_48V", "VDD_48V": "VDD_48V_IN"},
+    )
+    # Two hops from the named rail — the caller warns on any non-zero hop count.
+    assert _lookup_inferred_vin(
+        "VDD_48V_RP", supply_map, graph=graph,
+    ) == (48.0, None, 2)
+
+
+
+def test_overlap_messages_name_pads_not_arbitration_keys():
+    """The keys are composite ("R5:1") but PDN_*_PINS matches bare pad names,
+    so printing the key sent the user to an error about an unknown pin."""
+    p = TerminalSpec(
+        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0), component_designator="R5"),
+              TerminalPin("2", 1, 0, Pt2D(0, 0), component_designator="R5")),
+        requested_net="VIN",
+    )
+    n = TerminalSpec(
+        pins=(TerminalPin("1", 1, 0, Pt2D(0, 0), component_designator="R5"),),
+        requested_net="VIN_L",
+    )
+    result = AnnotationResult()
+    _arbitrate_overlapping_terminals(
+        p, n, _LOCAL_NET_TIER_ALIAS, _LOCAL_NET_TIER_NAME,
+        "SERIES on R5", result,
+    )
+    text = " ".join(result.warnings + result.errors)
+    assert "R5:1" not in text
+    assert "pin(s) 1" in text
+
+
+
+def test_plain_sheet_names_are_unaffected_by_the_page_id_path():
+    assert _sheet_name_matches("Power.SchDoc", ["Power.SchDoc"])
+    assert _sheet_name_matches("Power.SchDoc", ["SubA/Power.SchDoc"])
+    assert not _sheet_name_matches("SubA/Power.SchDoc", ["SubB/Power.SchDoc"])
+
+
+
+def test_regulator_smps_vin_does_not_warn_on_directly_declared_rail():
+    proj = _series_vin_proj(
+        {
+            "PDN_ROLE": "SERIES", "PDN_R": "50m",
+            "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
+        },
+        in_p_net="VDD_48V_IN",
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert not any("SERIES hop(s) upstream" in w for w in result.warnings)
+
+
+
+def test_regulator_smps_vin_resolves_under_merged_net_name():
+    """The user may write either merged name. Both the supply map and the
+    lookup key are canonicalised, so IN_P_NET on the folded name still lands."""
+    proj = _series_vin_proj(
+        {
+            "PDN_ROLE": "SERIES", "PDN_R": "50m",
+            "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
+        },
+        in_p_net="VDD_48V_F",   # the name the user wrote
+        in_p_pad_net=2,         # ...folded into VDD_48V by the merge pre-pass
+    )
+    result = parse_annotations(proj, enabled_layers=[1], net_remap={4: 2})
+    reg = next(d for d in result.directives if d.designator == "U5")
+    assert abs(reg.gain - (12.0 / (48.0 * 0.8))) < 1e-6, result.errors
+
+
+
+def test_regulator_smps_vin_series_ambiguous_fork():
+    proj = _minimal_proj(
+        nets=(
+            RawNet("GND"), RawNet("VDD_48V_IN"), RawNet("VDD_48V"),
+            RawNet("VDD_48V_RP"), RawNet("VDD_12V"), RawNet("ALT_48V"),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="J7", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SOURCE", "PDN_V": "48",
+                    "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="J8", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES", "PDN_R": "50m",
+                    "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="Q3a", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES", "PDN_R": "100m",
+                    "PDN_P_NET": "VDD_48V", "PDN_N_NET": "VDD_48V_RP",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="Q3b", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES", "PDN_R": "200m",
+                    "PDN_P_NET": "ALT_48V", "PDN_N_NET": "VDD_48V_RP",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="U5", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_REGULATOR_TYPE": "SMPS",
+                    "PDN_REGULATOR_EFFICIENCY": "0.8",
+                    "PDN_V": "12",
+                    "PDN_OUT_P_NET": "VDD_12V",
+                    "PDN_OUT_N_NET": "GND",
+                    "PDN_IN_P_NET": "VDD_48V_RP",
+                    "PDN_IN_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J7", center=Pt2D(-15, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="CONN", source_designator="J7",
+            ),
+            RawPcbComponent(
+                designator="J8", center=Pt2D(-10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="FUSE", source_designator="J8",
+            ),
+            RawPcbComponent(
+                designator="Q3a", center=Pt2D(-5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOT", source_designator="Q3a",
+            ),
+            RawPcbComponent(
+                designator="Q3b", center=Pt2D(-4, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOT", source_designator="Q3b",
+            ),
+            RawPcbComponent(
+                designator="U5", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOT", source_designator="U5",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1, -15), _pad(0, "2", 0, -14),
+            _pad(1, "1", 1, -10), _pad(1, "2", 2, -9),
+            _pad(2, "1", 2, -5), _pad(2, "2", 3, -4),
+            _pad(3, "1", 5, -4), _pad(3, "2", 3, -3),
+            _pad(4, "1", 4, 0), _pad(4, "2", 0, 1),
+            _pad(4, "3", 3, 2), _pad(4, "4", 0, 3),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert not result.ok
+    assert any("ambiguous SERIES upstream" in e for e in result.errors)
+
+
+# --- SERIES Vin graph construction --------------------------------------------
+
+_SERIES_VIN_NETS = {
+    "GND": 0, "VDD_48V_IN": 1, "VDD_48V": 2, "VDD_12V": 3, "VDD_48V_F": 4,
+}
+
+
+
+def test_regulator_smps_vin_through_series_chain():
+    """VIP-style: SOURCE -> SERIES -> SERIES -> SMPS on downstream net."""
+    proj = _minimal_proj(
+        nets=(
+            RawNet("GND"), RawNet("VDD_48V_IN"), RawNet("VDD_48V"),
+            RawNet("VDD_48V_RP"), RawNet("VDD_12V"),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="J7", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SOURCE",
+                    "PDN_V": "48",
+                    "PDN_P_NET": "VDD_48V_IN",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="J8", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN_R": "50m",
+                    "PDN_P_NET": "VDD_48V_IN",
+                    "PDN_N_NET": "VDD_48V",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="Q3", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN_R": "300m",
+                    "PDN_P_NET": "VDD_48V",
+                    "PDN_N_NET": "VDD_48V_RP",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="U5", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_REGULATOR_TYPE": "SMPS",
+                    "PDN_REGULATOR_EFFICIENCY": "0.8",
+                    "PDN_V": "12",
+                    "PDN_OUT_P_NET": "VDD_12V",
+                    "PDN_OUT_N_NET": "GND",
+                    "PDN_IN_P_NET": "VDD_48V_RP",
+                    "PDN_IN_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="J7", center=Pt2D(-15, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="CONN", source_designator="J7",
+            ),
+            RawPcbComponent(
+                designator="J8", center=Pt2D(-10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="FUSE", source_designator="J8",
+            ),
+            RawPcbComponent(
+                designator="Q3", center=Pt2D(-5, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOT", source_designator="Q3",
+            ),
+            RawPcbComponent(
+                designator="U5", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="SOT", source_designator="U5",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1, -15), _pad(0, "2", 0, -14),
+            _pad(1, "1", 1, -10), _pad(1, "2", 2, -9),
+            _pad(2, "1", 2, -5), _pad(2, "2", 3, -4),
+            _pad(3, "1", 4, 0), _pad(3, "2", 0, 1),
+            _pad(3, "3", 3, 2), _pad(3, "4", 0, 3),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    reg = next(d for d in result.directives if d.designator == "U5")
+    assert isinstance(reg, RegulatorSpec)
+    assert reg.regulator_type == "SMPS"
+    assert abs(reg.gain - (12.0 / (48.0 * 0.8))) < 1e-6
+    assert not any("cannot infer input voltage" in e for e in result.errors)
+
+
+
+def test_regulator_smps_vin_warns_when_inferred_through_series_chain():
+    """Vin taken from a walked chain is a guess about which leg is the power
+    path — a sense or bleed resistor produces a silently wrong gain, so say so."""
+    proj = _series_vin_proj({
+        "PDN_ROLE": "SERIES", "PDN_R": "50m",
+        "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
+    })
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert any(
+        "was inferred 1 SERIES hop(s) upstream" in w for w in result.warnings
+    ), result.warnings
+
+
+
+def test_resolve_local_net_pins_pcb_confirmed_beats_name():
+    """When PCB net confirms a row, prefer that tier over bare name matches."""
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="OTHER",
+            aliases=["VIN"],
+            source_sheets=["Supply.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "2")],
+        ),
+        _FakeNet(
+            name="VIN_1",
+            aliases=["VIN"],
+            source_sheets=["Supply.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "1")],
+        ),
+    ])
+    pins, tier = _resolve_local_net_pins(
+        netlist, "R1", "Supply.SchDoc", "VIN",
+        pcb_designator="R1.1",
+        routed_pin_keys={"1", "2"},
+        pcb_net_by_pin={"1": "VIN_1", "2": "VOUT"},
+    )
+    # Pin 1 is PCB-confirmed (VIN_1 on the row); pin 2 is alias-only → drop it.
+    assert pins == ["1"]
+    assert tier == _LOCAL_NET_TIER_PCB
+
+
+
+def test_resolve_local_net_pins_physical_source_sheet():
+    physical = (
+        "physical:0:logical:0:main.SchDoc:child:1:sheet_symbol:U_PWR"
+        ":sheet:power.SchDoc"
+    )
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="Sheet1_+3V3",
+            aliases=["+3V3"],
+            source_sheets=[physical],
+            terminals=[_FakeTerminal("U1", "14"), _FakeTerminal("C1", "1")],
+        ),
+    ])
+    proj = _minimal_proj(
+        physical_sheet_names=((physical, "Power.SchDoc"),),
+        compiled_netlist=netlist,
+    )
+    pins, _tier = _resolve_local_net_pins(
+        netlist, "U1", "Power.SchDoc", "+3V3", sheet_map=_sheet_map(proj),
+    )
+    assert pins == ["14"]
+
+
+
+def test_resolve_local_net_pins_prefers_name_over_shared_alias():
+    """Two nets sharing bare alias VIN: keep only the channel name-level match.
+
+    Models the multi-channel case where both sides of a SERIES element carry
+    the same local alias in the compiled netlist. The P label VIN must resolve
+    to pin 2 (net VIN_1) and not also claim pin 1 (net VIN_L.1).
+    """
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="VIN_1",
+            aliases=["VIN", "VIN.1"],
+            source_sheets=["Supply.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "2")],
+        ),
+        _FakeNet(
+            name="VIN_L.1",
+            aliases=["VIN", "VIN.1", "VIN.2"],
+            source_sheets=["Supply.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "1")],
+        ),
+    ])
+    pins, tier = _resolve_local_net_pins(
+        netlist, "R1", "Supply.SchDoc", "VIN",
+        pcb_designator="R1.1",
+        routed_pin_keys={"1", "2"},
+    )
+    assert pins == ["2"]
+    assert tier == _LOCAL_NET_TIER_NAME
+
+    n_pins, n_tier = _resolve_local_net_pins(
+        netlist, "R1", "Supply.SchDoc", "VIN_L",
+        pcb_designator="R1.1",
+        routed_pin_keys={"1", "2"},
+    )
+    assert n_pins == ["1"]
+    assert n_tier == _LOCAL_NET_TIER_NAME
+
+
+
+def test_series_shared_alias_resolves_disjoint_p_n():
+    """SERIES with local VIN / VIN_L must not short both pads of a 2-pin part."""
+    netlist = _FakeNetlist(nets=[
+        _FakeNet(
+            name="VIN_1",
+            aliases=["VIN", "VIN.1"],
+            source_sheets=["Supply.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "2")],
+        ),
+        _FakeNet(
+            name="VIN_L.1",
+            aliases=["VIN", "VIN.1"],
+            source_sheets=["Supply.SchDoc"],
+            terminals=[_FakeTerminal("R1.1", "1")],
+        ),
+    ])
+    proj = _minimal_proj(
+        nets=(RawNet("VIN_1"), RawNet("VIN_L.1")),
+        pcb_components=(
+            RawPcbComponent(
+                designator="R1.1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1005R", source_designator="R1",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN_R": "10m",
+                    "PDN_P_NET": "VIN",
+                    "PDN_N_NET": "VIN_L",
+                },
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1, 0),  # VIN_L.1
+            _pad(0, "2", 0, 1),  # VIN_1
+        ),
+        compiled_netlist=netlist,
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    series = [d for d in result.directives if isinstance(d, ResistorSpec)]
+    assert len(series) == 1
+    r = series[0]
+    p_nets = {p.net_index for p in r.p.pins}
+    n_nets = {p.net_index for p in r.n.pins}
+    assert p_nets == {0}
+    assert n_nets == {1}
+    assert p_nets.isdisjoint(n_nets)
+
+
+
+def test_series_upstream_map_auto_inferred_link_is_direction_agnostic():
+    """_autoinfer_2pin_nets takes P/N from raw pad order, so the Vin result must
+    not change when the two RawPad entries are swapped."""
+    params = {"PDN_ROLE": "SERIES", "PDN_R": "50m"}
+    forward = _series_vin_proj(params, series_pads=(("1", 1), ("2", 2)))
+    reversed_ = _series_vin_proj(params, series_pads=(("2", 2), ("1", 1)))
+    expected = 12.0 / (48.0 * 0.8)
+    for proj in (forward, reversed_):
+        graph = _collect_series_upstream_map(
+            _iter_pdn_parameter_sources(proj), proj,
+        )
+        # Recorded as an undirected pair — pad order states no power flow.
+        assert not graph.upstream
+        assert graph.undirected["VDD_48V"] == frozenset({"VDD_48V_IN"})
+        result = parse_annotations(proj, enabled_layers=[1])
+        reg = next(d for d in result.directives if d.designator == "U5")
+        assert abs(reg.gain - expected) < 1e-6, result.errors
+
+
+
+def test_series_upstream_map_reads_indexed_role_only_channels():
+    """A part whose SERIES channels come only from PDN<n>_ROLE overrides still
+    contributes its links — _is_pdn_annotated admits it, so the graph must too."""
+    proj = _series_vin_proj({
+        "PDN1_ROLE": "SERIES", "PDN1_R": "50m",
+        "PDN1_P_NET": "VDD_48V_IN", "PDN1_N_NET": "VDD_48V",
+        "PDN2_ROLE": "SERIES", "PDN2_R": "50m",
+        "PDN2_P_NET": "VDD_48V", "PDN2_N_NET": "VDD_12V",
+    })
+    graph = _collect_series_upstream_map(_iter_pdn_parameter_sources(proj), proj)
+    assert graph.upstream == {
+        "VDD_48V": "VDD_48V_IN", "VDD_12V": "VDD_48V",
+    }
+
+
+
+def test_series_upstream_map_reads_pin_specified_channels():
+    """PDN_P_PINS / PDN_N_PINS is a supported way to state a SERIES element's
+    two sides, so it must produce the same edge PDN_P_NET / PDN_N_NET would."""
+    proj = _series_vin_proj(
+        {
+            "PDN_ROLE": "SERIES", "PDN_R": "50m",
+            "PDN_P_PINS": "1", "PDN_N_PINS": "2,3",
+        },
+        # pin 1 on VDD_48V_IN, pins 2+3 both on VDD_48V.
+        series_pads=(("1", 1), ("2", 2), ("3", 2)),
+    )
+    graph = _collect_series_upstream_map(_iter_pdn_parameter_sources(proj), proj)
+    assert graph.upstream == {"VDD_48V": "VDD_48V_IN"}
+
+    result = parse_annotations(proj, enabled_layers=[1])
+    reg = next(d for d in result.directives if d.designator == "U5")
+    assert abs(reg.gain - (12.0 / (48.0 * 0.8))) < 1e-6
+
+
+
+def test_series_upstream_map_skips_merged_short_self_edges():
+    """A 0 Ω the merge pre-pass absorbed has both ends on one net now. Neither
+    the skip list nor the self-edge guard may let it shadow the real edge."""
+    proj = _series_vin_proj(
+        {
+            "PDN_ROLE": "SERIES", "PDN_R": "50m",
+            "PDN_P_NET": "VDD_48V_IN", "PDN_N_NET": "VDD_48V",
+        },
+        extra_series={
+            "PDN_ROLE": "SERIES", "PDN_R": "0.001",
+            "PDN_P_NET": "VDD_48V", "PDN_N_NET": "VDD_48V_F",
+        },
+    )
+    # VDD_48V_F (index 4) merged into VDD_48V (index 2).
+    net_remap = {4: 2}
+    graph = _collect_series_upstream_map(
+        _iter_pdn_parameter_sources(proj), proj,
+        net_remap=net_remap, skip_designators={"R9"},
+    )
+    assert graph.upstream == {"VDD_48V": "VDD_48V_IN"}
+    assert not graph.ambiguous
+
+    # Even without the skip list, the self-edge guard must hold the line.
+    unskipped = _collect_series_upstream_map(
+        _iter_pdn_parameter_sources(proj), proj, net_remap=net_remap,
+    )
+    assert unskipped.upstream == {"VDD_48V": "VDD_48V_IN"}
+    assert not unskipped.ambiguous
+
+
+
+def test_sheet_map_keeps_same_named_sheets_in_different_directories_apart():
+    """Harvesting the bare leaf would collapse these onto one name, which is
+    the collision _sheet_name_matches exists to prevent."""
+    page_a = "physical:0:logical:0:SubA/Power.SchDoc"
+    page_b = "physical:1:logical:1:SubB/Power.SchDoc"
+    proj = _minimal_proj(physical_sheet_names=(
+        (page_a, "SubA/Power.SchDoc"),
+        (page_b, "SubB/Power.SchDoc"),
+    ))
+    smap = _sheet_map(proj)
+    assert _sheet_name_matches("SubA/Power.SchDoc", [page_a], sheet_map=smap)
+    assert not _sheet_name_matches("SubA/Power.SchDoc", [page_b], sheet_map=smap)
+
+
+
+def test_sheet_name_matches_physical_page_id_via_map():
+    """altium_monkey ≥ 2026.7 emits physical page ids in source_sheets."""
+    physical = (
+        "physical:0:logical:0:main.SchDoc:child:1:sheet_symbol:U_PWR"
+        ":sheet:power.SchDoc"
+    )
+    proj = _minimal_proj(
+        physical_sheet_names=((physical, "Power.SchDoc"),),
+    )
+    smap = _sheet_map(proj)
+    assert _sheet_name_matches("Power.SchDoc", [physical], sheet_map=smap)
+    assert not _sheet_name_matches("Other.SchDoc", [physical], sheet_map=smap)
+
+
+
+def test_unmapped_physical_page_id_is_unknown_not_guessed():
+    """A child page id embeds its PARENT's logical id, so scanning it for a
+    ``*.SchDoc`` token yields the root sheet — which both hides real matches
+    and invents false ones. An unmapped id must read as unknown provenance,
+    degrading to the permissive path rather than binding to a guess."""
+    from fypa.altium.annotations import _logical_schdoc_name
+
+    child = (
+        "physical:0:logical:0:main.SchDoc:child:logical:0:main.SchDoc"
+        ":sheet_symbol:UID-ABC:1"
+    )
+    assert _logical_schdoc_name(child, {}) is None
+    # Not "matches the root sheet", and not a hard reject either: with no
+    # usable provenance the net is accepted the same way one with no
+    # source_sheets at all is.
+    assert _sheet_name_matches("Power.SchDoc", [child])
+    assert _sheet_name_matches("main.SchDoc", [child])
+    # …but a page the map DOES cover still discriminates.
+    proj = _minimal_proj(physical_sheet_names=((child, "Power.SchDoc"),))
+    smap = _sheet_map(proj)
+    assert _sheet_name_matches("Power.SchDoc", [child], sheet_map=smap)
+    assert not _sheet_name_matches("main.SchDoc", [child], sheet_map=smap)


### PR DESCRIPTION
## Summary

- Allow `PDN_<Des>_*` parameters on sheet symbols to override child-sheet PDN directives per PCB instance (e.g. different sink currents or regulator voltages for reused sheets).
- Bind overrides via `SOURCEUNIQUEID` path (preferred) or hierarchical-path / sheet-name fallback; support indexed channels and REPEAT slot forms (`PDN_J1_I.N`).
- Merge sheet-symbol value overrides onto PCB-ECO / Blanket directives for the same placement (no duplicate sources; clearer partial-coverage warnings).
- When repeated regulator sheets publish different `PDN_V` onto a shared local output name, expand that net per instance for SMPS Vin inference so rails do not collide or drop from the supply map; propagate along placed SERIES edges (including 2-pin autoinfer) and expand `PDN_IN_P_NET` per placement.

## Motivation

Reusable child sheets are often placed several times on one board. The shared schematic can only hold one default `PDN_*` value, but real loads and rail voltages differ per placement. Editing each physical instance only in the FYPA viewer or via PCB ECO does not keep that intent in the schematic. Sheet-symbol overrides (`PDN_<Des>_*` on each sheet symbol) keep per-instance values in Altium.

Different per-placement regulator voltages on a shared local switch/output label then require instance-scoped supply-map keys and SERIES-aware Vin lookup; otherwise SMPS gain inference can fail for downstream regulators on the filtered rails.

## Test plan

- [ ] `uv run pytest tests/test_annotations.py -q`
- [ ] Spot-check a project with ≥2 placements of the same child sheet and different `PDN_<Des>_I` (or `_V`) on each sheet symbol; confirm distinct directives per PCB instance
- [ ] Confirm UniqueID binding when present; hierpath fallback only when `SOURCEUNIQUEID` is empty
- [ ] Spot-check repeated regulator sheets with a shared local OUT name and a SERIES filter inductor; confirm downstream SMPS Vin / gain without “cannot infer input voltage”
