### PR TITLE
Add metric footprint detection and Capacitors/Impedance convention control

### DIFF
--- a/docs/pdn_impedance.md
+++ b/docs/pdn_impedance.md
@@ -111,7 +111,9 @@ The case size is parsed from the footprint name. FYPA recognises:
 Note that `0603` is both an imperial code *and* the metric code for an 0201.
 Unambiguous metric codes (1005, 1608, …) are always read as metric. For the
 ambiguous pair `0402` / `0603`, the **Case size convention** setting on the
-Impedance tab chooses imperial (default in Auto) or metric.
+Impedance tab chooses imperial (default in Auto) or metric. Names that spell
+out an imperial land pattern (`C_0402_SL`) stay imperial even when the
+project convention is metric.
 
 Pad geometry from the layout is always in millimetres — only the **name**
 convention affects classification and how the Pkg column is labelled.

--- a/docs/pdn_impedance.md
+++ b/docs/pdn_impedance.md
@@ -101,11 +101,20 @@ vendor's model.
 
 ### Package detection, and what "SMD only" means
 
-The case size is parsed from the footprint name, handling the three conventions
-seen in the wild: a bare imperial code (`C_0402_SL`), an explicit metric one
-(`C_0402_1005Metric`), and IPC-7351 land names (`CAPC1608X90N`, whose digits
-are always metric). Note that `0603` is both an imperial code *and* the metric
-code for an 0201; the metric reading is taken only when the name says so.
+The case size is parsed from the footprint name. FYPA recognises:
+
+* a bare imperial code (`C_0402_SL`, `0603`);
+* a bare metric code with optional suffix letters (`1005B`, `1608C`, `1608C-HD`);
+* an explicit metric suffix (`C_0402_1005Metric`);
+* IPC-7351 land names (`CAPC1608X90N`, whose digits are always metric).
+
+Note that `0603` is both an imperial code *and* the metric code for an 0201.
+Unambiguous metric codes (1005, 1608, …) are always read as metric. For the
+ambiguous pair `0402` / `0603`, the **Case size convention** setting on the
+Impedance tab chooses imperial (default in Auto) or metric.
+
+Pad geometry from the layout is always in millimetres — only the **name**
+convention affects classification and how the Pkg column is labelled.
 
 **Only SMD chip packages are supported.** A tantalum D-case brick, an
 electrolytic, anything through-hole — none has a case-size code, and none has an

--- a/fypa/altium_viewer.py
+++ b/fypa/altium_viewer.py
@@ -8970,6 +8970,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
             self._invalidate_caps_cache(repopulate=False, heavy=True)
             self._caps_shapes_cache = None
             self._impedance_populated = False
+            self._sync_footprint_convention_ui()
             if self._project is not None:
                 self._update_pending_rails()
 
@@ -25129,6 +25130,20 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         proj.viewer_settings["footprint_convention"] = conv
         self._display_dirty = True
 
+    def _sync_footprint_convention_ui(self) -> None:
+        """Refresh the Impedance-tab convention combo and package labels from
+        the active project — needed after an in-place project swap."""
+        combo = getattr(self, "imp_footprint_conv_combo", None)
+        if combo is not None:
+            current = self._footprint_convention()
+            combo.blockSignals(True)
+            idx = combo.findData(current)
+            if idx >= 0:
+                combo.setCurrentIndex(idx)
+            combo.blockSignals(False)
+        if getattr(self, "imp_pkg_table", None) is not None:
+            self._populate_package_table()
+
     def _build_capacitors_tab(self) -> QWidget:
         """Build the Capacitors tab — a sortable table of every decoupling
         capacitor with its Tier-1 mounted loop inductance, informational
@@ -26447,10 +26462,8 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
             "How bare case-size codes in footprint names are read and "
             "shown. Auto recognises unambiguous metric codes (1005, 1608) "
             "and treats bare 0402 / 0603 as imperial.")
-        self._footprint_conv_populating = True
         self.imp_footprint_conv_combo.currentIndexChanged.connect(
             self._on_footprint_convention_changed)
-        self._footprint_conv_populating = False
         conv_row.addWidget(self.imp_footprint_conv_combo, 1)
         layout.addLayout(conv_row)
 
@@ -26495,8 +26508,6 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         self._imp_pkg_populating = False
 
     def _on_footprint_convention_changed(self, _index: int = 0) -> None:
-        if getattr(self, "_footprint_conv_populating", False):
-            return
         combo = getattr(self, "imp_footprint_conv_combo", None)
         if combo is None:
             return
@@ -26690,6 +26701,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
             combo.blockSignals(False)
             if rails:
                 self._load_impedance_rail_config(rails[0])
+            self._sync_footprint_convention_ui()
             self._replot_impedance()
 
         self._ensure_cap_rows_async(_ready)

--- a/fypa/altium_viewer.py
+++ b/fypa/altium_viewer.py
@@ -7823,6 +7823,10 @@ _NET_TABLE_ROW_ROLE = int(Qt.UserRole) + 1
 # identity that survives the user re-sorting the table.
 _CAPS_TABLE_ROW_ROLE = int(Qt.UserRole) + 2
 
+# Canonical imperial package key on the Impedance-tab package table's name
+# cell — the visible text may be a metric label when that convention is on.
+_PKG_CANONICAL_ROLE = int(Qt.UserRole) + 3
+
 # Columns of the Capacitors-tab table: (display label, numeric?). Defined at
 # module scope so the label→index map below can be built from it (a class-body
 # comprehension can't see other class-body names).
@@ -23008,6 +23012,9 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         if caploop is not None:
             proj.viewer_settings["caploop"] = caploop.to_dict()
 
+        proj.viewer_settings["footprint_convention"] = \
+            self._footprint_convention()
+
         overlay_state = getattr(self, "_overlay_state", None)
         if overlay_state:
             proj.viewer_settings["overlay_state"] = {
@@ -25104,6 +25111,24 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
             self._caploop_settings_obj = obj
         return obj
 
+    def _footprint_convention(self) -> str:
+        """Case-size naming convention for footprint parsing and display."""
+        from fypa.caploop.packages import normalize_footprint_convention
+
+        if getattr(self, "_project", None) is not None:
+            stored = self._project.viewer_settings.get("footprint_convention")
+            if stored is not None:
+                return normalize_footprint_convention(str(stored))
+        return "auto"
+
+    def _set_footprint_convention(self, convention: str) -> None:
+        from fypa.caploop.packages import normalize_footprint_convention
+
+        conv = normalize_footprint_convention(convention)
+        proj = self._ensure_project()
+        proj.viewer_settings["footprint_convention"] = conv
+        self._display_dirty = True
+
     def _build_capacitors_tab(self) -> QWidget:
         """Build the Capacitors tab — a sortable table of every decoupling
         capacitor with its Tier-1 mounted loop inductance, informational
@@ -25323,10 +25348,12 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         # so toggling a checkbox is a millisecond, not a five-second freeze.
         _t1 = time.monotonic()
         forced = frozenset(d for d, v in includes.items() if v)
+        convention = self._footprint_convention()
         cached = getattr(self, "_caps_identity_cache", None)
         if (cached is not None and cached[0] is extracted
-                and cached[1] == settings and cached[2] == forced):
-            base = cached[3]
+                and cached[1] == settings and cached[2] == forced
+                and cached[3] == convention):
+            base = cached[4]
         else:
             base = identify_capacitors(
                 extracted, self._rail_to_members,
@@ -25334,8 +25361,10 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
                 settings=settings,
                 net_layer_shapes=shapes,
                 include_overrides={d: True for d in forced},
+                footprint_convention=convention,
             )
-            self._caps_identity_cache = (extracted, settings, forced, base)
+            self._caps_identity_cache = (
+                extracted, settings, forced, convention, base)
             log.info("Caps report: identify %.2fs (%d caps)",
                      time.monotonic() - _t1, len(base))
         caps = apply_cap_overrides(
@@ -25609,6 +25638,11 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
     def _populate_caps_table(self) -> None:
         """Fill the Capacitors table from the cached cap report. Same
         plain-cell + single click-dispatcher pattern as the Vias table."""
+        from fypa.caploop.packages import (
+            format_package_label,
+            package_detection_tooltip,
+        )
+
         log = logging.getLogger(__name__)
         _t0 = time.monotonic()
         rows = self._get_or_compute_cap_rows()
@@ -25619,6 +25653,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         warn_fg = QBrush(QColor(_t["warn_fg"]))
         action_fg = QBrush(QColor(_t["accent"]))
         muted_fg = QBrush(QColor(_t["fg_muted"]))
+        footprint_convention = self._footprint_convention()
 
         # itemChanged fires for every setItem during populate — guard the
         # include-toggle handler with a populating flag.
@@ -25672,6 +25707,9 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
             if row.get("target_is_override"):
                 target_text += " ✎"
 
+            package_label = format_package_label(
+                row.get("package"), footprint_convention)
+
             cells = (
                 None,  # action
                 None,  # use checkbox — set above
@@ -25679,7 +25717,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
                 row["rail"],
                 None if row.get("capacitance_f") is None
                 else row["capacitance_f"] * 1e6,
-                row.get("package") or "—",
+                package_label if row.get("package") else "—",
                 None if row.get("esl_h") is None else row["esl_h"] * 1e9,
                 None if row.get("esr_ohm") is None else row["esr_ohm"] * 1e3,
                 row.get("voltage_rating_v"),
@@ -25750,14 +25788,9 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
                 if col_label == "Flags":
                     item.setToolTip(self._cap_flags_tooltip(row))
                 if col_label == "Pkg":
-                    item.setToolTip(
-                        f"SMD case size parsed from the footprint "
-                        f"{row['cap'].footprint!r}. It selects the default "
-                        f"ESL / ESR from the package library."
-                        if row.get("package") else
-                        f"{row['cap'].footprint!r} is not a recognised SMD "
-                        "chip package. Set ESL and ESR on this part to "
-                        "include it in the impedance model.")
+                    item.setToolTip(package_detection_tooltip(
+                        row["cap"].footprint,
+                        row.get("package")))
                 if col_label in ("ESL (nH)", "ESR (mΩ)"):
                     is_esl = col_label.startswith("ESL")
                     overridden = row.get(
@@ -25771,12 +25804,12 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
                         item.setToolTip(
                             f"Per-part override. Double-click to change, or "
                             f"clear the field to fall back to the "
-                            f"{row['package']} package default.")
+                            f"{package_label} package default.")
                         item.setForeground(action_fg)
                     else:
                         item.setToolTip(
                             f"Typical equivalent series {what} for a "
-                            f"{row['package']} package. Double-click to "
+                            f"{package_label} package. Double-click to "
                             "override this part.")
                         item.setForeground(muted_fg)
                 if col_label == "Target":
@@ -26397,6 +26430,30 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         note.setStyleSheet(f"QLabel {{ color: {_T()['fg_muted']}; }}")
         layout.addWidget(note)
 
+        conv_row = QHBoxLayout()
+        conv_row.addWidget(QLabel("Case size convention:"))
+        self.imp_footprint_conv_combo = QComboBox()
+        for value, label in (
+            ("auto", "Auto"),
+            ("metric", "Metric"),
+            ("imperial", "Imperial"),
+        ):
+            self.imp_footprint_conv_combo.addItem(label, value)
+        current = self._footprint_convention()
+        idx = self.imp_footprint_conv_combo.findData(current)
+        if idx >= 0:
+            self.imp_footprint_conv_combo.setCurrentIndex(idx)
+        self.imp_footprint_conv_combo.setToolTip(
+            "How bare case-size codes in footprint names are read and "
+            "shown. Auto recognises unambiguous metric codes (1005, 1608) "
+            "and treats bare 0402 / 0603 as imperial.")
+        self._footprint_conv_populating = True
+        self.imp_footprint_conv_combo.currentIndexChanged.connect(
+            self._on_footprint_convention_changed)
+        self._footprint_conv_populating = False
+        conv_row.addWidget(self.imp_footprint_conv_combo, 1)
+        layout.addLayout(conv_row)
+
         self.imp_pkg_table = QTableWidget()
         self.imp_pkg_table.setColumnCount(3)
         self.imp_pkg_table.setHorizontalHeaderLabels(
@@ -26417,12 +26474,17 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         return box
 
     def _populate_package_table(self) -> None:
+        from fypa.caploop.packages import format_package_label
+
         lib = self._caploop_package_library()
         table = self.imp_pkg_table
+        convention = self._footprint_convention()
         self._imp_pkg_populating = True
         table.setRowCount(len(lib))
         for r, model in enumerate(lib):
-            name = QTableWidgetItem(model.name)
+            name = QTableWidgetItem(
+                format_package_label(model.name, convention))
+            name.setData(_PKG_CANONICAL_ROLE, model.name)
             name.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
             table.setItem(r, 0, name)
             for c, value in ((1, model.esl_nh), (2, model.esr_mohm)):
@@ -26432,13 +26494,29 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         table.resizeColumnsToContents()
         self._imp_pkg_populating = False
 
+    def _on_footprint_convention_changed(self, _index: int = 0) -> None:
+        if getattr(self, "_footprint_conv_populating", False):
+            return
+        combo = getattr(self, "imp_footprint_conv_combo", None)
+        if combo is None:
+            return
+        value = combo.currentData()
+        if not value:
+            return
+        self._set_footprint_convention(str(value))
+        self._populate_package_table()
+        self._invalidate_caps_cache(heavy=True)
+
     def _on_package_item_changed(self, item) -> None:
         """Commit an edited ESL / ESR back to the library, persist it, and
         recompute every capacitor that uses that package."""
         if getattr(self, "_imp_pkg_populating", False) or item.column() == 0:
             return
         table = self.imp_pkg_table
-        package = table.item(item.row(), 0).text()
+        name_item = table.item(item.row(), 0)
+        package = name_item.data(_PKG_CANONICAL_ROLE) if name_item else None
+        if not package:
+            package = name_item.text() if name_item else ""
         lib = self._caploop_package_library()
         model = lib.get(package)
         try:

--- a/fypa/altium_viewer.py
+++ b/fypa/altium_viewer.py
@@ -25130,17 +25130,37 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         proj.viewer_settings["footprint_convention"] = conv
         self._display_dirty = True
 
+    def _build_footprint_convention_combo(self) -> QComboBox:
+        """Case-size naming convention — shared by Capacitors and Impedance tabs."""
+        combo = QComboBox()
+        for value, label in (
+            ("auto", "Auto"),
+            ("metric", "Metric"),
+            ("imperial", "Imperial"),
+        ):
+            combo.addItem(label, value)
+        current = self._footprint_convention()
+        idx = combo.findData(current)
+        if idx >= 0:
+            combo.setCurrentIndex(idx)
+        combo.setToolTip(
+            "How bare case-size codes in footprint names are read and "
+            "shown. Auto recognises unambiguous metric codes (1005, 1608) "
+            "and treats bare 0402 / 0603 as imperial.")
+        combo.currentIndexChanged.connect(self._on_footprint_convention_changed)
+        return combo
+
     def _sync_footprint_convention_ui(self) -> None:
-        """Refresh the Impedance-tab convention combo and package labels from
-        the active project — needed after an in-place project swap."""
-        combo = getattr(self, "imp_footprint_conv_combo", None)
-        if combo is not None:
-            current = self._footprint_convention()
-            combo.blockSignals(True)
-            idx = combo.findData(current)
-            if idx >= 0:
-                combo.setCurrentIndex(idx)
-            combo.blockSignals(False)
+        """Refresh convention combos and package labels from the active project."""
+        current = self._footprint_convention()
+        for attr in ("caps_footprint_conv_combo", "imp_footprint_conv_combo"):
+            combo = getattr(self, attr, None)
+            if combo is not None:
+                combo.blockSignals(True)
+                idx = combo.findData(current)
+                if idx >= 0:
+                    combo.setCurrentIndex(idx)
+                combo.blockSignals(False)
         if getattr(self, "imp_pkg_table", None) is not None:
             self._populate_package_table()
 
@@ -25192,6 +25212,11 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         )
         self.caps_overlay_box.toggled.connect(self._on_caps_overlay_toggled)
         filter_row.addWidget(self.caps_overlay_box)
+
+        filter_row.addSpacing(12)
+        filter_row.addWidget(QLabel("Footprints:"))
+        self.caps_footprint_conv_combo = self._build_footprint_convention_combo()
+        filter_row.addWidget(self.caps_footprint_conv_combo)
 
         filter_row.addSpacing(12)
         self.caps_tier23_btn = QPushButton("Compute Tier 2/3")
@@ -26447,23 +26472,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
 
         conv_row = QHBoxLayout()
         conv_row.addWidget(QLabel("Case size convention:"))
-        self.imp_footprint_conv_combo = QComboBox()
-        for value, label in (
-            ("auto", "Auto"),
-            ("metric", "Metric"),
-            ("imperial", "Imperial"),
-        ):
-            self.imp_footprint_conv_combo.addItem(label, value)
-        current = self._footprint_convention()
-        idx = self.imp_footprint_conv_combo.findData(current)
-        if idx >= 0:
-            self.imp_footprint_conv_combo.setCurrentIndex(idx)
-        self.imp_footprint_conv_combo.setToolTip(
-            "How bare case-size codes in footprint names are read and "
-            "shown. Auto recognises unambiguous metric codes (1005, 1608) "
-            "and treats bare 0402 / 0603 as imperial.")
-        self.imp_footprint_conv_combo.currentIndexChanged.connect(
-            self._on_footprint_convention_changed)
+        self.imp_footprint_conv_combo = self._build_footprint_convention_combo()
         conv_row.addWidget(self.imp_footprint_conv_combo, 1)
         layout.addLayout(conv_row)
 
@@ -26508,14 +26517,25 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         self._imp_pkg_populating = False
 
     def _on_footprint_convention_changed(self, _index: int = 0) -> None:
-        combo = getattr(self, "imp_footprint_conv_combo", None)
-        if combo is None:
-            return
-        value = combo.currentData()
+        sender = self.sender()
+        if isinstance(sender, QComboBox):
+            value = sender.currentData()
+        else:
+            combo = getattr(self, "imp_footprint_conv_combo", None)
+            value = combo.currentData() if combo else None
         if not value:
             return
         self._set_footprint_convention(str(value))
-        self._populate_package_table()
+        for attr in ("caps_footprint_conv_combo", "imp_footprint_conv_combo"):
+            combo = getattr(self, attr, None)
+            if combo is not None and combo is not sender:
+                combo.blockSignals(True)
+                idx = combo.findData(value)
+                if idx >= 0:
+                    combo.setCurrentIndex(idx)
+                combo.blockSignals(False)
+        if getattr(self, "imp_pkg_table", None) is not None:
+            self._populate_package_table()
         self._invalidate_caps_cache(heavy=True)
 
     def _on_package_item_changed(self, item) -> None:

--- a/fypa/caploop/identify.py
+++ b/fypa/caploop/identify.py
@@ -750,6 +750,7 @@ def identify_capacitors(
                            shapely.geometry.base.BaseGeometry] | None = None,
     include_overrides: dict[str, bool] | None = None,
     target_overrides: dict[str, str] | None = None,
+    footprint_convention: str = "auto",
 ) -> list[CapInstance]:
     """Find every decoupling capacitor and bundle its analysis geometry.
 
@@ -931,7 +932,8 @@ def identify_capacitors(
             designator=comp.designator,
             source_designator=comp.source_designator,
             footprint=comp.footprint,
-            package=detect_package(comp.footprint),
+            package=detect_package(
+                comp.footprint, convention=footprint_convention),
             center_xy=(comp.center.x, comp.center.y),
             mount_layer_id=mount_layer_id,
             rail_net=rail_net,

--- a/fypa/caploop/packages.py
+++ b/fypa/caploop/packages.py
@@ -117,8 +117,11 @@ def _has_explicit_imperial_marker(footprint: str, code: str) -> bool:
     return False
 
 
-def _code_match_priority(code: str) -> int:
+def _code_match_priority(code: str, footprint: str) -> int:
     """Higher = more confident. Used to pick among several bare codes."""
+    if (code in _AMBIGUOUS_CODES
+            and _has_explicit_imperial_marker(footprint, code)):
+        return 4
     if code in _METRIC_TO_IMPERIAL and code not in DEFAULT_PACKAGE_MODELS:
         return 3
     if code in DEFAULT_PACKAGE_MODELS and code not in _AMBIGUOUS_CODES:
@@ -229,7 +232,7 @@ def detect_package(
         pkg = _resolve_bare_code(code, conv, footprint)
         if pkg is None:
             continue
-        key = (_code_match_priority(code), -match.start(), pkg)
+        key = (_code_match_priority(code, footprint), -match.start(), pkg)
         if best is None or key > best:
             best = key
     return best[2] if best is not None else None

--- a/fypa/caploop/packages.py
+++ b/fypa/caploop/packages.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from typing import Literal
 
 
 @dataclass(frozen=True, slots=True)
@@ -82,6 +83,16 @@ _METRIC_TO_IMPERIAL: dict[str, str] = {
     "5750": "2220",
 }
 
+# Imperial codes that are also valid metric codes for a *different* body size.
+_AMBIGUOUS_CODES = frozenset({"0402", "0603"})
+
+_IMPERIAL_TO_METRIC: dict[str, str] = {
+    imperial: metric for metric, imperial in _METRIC_TO_IMPERIAL.items()
+}
+
+FootprintConvention = Literal["auto", "metric", "imperial"]
+FOOTPRINT_CONVENTIONS: tuple[str, ...] = ("auto", "metric", "imperial")
+
 # IPC-7351 chip-capacitor land names, e.g. "CAPC1608X90N" — the digits are
 # always metric.
 _IPC_RE = re.compile(r"CAPC(\d{4})X\d+", re.IGNORECASE)
@@ -91,18 +102,74 @@ _METRIC_RE = re.compile(r"(\d{4})\s*metric", re.IGNORECASE)
 _CODE_RE = re.compile(r"(?<!\d)(\d{4,5})(?!\d)")
 
 
-def detect_package(footprint: str) -> str | None:
+def normalize_footprint_convention(convention: str) -> FootprintConvention:
+    """Return a valid convention name, defaulting to ``auto``."""
+    if convention in FOOTPRINT_CONVENTIONS:
+        return convention  # type: ignore[return-value]
+    return "auto"
+
+
+def format_package_label(
+    package: str | None,
+    convention: str = "imperial",
+) -> str:
+    """Display label for a canonical (imperial-keyed) package name."""
+    if not package:
+        return "—"
+    conv = normalize_footprint_convention(convention)
+    if conv == "metric":
+        return _IMPERIAL_TO_METRIC.get(package, package)
+    return package
+
+
+def package_detection_tooltip(
+    footprint: str,
+    package: str | None,
+) -> str:
+    """Tooltip for the Capacitors-tab Pkg column."""
+    if not package:
+        return (
+            f"{footprint!r} is not a recognised SMD chip package. "
+            "Set ESL and ESR on this part to include it in the "
+            "impedance model.")
+    imperial_label = format_package_label(package, "imperial")
+    metric = _IMPERIAL_TO_METRIC.get(package)
+    if metric:
+        body = (
+            f"SMD case size parsed from footprint {footprint!r} → "
+            f"{imperial_label} ({metric} metric).")
+    else:
+        body = (
+            f"SMD case size parsed from footprint {footprint!r} → "
+            f"{imperial_label}.")
+    return body + " It selects the default ESL / ESR from the package library."
+
+
+def detect_package(
+    footprint: str,
+    *,
+    convention: str = "auto",
+) -> str | None:
     """Imperial case code for an SMD footprint name, or ``None``.
 
-    Handles the three conventions seen in the wild — a bare imperial code
-    (``C_0402_SL``, ``0603``), an explicit metric one (``C_0402_1005Metric``),
-    and IPC-7351 land names (``CAPC1608X90N``) whose digits are always metric.
+    Handles the conventions seen in the wild — a bare imperial code
+    (``C_0402_SL``, ``0603``), a bare metric one (``1005B``, ``1608C``),
+    an explicit metric suffix (``C_0402_1005Metric``), and IPC-7351 land
+    names (``CAPC1608X90N``) whose digits are always metric.
+
+    The return value is always the **imperial canonical key** used by
+    :class:`PackageLibrary`, regardless of ``convention``. ``convention``
+    only disambiguates bare ``0402`` / ``0603`` codes that exist in both
+    systems.
+
     Returns ``None`` for anything else, which is the signal that the part is
     not an SMD chip capacitor and needs a per-part override to take part in the
     impedance model.
     """
     if not footprint:
         return None
+
+    conv = normalize_footprint_convention(convention)
 
     ipc = _IPC_RE.search(footprint)
     if ipc:
@@ -114,8 +181,14 @@ def detect_package(footprint: str) -> str | None:
 
     for match in _CODE_RE.finditer(footprint):
         code = match.group(1)
+        if code in _AMBIGUOUS_CODES:
+            if conv == "metric":
+                return _METRIC_TO_IMPERIAL.get(code)
+            return code
         if code in DEFAULT_PACKAGE_MODELS:
             return code
+        if code in _METRIC_TO_IMPERIAL:
+            return _METRIC_TO_IMPERIAL[code]
     return None
 
 

--- a/fypa/caploop/packages.py
+++ b/fypa/caploop/packages.py
@@ -102,6 +102,50 @@ _METRIC_RE = re.compile(r"(\d{4})\s*metric", re.IGNORECASE)
 _CODE_RE = re.compile(r"(?<!\d)(\d{4,5})(?!\d)")
 
 
+def _has_explicit_imperial_marker(footprint: str, code: str) -> bool:
+    """True when *footprint* names an imperial land pattern, not a bare code."""
+    if code not in _AMBIGUOUS_CODES:
+        return False
+    # Underscore-delimited land name: C_0402_SL, FOOT_0603_X
+    if re.search(rf'[_/\-]{re.escape(code)}(?:[_/\-]|$)', footprint, re.I):
+        return True
+    # Component prefix: C0402, C_0402, R0603
+    if re.search(
+            rf'(?:^|[_/\-])[CRLD](?:[_\-]?){re.escape(code)}\b',
+            footprint, re.I):
+        return True
+    return False
+
+
+def _code_match_priority(code: str) -> int:
+    """Higher = more confident. Used to pick among several bare codes."""
+    if code in _METRIC_TO_IMPERIAL and code not in DEFAULT_PACKAGE_MODELS:
+        return 3
+    if code in DEFAULT_PACKAGE_MODELS and code not in _AMBIGUOUS_CODES:
+        return 2
+    if code in _AMBIGUOUS_CODES:
+        return 1
+    return 0
+
+
+def _resolve_bare_code(
+    code: str,
+    conv: FootprintConvention,
+    footprint: str,
+) -> str | None:
+    if code in _AMBIGUOUS_CODES:
+        if _has_explicit_imperial_marker(footprint, code):
+            return code
+        if conv == "metric":
+            return _METRIC_TO_IMPERIAL.get(code)
+        return code
+    if code in DEFAULT_PACKAGE_MODELS:
+        return code
+    if code in _METRIC_TO_IMPERIAL:
+        return _METRIC_TO_IMPERIAL[code]
+    return None
+
+
 def normalize_footprint_convention(convention: str) -> FootprintConvention:
     """Return a valid convention name, defaulting to ``auto``."""
     if convention in FOOTPRINT_CONVENTIONS:
@@ -179,17 +223,16 @@ def detect_package(
     if metric:
         return _METRIC_TO_IMPERIAL.get(metric.group(1))
 
+    best: tuple[int, int, str] | None = None
     for match in _CODE_RE.finditer(footprint):
         code = match.group(1)
-        if code in _AMBIGUOUS_CODES:
-            if conv == "metric":
-                return _METRIC_TO_IMPERIAL.get(code)
-            return code
-        if code in DEFAULT_PACKAGE_MODELS:
-            return code
-        if code in _METRIC_TO_IMPERIAL:
-            return _METRIC_TO_IMPERIAL[code]
-    return None
+        pkg = _resolve_bare_code(code, conv, footprint)
+        if pkg is None:
+            continue
+        key = (_code_match_priority(code), -match.start(), pkg)
+        if best is None or key > best:
+            best = key
+    return best[2] if best is not None else None
 
 
 class PackageLibrary:

--- a/tests/test_caploop_identify.py
+++ b/tests/test_caploop_identify.py
@@ -147,6 +147,25 @@ def test_package_is_classified_from_the_footprint():
     assert _identify(proj)[0].package is None
 
 
+def test_metric_footprint_name_is_classified():
+    import dataclasses
+    caps = _identify(_standard_cap_project(
+        pcb_components=(dataclasses.replace(
+            _comp("C1"), footprint="1608C"),)))
+    assert caps[0].package == "0603"
+
+
+def test_footprint_convention_metric_disambiguates_bare_codes():
+    import dataclasses
+    caps = _identify(
+        _standard_cap_project(
+            pcb_components=(dataclasses.replace(
+                _comp("C1"), footprint="0603"),)),
+        footprint_convention="metric",
+    )
+    assert caps[0].package == "0201"
+
+
 def test_detects_decoupling_cap_and_orientation():
     caps = _identify(_standard_cap_project())
     assert len(caps) == 1

--- a/tests/test_caploop_impedance_tab.py
+++ b/tests/test_caploop_impedance_tab.py
@@ -295,6 +295,38 @@ def test_resetting_the_library_restores_the_defaults(viewer):
     assert viewer._project.viewer_settings["caploop_packages"] == {}
 
 
+def test_metric_convention_shows_metric_package_labels(viewer):
+    viewer._set_footprint_convention("metric")
+    viewer._sync_footprint_convention_ui()
+    table = viewer.imp_pkg_table
+    row = next(r for r in range(table.rowCount())
+               if table.item(r, 0).data(av._PKG_CANONICAL_ROLE) == "0402")
+    assert table.item(row, 0).text() == "1005"
+    assert viewer.imp_footprint_conv_combo.currentData() == "metric"
+
+
+def test_sync_footprint_convention_ui_reads_saved_project_setting(viewer):
+    viewer._project.viewer_settings["footprint_convention"] = "imperial"
+    viewer._sync_footprint_convention_ui()
+    assert viewer.imp_footprint_conv_combo.currentData() == "imperial"
+    row = next(r for r in range(viewer.imp_pkg_table.rowCount())
+               if viewer.imp_pkg_table.item(r, 0).data(
+                   av._PKG_CANONICAL_ROLE) == "0402")
+    assert viewer.imp_pkg_table.item(row, 0).text() == "0402"
+
+
+def test_editing_a_package_under_metric_labels_uses_canonical_key(viewer):
+    viewer._set_footprint_convention("metric")
+    viewer._sync_footprint_convention_ui()
+    table = viewer.imp_pkg_table
+    row = next(r for r in range(table.rowCount())
+               if table.item(r, 0).data(av._PKG_CANONICAL_ROLE) == "0402")
+    assert table.item(row, 0).text() == "1005"
+    table.item(row, 1).setText("1.5")
+    assert viewer._project.viewer_settings["caploop_packages"]["0402"][
+        "esl_h"] == pytest.approx(1.5e-9)
+
+
 # --- per-part overrides feed the model ------------------------------------------------
 
 

--- a/tests/test_caploop_packages.py
+++ b/tests/test_caploop_packages.py
@@ -55,9 +55,17 @@ def test_explicit_imperial_names_ignore_metric_convention(footprint, expected):
     assert detect_package(footprint, convention="metric") == expected
 
 
-def test_unambiguous_metric_code_wins_over_ambiguous_imperial():
-    """When several bare codes appear, prefer the unambiguous metric one."""
+def test_unambiguous_metric_code_wins_over_bare_ambiguous_imperial():
+    """Bare 0603 without a land-pattern marker loses to 1005."""
     assert detect_package("0603_1005") == "0402"
+
+
+@pytest.mark.parametrize("footprint,expected", [
+    ("C_0603_1005", "0603"),
+    ("C_0402_1005", "0402"),
+])
+def test_explicit_imperial_marker_wins_over_metric_code(footprint, expected):
+    assert detect_package(footprint) == expected
 
 
 def test_format_package_label():

--- a/tests/test_caploop_packages.py
+++ b/tests/test_caploop_packages.py
@@ -42,10 +42,22 @@ def test_detect_package(footprint, expected):
 @pytest.mark.parametrize("footprint,expected", [
     ("0603", "0201"),
     ("0402", "01005"),
-    ("C_0603_SL", "0201"),
 ])
 def test_detect_package_metric_convention(footprint, expected):
     assert detect_package(footprint, convention="metric") == expected
+
+
+@pytest.mark.parametrize("footprint,expected", [
+    ("C_0603_SL", "0603"),
+    ("C_0402_SL", "0402"),
+])
+def test_explicit_imperial_names_ignore_metric_convention(footprint, expected):
+    assert detect_package(footprint, convention="metric") == expected
+
+
+def test_unambiguous_metric_code_wins_over_ambiguous_imperial():
+    """When several bare codes appear, prefer the unambiguous metric one."""
+    assert detect_package("0603_1005") == "0402"
 
 
 def test_format_package_label():

--- a/tests/test_caploop_packages.py
+++ b/tests/test_caploop_packages.py
@@ -7,6 +7,8 @@ from fypa.caploop.packages import (
     DEFAULT_PACKAGE_MODELS,
     PackageLibrary,
     detect_package,
+    format_package_label,
+    normalize_footprint_convention,
 )
 
 
@@ -27,9 +29,35 @@ from fypa.caploop.packages import (
     ("CAPC1005X55N", "0402"),
     # Reverse geometry.
     ("C_0306_SL", "0306"),
+    # Bare metric codes with Altium-style suffix letters.
+    ("1005B", "0402"),
+    ("1608C", "0603"),
+    ("1005R", "0402"),
+    ("1608C-HD", "0603"),
 ])
 def test_detect_package(footprint, expected):
     assert detect_package(footprint) == expected
+
+
+@pytest.mark.parametrize("footprint,expected", [
+    ("0603", "0201"),
+    ("0402", "01005"),
+    ("C_0603_SL", "0201"),
+])
+def test_detect_package_metric_convention(footprint, expected):
+    assert detect_package(footprint, convention="metric") == expected
+
+
+def test_format_package_label():
+    assert format_package_label("0402", "imperial") == "0402"
+    assert format_package_label("0402", "metric") == "1005"
+    assert format_package_label("0402", "auto") == "0402"
+    assert format_package_label(None, "metric") == "—"
+
+
+def test_normalize_footprint_convention():
+    assert normalize_footprint_convention("metric") == "metric"
+    assert normalize_footprint_convention("bogus") == "auto"
 
 
 def test_metric_and_imperial_0603_are_disambiguated():

--- a/tests/test_caploop_table.py
+++ b/tests/test_caploop_table.py
@@ -137,6 +137,21 @@ def test_package_column_and_library_defaults(viewer):
     assert "Typical" in tip and "0402" in tip
 
 
+def test_package_column_uses_metric_labels_when_configured(qapp):
+    import dataclasses
+    from tests.test_caploop_identify import _comp, _standard_cap_project
+
+    v = _Viewer()
+    v._loaded_project = types.SimpleNamespace(
+        extracted=_standard_cap_project(
+            pcb_components=(dataclasses.replace(
+                _comp("C1"), footprint="1005B"),)))
+    v._set_footprint_convention("metric")
+    v._caps_tab_index = v.tabs.addTab(v._build_capacitors_tab(), "Capacitors")
+    v._populate_caps_table()
+    assert _cell(v, "Pkg").text() == "1005"
+
+
 def test_unrecognised_package_shows_no_defaults(qapp):
     import dataclasses
     from tests.test_caploop_identify import _comp, _standard_cap_project

--- a/tests/test_caploop_table.py
+++ b/tests/test_caploop_table.py
@@ -152,6 +152,26 @@ def test_package_column_uses_metric_labels_when_configured(qapp):
     assert _cell(v, "Pkg").text() == "1005"
 
 
+def test_caps_footprint_convention_combo_updates_pkg_column(qapp):
+    import dataclasses
+    from tests.test_caploop_identify import _comp, _standard_cap_project
+
+    v = _Viewer()
+    v._loaded_project = types.SimpleNamespace(
+        extracted=_standard_cap_project(
+            pcb_components=(dataclasses.replace(
+                _comp("C1"), footprint="1005B"),)))
+    v._caps_tab_index = v.tabs.addTab(v._build_capacitors_tab(), "Capacitors")
+    v._populate_caps_table()
+    assert _cell(v, "Pkg").text() == "0402"
+    idx = v.caps_footprint_conv_combo.findData("metric")
+    assert idx >= 0
+    v.caps_footprint_conv_combo.setCurrentIndex(idx)
+    v._populate_caps_table()
+    assert _cell(v, "Pkg").text() == "1005"
+    assert v._project.viewer_settings["footprint_convention"] == "metric"
+
+
 def test_unrecognised_package_shows_no_defaults(qapp):
     import dataclasses
     from tests.test_caploop_identify import _comp, _standard_cap_project


### PR DESCRIPTION
## Motivation
Footprint names often use bare case codes (`0402`, `0603`) that collide between imperial and metric. Without a convention switch, package labeling and parasitics on the Capacitors / Impedance tabs can mis-read metric boards (or the reverse).

## Summary
- Detect metric case codes in footprint names and map them to imperial equivalents where needed
- Per-project convention: `auto` / `metric` / `imperial`
- Expose the same control on the Capacitors filter row (kept in sync with Impedance)

## Test plan
- [ ] `pytest tests/test_caploop_packages.py tests/test_caploop_identify.py tests/test_caploop_table.py tests/test_caploop_impedance_tab.py`
- [ ] Metric board: convention = metric → Pkg / parasitics match metric codes
- [ ] Imperial board / explicit imperial markers still prefer imperial
