### PR TITLE
Nest SERIES-bridged rail subnets and Ctrl+Click subtree visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,8 @@ ExampleDesigns/Sandbox/*
 # would re-leak exactly what it removes. Run it before each commit.
 sanitize_sandbox.ps1
 wiring.json
-scripts/test-*.ps1
+# Local override for test-combined (team config is on team/local branch)
+scripts/test-combined.json
+# Fork-local team config (team/test-combined.json is tracked on team/local only)
+team/*
+!team/test-combined.json

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ sanitize_sandbox.ps1
 wiring.json
 # Local override for test-combined (team config is on team/local branch)
 scripts/test-combined.json
+scripts/py314.local.json
 # Fork-local team config (team/test-combined.json is tracked on team/local only)
 team/*
 !team/test-combined.json

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -1,0 +1,50 @@
+# Fork workflow (team/local)
+
+This fork keeps upstream-ready work separate from local team tooling.
+
+## Branches
+
+| Branch | Purpose |
+|--------|---------|
+| `main` | Tracks upstream; use as the base for upstream pull requests |
+| `team/local` | Shared fork config (combined-test branch list, etc.) |
+
+Daily development can use `team/local` or feature branches. **Do not merge `team/local` into branches you open upstream.**
+
+## Combined local test
+
+`scripts/test-combined.ps1` builds a throwaway branch, merges configured feature branches, runs topology tests and FYPA, then returns to your previous branch. Run it from **any** branch — config is read from `team/local` via `git show` when the file is not in your working tree.
+
+Config lives in `team/test-combined.json` on the `team/local` branch:
+
+```json
+{
+  "baseBranch": "main",
+  "testBranch": "test/combined",
+  "deleteTestBranchFirst": true,
+  "extraFeatureBranches": ["feature/example-a", "fix/example-b"]
+}
+```
+
+- `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate).
+- By default, `baseBranch` and `extraFeatureBranches` are **fetched from `origin`** and merged via `origin/<branch>`. Use `--local-only` to use local branches only.
+- Override any field on the command line, e.g. `-DeleteTestBranchFirst:$false`.
+
+```powershell
+pwsh scripts/test-combined.ps1
+pwsh scripts/test-combined.ps1 --local-only
+```
+
+Resolution order: `scripts/test-combined.json` (local override) → `team/test-combined.json` → `team/local:team/test-combined.json` → example file.
+
+For a one-off local config, copy `scripts/test-combined.example.json` to `scripts/test-combined.json` (gitignored).
+
+## Upstream pull requests
+
+Create the PR branch from upstream, not from `team/local`:
+
+```powershell
+git fetch upstream
+git checkout -b feature/my-fix upstream/main
+git cherry-pick <commit>   # feature commits only
+```

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -27,7 +27,7 @@ Config lives in `team/test-combined.json` on the `team/local` branch:
 ```
 
 - `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate). Only applies when the branch is rebuilt, not when it is reused.
-- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`** and merged via `origin/<branch>`. If fetch fails (offline), local refs are used instead. Use `--local-only` to skip fetch entirely.
+- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`**. Each input tip is resolved so **local work is never dropped**: if the local branch is ahead of or diverged from `origin/<branch>`, the local tip is used; if local is behind, `origin/<branch>` is used; branches that exist only locally or only on the remote are accepted either way. If fetch fails (offline), the same resolution runs against existing refs. Use `--local-only` to skip fetch and use local branches only.
 - When the existing `testBranch` tip has a matching stamp (input SHAs + config identity stored as a git note), the branch is **reused** instead of rebuilt. Pass `-Rebuild` to force a clean recreate.
 - Topology pytest runs by default. Pass `-SkipTests` to skip them (the Altium launcher always passes `-SkipTests`).
 - Override any field on the command line, e.g. `-DeleteTestBranchFirst:$false`.

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -27,14 +27,14 @@ Config lives in `team/test-combined.json` on the `team/local` branch:
 ```
 
 - `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate). Only applies when the branch is rebuilt, not when it is reused.
-- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`**. Each input tip is resolved so **local work is never dropped**: if the local branch is ahead of or diverged from `origin/<branch>`, the local tip is used; if local is behind, `origin/<branch>` is used; branches that exist only locally or only on the remote are accepted either way. If fetch fails (offline), the same resolution runs against existing refs. Use `--local-only` to skip fetch and use local branches only.
+- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`**. Each input tip is resolved so **local work is never dropped**: if the local branch is ahead of or diverged from `origin/<branch>`, the local tip is used; if local is behind, `origin/<branch>` is used; branches that exist only locally or only on the remote are accepted either way. If fetch fails (offline), the same resolution runs against existing refs. Use `-LocalOnly` to skip fetch and use local branches only.
 - When the existing `testBranch` tip has a matching stamp (input SHAs + config identity stored as a git note), the branch is **reused** instead of rebuilt. Pass `-Rebuild` to force a clean recreate.
 - Topology pytest runs by default. Pass `-SkipTests` to skip them (the Altium launcher always passes `-SkipTests`).
 - Override any field on the command line, e.g. `-DeleteTestBranchFirst:$false`.
 
 ```powershell
 pwsh scripts/test-combined.ps1
-pwsh scripts/test-combined.ps1 --local-only
+pwsh scripts/test-combined.ps1 -LocalOnly
 pwsh scripts/test-combined.ps1 -Rebuild
 pwsh scripts/test-combined.ps1 -SkipTests
 ```

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -13,7 +13,7 @@ Daily development can use `team/local` or feature branches. **Do not merge `team
 
 ## Combined local test
 
-`scripts/test-combined.ps1` builds a throwaway branch, merges configured feature branches, runs topology tests and FYPA, then returns to your previous branch. Run it from **any** branch — config is read from `team/local` via `git show` when the file is not in your working tree.
+`scripts/test-combined.ps1` builds a throwaway branch, merges configured feature branches, optionally runs topology tests and FYPA, then returns to your previous branch. Run it from **any** branch — config is read from `team/local` via `git show` when the file is not in your working tree.
 
 Config lives in `team/test-combined.json` on the `team/local` branch:
 
@@ -26,13 +26,17 @@ Config lives in `team/test-combined.json` on the `team/local` branch:
 }
 ```
 
-- `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate).
-- By default, `baseBranch` and `extraFeatureBranches` are **fetched from `origin`** and merged via `origin/<branch>`. Use `--local-only` to use local branches only.
+- `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate). Only applies when the branch is rebuilt, not when it is reused.
+- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`** and merged via `origin/<branch>`. If fetch fails (offline), local refs are used instead. Use `--local-only` to skip fetch entirely.
+- When the existing `testBranch` tip has a matching stamp (input SHAs + config identity stored as a git note), the branch is **reused** instead of rebuilt. Pass `-Rebuild` to force a clean recreate.
+- Topology pytest runs by default. Pass `-SkipTests` to skip them (the Altium launcher always passes `-SkipTests`).
 - Override any field on the command line, e.g. `-DeleteTestBranchFirst:$false`.
 
 ```powershell
 pwsh scripts/test-combined.ps1
 pwsh scripts/test-combined.ps1 --local-only
+pwsh scripts/test-combined.ps1 -Rebuild
+pwsh scripts/test-combined.ps1 -SkipTests
 ```
 
 Resolution order: `scripts/test-combined.json` (local override) → `team/test-combined.json` → `team/local:team/test-combined.json` → example file.

--- a/fypa/altium_viewer.py
+++ b/fypa/altium_viewer.py
@@ -9065,39 +9065,21 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         return compute_rail_groups(metadata)
 
     def _series_bridge_metadata(self) -> dict:
-        """Metadata shaped for :func:`build_rail_trees` (RESISTOR edges only).
+        """Metadata for :func:`build_rail_trees` on pending / editor rails.
 
-        Merges solved-metadata RESISTOR directives with unresolved editor
-        SERIES bridges so pending rails get the same spanning-tree shape.
-        Editor SERIES pairs already present as RESISTOR pin bridges are skipped.
+        Keeps SOURCE/SINK/REGULATOR (alias edges) and RESISTOR (SERIES bridges)
+        from solved metadata, then appends unresolved editor SERIES whose pin
+        pairs are not already covered (all bipartite RESISTOR pairs counted).
         """
-        directives: list[dict] = []
-        seen_bridges: set[frozenset[str]] = set()
+        from fypa.rail_groups import (
+            filter_directives_for_rail_trees,
+            resistor_bridge_pairs,
+        )
         meta = self.metadata if isinstance(self.metadata, dict) else {}
-
-        def _bridge_key(d: dict) -> frozenset[str] | None:
-            terms = d.get("terminals") or {}
-            nets_per_term: list[set[str]] = []
-            for t in terms.values():
-                nets = {p.get("net") for p in t.get("pins", []) if p.get("net")}
-                if nets:
-                    nets_per_term.append(nets)
-            if len(nets_per_term) != 2:
-                return None
-            # One representative net per side for dedupe of simple 1:1 bridges.
-            a = next(iter(nets_per_term[0]))
-            b = next(iter(nets_per_term[1]))
-            if not a or not b:
-                return None
-            return frozenset((a, b))
-
-        for d in meta.get("directives", []) or []:
-            if d.get("role") != "RESISTOR":
-                continue
-            directives.append(d)
-            key = _bridge_key(d)
-            if key is not None and len(key) == 2:
-                seen_bridges.add(key)
+        directives = filter_directives_for_rail_trees(meta.get("directives"))
+        seen_bridges: set[frozenset[str]] = set()
+        for d in directives:
+            seen_bridges.update(resistor_bridge_pairs(d))
         project = getattr(self, "_project", None)
         if project is not None:
             for ed in getattr(project, "editor_directives", []) or []:
@@ -9108,10 +9090,9 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
                 ):
                     continue
                 key = frozenset((ed.p_net, ed.n_net))
-                if len(key) == 2 and key in seen_bridges:
+                if len(key) != 2 or key in seen_bridges:
                     continue
-                if len(key) == 2:
-                    seen_bridges.add(key)
+                seen_bridges.add(key)
                 directives.append({
                     "role": "RESISTOR",
                     "terminals": {

--- a/fypa/altium_viewer.py
+++ b/fypa/altium_viewer.py
@@ -10359,10 +10359,13 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
                 eye.setVisibleState(on, partial=False, emit=False)
 
     def _sync_rail_tree_node_partials(self, rail: str) -> None:
-        """Mark intermediate node eyes partial when descendants are mixed.
+        """Update intermediate node partial badges from subtree visibility.
 
         Does **not** change each node's own on/off (that is copper for that
-        net). Only the partial badge is derived from descendant visibility.
+        net). Partial is set when descendants are mixed, or when this net
+        is off while all descendants are on (muted open). Parent-on with
+        all descendants off stays a plain eye so a click still toggles
+        this net.
         """
         from fypa.rail_groups import rail_tree_node_partial_flags
 

--- a/fypa/altium_viewer.py
+++ b/fypa/altium_viewer.py
@@ -2431,18 +2431,25 @@ def _overlay_hole_ring(rec: dict) -> np.ndarray:
 
 
 class SidebarToggleButton(QToolButton):
-    """Slim vertical splitter handle that collapses / expands the heatmap
-    side panel. Paints a crisp anti-aliased triangle pointing in the
-    direction the panel will travel on the next click, instead of relying
-    on Unicode arrow glyphs (which render fuzzy at this size on Windows).
+    """Slim vertical splitter between the heatmap side panel and the plot.
+
+    * **Click** — collapse / expand the side panel (hotkey ``B``).
+    * **Drag horizontally** — resize the side panel width.
     """
+
+    # Delta (px) from the press position while dragging; positive = wider panel.
+    resizedBy = Signal(int)
+
+    _DRAG_THRESHOLD_PX = 4
 
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
         self._collapsed = False
+        self._press_global_x: float | None = None
+        self._dragging = False
         self.setAutoRaise(True)
         self.setFocusPolicy(Qt.NoFocus)
-        self.setCursor(Qt.PointingHandCursor)
+        self.setCursor(Qt.SizeHorCursor)
         self.setFixedWidth(14)
         self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
 
@@ -2455,6 +2462,37 @@ class SidebarToggleButton(QToolButton):
 
     def isCollapsed(self) -> bool:
         return self._collapsed
+
+    def mousePressEvent(self, event) -> None:  # noqa: N802
+        if event.button() == Qt.LeftButton:
+            self._press_global_x = float(event.globalPosition().x())
+            self._dragging = False
+        super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event) -> None:  # noqa: N802
+        if (
+            self._press_global_x is not None
+            and event.buttons() & Qt.LeftButton
+            and not self._collapsed
+        ):
+            dx = int(round(float(event.globalPosition().x()) - self._press_global_x))
+            if not self._dragging and abs(dx) >= self._DRAG_THRESHOLD_PX:
+                self._dragging = True
+            if self._dragging:
+                self.resizedBy.emit(dx)
+                event.accept()
+                return
+        super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event) -> None:  # noqa: N802
+        if event.button() == Qt.LeftButton and self._dragging:
+            self._dragging = False
+            self._press_global_x = None
+            event.accept()
+            return
+        self._press_global_x = None
+        self._dragging = False
+        super().mouseReleaseEvent(event)
 
     def paintEvent(self, event) -> None:  # noqa: N802 (Qt naming)
         t = _T()
@@ -8743,6 +8781,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         saved_rails: dict[str, bool] = {}
         saved_subnets: dict[tuple[str, str], bool] = {}
         saved_expanded: dict[str, bool] = {}
+        saved_subnet_expanded: dict[tuple[str, str], bool] = {}
         if preserve_visibility:
             saved_layers = {
                 p: e.isVisibleState() for p, e in self._layer_eye_buttons
@@ -8757,6 +8796,9 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
                 for net, eye in nets.items():
                     saved_subnets[(rail, net)] = eye.isVisibleState()
             saved_expanded = dict(getattr(self, "_rail_expanded", {}))
+            saved_subnet_expanded = dict(
+                getattr(self, "_subnet_node_expanded", {}),
+            )
 
         while self.layer_list.count() > 1:
             self.layer_list.takeItem(self.layer_list.count() - 1)
@@ -8821,6 +8863,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
             saved_rails=saved_rails,
             saved_subnets=saved_subnets,
             saved_expanded=saved_expanded,
+            saved_subnet_expanded=saved_subnet_expanded,
         )
 
         has_rails = bool(self._rails)
@@ -9085,13 +9128,40 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         rail: str,
         members: list[str],
         trees: dict | None,
-    ) -> list[tuple[str, int]]:
-        """DFS ``(net, depth)`` rows for an expanded rail; flat fallback."""
-        from fypa.rail_groups import flatten_rail_tree
+        *,
+        node_expanded: dict | None = None,
+    ) -> list[tuple[str, int, bool]]:
+        """Visible subnet rows as ``(net, depth, has_children)``.
+
+        Walks the SERIES tree but only descends into nodes marked expanded
+        in ``node_expanded`` (defaults: primary expanded, others collapsed).
+        Flat fallback when no tree is available.
+        """
+        from fypa.rail_groups import RailTreeNode
+        expanded_map = node_expanded if node_expanded is not None else {}
         tree = (trees or {}).get(rail)
-        if tree is not None:
-            return flatten_rail_tree(tree)
-        return [(net, 1) for net in members]
+        if tree is None:
+            return [(net, 1, False) for net in members]
+
+        rows: list[tuple[str, int, bool]] = []
+
+        def _is_expanded(net: str) -> bool:
+            key = (rail, net)
+            if key in expanded_map:
+                return bool(expanded_map[key])
+            # First open: reveal the primary's children; deeper levels stay
+            # collapsed so long SERIES chains don't explode the list.
+            return net == rail
+
+        def _walk(node: RailTreeNode, depth: int) -> None:
+            has_children = bool(node.children)
+            rows.append((node.name, depth, has_children))
+            if has_children and _is_expanded(node.name):
+                for child in node.children:
+                    _walk(child, depth + 1)
+
+        _walk(tree, 1)
+        return rows
 
     def showEvent(self, event) -> None:
         """Apply the deferred ``showMaximized`` once Qt has actually shown the
@@ -9516,19 +9586,28 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
 
         side.addStretch(1)
 
-        # Wrap side layout in a fixed-width container, then put that inside a
-        # QScrollArea so the panel scrolls vertically when its contents exceed
-        # the window height (e.g. on boards with many copper layers).
+        # Wrap side layout in a width-adjustable container, then put that
+        # inside a QScrollArea so the panel scrolls vertically when its
+        # contents exceed the window height (e.g. many copper layers).
+        # Width is user-draggable via the SidebarToggleButton splitter.
+        self._SIDEBAR_DEFAULT_W = 260
+        self._SIDEBAR_MIN_W = 180
+        self._SIDEBAR_MAX_W = 520
+        self._SIDEBAR_SCROLLBAR_W = 18
+        self._sidebar_content_w = self._SIDEBAR_DEFAULT_W
+        self._sidebar_drag_start_w = self._sidebar_content_w
+
         side_widget = QWidget()
         side_widget.setLayout(side)
-        side_widget.setFixedWidth(260)
+        side_widget.setFixedWidth(self._sidebar_content_w)
+        self._sidebar_widget = side_widget
 
         side_scroll = QScrollArea()
         side_scroll.setWidget(side_widget)
         # Resizable=True is essential: with =False, the inner widget uses its
         # width-agnostic sizeHint() for height, which under-estimates the
         # height of word-wrapped labels (e.g. summary_label) at the actual
-        # 260px width, and the controls below it overlap. =True makes the
+        # panel width, and the controls below it overlap. =True makes the
         # layout reflow at the real width.
         side_scroll.setWidgetResizable(True)
         side_scroll.setFrameShape(QFrame.NoFrame)
@@ -9537,25 +9616,24 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         # constant regardless of whether scrolling is needed; without this,
         # adding/removing the scrollbar would shift content widths around.
         side_scroll.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOn)
-        # Reserve room for the vertical scrollbar so its appearance doesn't
-        # crop the 260px-wide content. 18px covers the default Fusion/Win
-        # scrollbar extent with a hair of margin.
-        side_scroll.setFixedWidth(260 + 18)
+        side_scroll.setFixedWidth(
+            self._sidebar_content_w + self._SIDEBAR_SCROLLBAR_W,
+        )
         side_scroll.setStyleSheet(
             f"QScrollArea {{ background-color: {_T()['bg']}; }}"
         )
         outer.addWidget(side_scroll)
         self._sidebar_scroll = side_scroll
 
-        # Slim vertical splitter handle that toggles the sidebar's visibility
-        # so the user can give the viewport extra real estate. Custom-painted
-        # triangle stays crisp at 14px; Unicode arrow glyphs were fuzzy.
+        # Slim vertical splitter: click toggles collapse; drag resizes width.
         # Hotkey "B" mirrors the click.
         self._sidebar_toggle_btn = SidebarToggleButton()
         self._sidebar_toggle_btn.setToolTip(
-            "Collapse / expand the side panel (B)"
+            "Drag to resize the side panel · Click to collapse / expand (B)"
         )
         self._sidebar_toggle_btn.clicked.connect(self._toggle_sidebar)
+        self._sidebar_toggle_btn.resizedBy.connect(self._on_sidebar_resized_by)
+        self._sidebar_toggle_btn.pressed.connect(self._on_sidebar_resize_press)
         outer.addWidget(self._sidebar_toggle_btn)
 
         # Plot area — custom QOpenGLWidget rendering the FEM mesh directly
@@ -9903,6 +9981,10 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
 
     # --- Rails list (expandable subnet rows) ---------------------------------
 
+    # Indent per tree depth (px). Kept modest so deep SERIES chains stay
+    # readable in the default sidebar width.
+    _RAIL_SUBNET_INDENT_PX = 10
+
     def _init_rail_list_state(self) -> None:
         """Allocate per-rail / per-subnet visibility state containers."""
         self._rail_eye_buttons: list[tuple[str, EyeButton]] = []
@@ -9914,15 +9996,24 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         self._subnet_eye_holder.setFixedSize(0, 0)
         self._subnet_eye_holder.hide()
         self._rail_expand_buttons: dict[str, QToolButton] = {}
+        self._subnet_expand_buttons: dict[tuple[str, str], QToolButton] = {}
         self._rail_subnet_items: dict[str, list[QListWidgetItem]] = {}
         self._rail_expanded: dict[str, bool] = {}
+        # (rail, net) → whether that tree node's children are shown.
+        self._subnet_node_expanded: dict[tuple[str, str], bool] = getattr(
+            self, "_subnet_node_expanded", {},
+        )
         self._rail_list_items: dict[str, QListWidgetItem] = {}
         self._rail_to_trees: dict = getattr(self, "_rail_to_trees", {})
         self._pending_rail_items: list = []
         self._pending_rail_list_items: dict[str, QListWidgetItem] = {}
         self._pending_rail_expand_buttons: dict[str, QToolButton] = {}
+        self._pending_subnet_expand_buttons: dict[tuple[str, str], QToolButton] = {}
         self._pending_rail_subnet_items: dict[str, list[QListWidgetItem]] = {}
         self._pending_rail_expanded: dict[str, bool] = {}
+        self._pending_subnet_node_expanded: dict[tuple[str, str], bool] = getattr(
+            self, "_pending_subnet_node_expanded", {},
+        )
         self._pending_rail_trees: dict = {}
 
     def _ground_rail_names(self) -> set[str]:
@@ -9932,6 +10023,25 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         if self._no_pdn_visibility():
             return False
         return rail.lower() not in self._ground_rail_names()
+
+    def _make_expand_tool_button(
+        self,
+        *,
+        expanded: bool,
+        tip: str,
+        on_toggled,
+    ) -> QToolButton:
+        btn = QToolButton()
+        btn.setCheckable(True)
+        btn.setChecked(expanded)
+        btn.setArrowType(Qt.DownArrow if expanded else Qt.RightArrow)
+        btn.setFixedSize(14, 14)
+        btn.setAutoRaise(True)
+        btn.setFocusPolicy(Qt.NoFocus)
+        btn.setCursor(Qt.PointingHandCursor)
+        btn.setToolTip(tip)
+        btn.toggled.connect(on_toggled)
+        return btn
 
     def _build_rail_row_widget(
         self,
@@ -9982,6 +10092,9 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         for btn in getattr(self, "_rail_expand_buttons", {}).values():
             if _qt_widget_alive(btn):
                 btn.blockSignals(True)
+        for btn in getattr(self, "_subnet_expand_buttons", {}).values():
+            if _qt_widget_alive(btn):
+                btn.blockSignals(True)
         for nets in getattr(self, "_subnet_eye_buttons", {}).values():
             for eye in nets.values():
                 if _qt_widget_alive(eye):
@@ -9994,6 +10107,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         saved_rails: dict[str, bool] | None = None,
         saved_subnets: dict[tuple[str, str], bool] | None = None,
         saved_expanded: dict[str, bool] | None = None,
+        saved_subnet_expanded: dict[tuple[str, str], bool] | None = None,
     ) -> None:
         """Rebuild solved-rail rows (not including the 'All Rails' header)."""
         self._silence_rail_list_widgets()
@@ -10004,6 +10118,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         self._rail_eye_buttons.clear()
         self._subnet_eye_buttons.clear()
         self._rail_expand_buttons.clear()
+        self._subnet_expand_buttons.clear()
         self._rail_subnet_items.clear()
         self._rail_list_items.clear()
 
@@ -10017,6 +10132,11 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
             }
         else:
             self._rail_expanded = {}
+        if saved_subnet_expanded is not None:
+            self._subnet_node_expanded = {
+                k: bool(v) for k, v in saved_subnet_expanded.items()
+                if k[0] in self._rails
+            }
 
         for rail in self._rails:
             members = self._rail_to_members.get(rail, [rail])
@@ -10030,19 +10150,12 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
             expand_btn = None
             expanded = bool(self._rail_expanded.get(rail, False))
             if has_subnets:
-                expand_btn = QToolButton()
-                expand_btn.setCheckable(True)
-                expand_btn.setChecked(expanded)
-                expand_btn.setArrowType(
-                    Qt.DownArrow if expanded else Qt.RightArrow,
-                )
-                expand_btn.setFixedSize(14, 14)
-                expand_btn.setAutoRaise(True)
-                expand_btn.setFocusPolicy(Qt.NoFocus)
-                expand_btn.setCursor(Qt.PointingHandCursor)
-                expand_btn.setToolTip("Show/hide subnet nets")
-                expand_btn.toggled.connect(
-                    lambda exp, r=rail: self._on_rail_expand_toggled(r, exp),
+                expand_btn = self._make_expand_tool_button(
+                    expanded=expanded,
+                    tip="Show/hide subnet nets",
+                    on_toggled=lambda exp, r=rail: self._on_rail_expand_toggled(
+                        r, exp,
+                    ),
                 )
                 self._rail_expand_buttons[rail] = expand_btn
                 self._rail_expanded[rail] = expanded
@@ -10101,7 +10214,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
     def _insert_subnet_rows(
         self, rail: str, *, after_item: QListWidgetItem,
     ) -> None:
-        """Insert indented subnet rows directly below a parent rail row."""
+        """Insert indented subnet rows for the currently expanded tree nodes."""
         if self._rail_subnet_items.get(rail):
             return
         members = self._rail_to_members.get(rail, [rail])
@@ -10109,16 +10222,34 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         items: list[QListWidgetItem] = []
         row_idx = self.rail_list.row(after_item) + 1
         trees = getattr(self, "_rail_to_trees", {})
-        for net, depth in self._subnet_rows_for_rail(rail, members, trees):
+        indent_px = self._RAIL_SUBNET_INDENT_PX
+        for net, depth, has_children in self._subnet_rows_for_rail(
+            rail, members, trees,
+            node_expanded=self._subnet_node_expanded,
+        ):
             eye = subnets.get(net)
             if eye is None or not _qt_widget_alive(eye):
                 continue
             is_primary = net == rail
+            expand_btn = None
+            if has_children:
+                key = (rail, net)
+                node_exp = self._subnet_node_expanded.get(key, net == rail)
+                self._subnet_node_expanded[key] = node_exp
+                expand_btn = self._make_expand_tool_button(
+                    expanded=node_exp,
+                    tip=f"Show/hide children of {net}",
+                    on_toggled=lambda exp, r=rail, n=net: (
+                        self._on_subnet_node_expand_toggled(r, n, exp)
+                    ),
+                )
+                self._subnet_expand_buttons[key] = expand_btn
             subnet_row = self._build_rail_row_widget(
                 eye,
+                expand_btn=expand_btn,
                 label_text=net,
                 bold=is_primary,
-                indent=18 * depth,
+                indent=indent_px * depth,
             )
             if is_primary:
                 tip = f"Primary net of rail {rail}"
@@ -10138,6 +10269,13 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
 
     def _remove_subnet_rows(self, rail: str) -> None:
         self._detach_subnet_eyes(rail)
+        for key in [
+            k for k in list(self._subnet_expand_buttons)
+            if k[0] == rail
+        ]:
+            btn = self._subnet_expand_buttons.pop(key)
+            if _qt_widget_alive(btn):
+                btn.blockSignals(True)
         for item in self._rail_subnet_items.pop(rail, []):
             row = self.rail_list.row(item)
             if row >= 0:
@@ -10187,6 +10325,20 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
             self._insert_subnet_rows(rail, after_item=parent_item)
         else:
             self._remove_subnet_rows(rail)
+        self._update_rail_list_height()
+
+    def _on_subnet_node_expand_toggled(
+        self, rail: str, net: str, expanded: bool,
+    ) -> None:
+        self._subnet_node_expanded[(rail, net)] = expanded
+        btn = self._subnet_expand_buttons.get((rail, net))
+        if btn is not None and _qt_widget_alive(btn):
+            btn.setArrowType(Qt.DownArrow if expanded else Qt.RightArrow)
+        parent_item = self._rail_list_items.get(rail)
+        if parent_item is None or not self._rail_expanded.get(rail):
+            return
+        self._remove_subnet_rows(rail)
+        self._insert_subnet_rows(rail, after_item=parent_item)
         self._update_rail_list_height()
 
     def _on_subnet_eye_toggled(self, rail: str, net: str, _on: bool) -> None:
@@ -16122,12 +16274,43 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
 
     def _toggle_sidebar(self) -> None:
         """Show / hide the heatmap-tab side panel so the user can give the
-        viewport the panel's 260px of horizontal real estate. The slim
-        toggle button between the panel and the plot stays visible either
+        viewport the panel's horizontal real estate. The slim toggle /
+        resize handle between the panel and the plot stays visible either
         way, and its triangle flips ▶ / ◀ to mirror the new state."""
         was_visible = self._sidebar_scroll.isVisible()
         self._sidebar_scroll.setVisible(not was_visible)
         self._sidebar_toggle_btn.setCollapsed(was_visible)
+
+    def _on_sidebar_resize_press(self) -> None:
+        """Remember content width at the start of a splitter drag."""
+        self._sidebar_drag_start_w = getattr(
+            self, "_sidebar_content_w", self._SIDEBAR_DEFAULT_W,
+        )
+
+    def _on_sidebar_resized_by(self, delta_px: int) -> None:
+        """Apply a drag delta from :class:`SidebarToggleButton`."""
+        start = getattr(
+            self, "_sidebar_drag_start_w", self._SIDEBAR_DEFAULT_W,
+        )
+        self._apply_sidebar_content_width(start + int(delta_px))
+
+    def _apply_sidebar_content_width(self, content_w: int) -> None:
+        """Clamp and apply the left side-panel content width (px)."""
+        scroll = getattr(self, "_sidebar_scroll", None)
+        widget = getattr(self, "_sidebar_widget", None)
+        if scroll is None or widget is None:
+            return
+        max_w = getattr(self, "_SIDEBAR_MAX_W", 520)
+        gl = getattr(self, "_gl_viewer", None)
+        if gl is not None and gl.width() > 0:
+            # Leave room for the plot + toggle handle.
+            max_w = min(max_w, max(self._SIDEBAR_MIN_W, gl.width() - 80))
+        w = max(self._SIDEBAR_MIN_W, min(int(content_w), max_w))
+        if w == getattr(self, "_sidebar_content_w", None) and widget.width() == w:
+            return
+        self._sidebar_content_w = w
+        widget.setFixedWidth(w)
+        scroll.setFixedWidth(w + self._SIDEBAR_SCROLLBAR_W)
 
     def _hotkey_2d_mode(self) -> None:
         self.view_3d_box.setChecked(False)
@@ -20409,6 +20592,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         self._pending_rail_items = []
         self._pending_rail_list_items = {}
         self._pending_rail_expand_buttons = {}
+        self._pending_subnet_expand_buttons = {}
         self._pending_rail_subnet_items = {}
         self._pending_rails = self._editor_pending_rails()
         from fypa.rail_groups import build_rail_trees
@@ -20426,20 +20610,11 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
             expand_btn = None
             expanded = bool(self._pending_rail_expanded.get(name, False))
             if has_subnets:
-                expand_btn = QToolButton()
-                expand_btn.setCheckable(True)
-                expand_btn.setChecked(expanded)
-                expand_btn.setArrowType(
-                    Qt.DownArrow if expanded else Qt.RightArrow,
-                )
-                expand_btn.setFixedSize(14, 14)
-                expand_btn.setAutoRaise(True)
-                expand_btn.setFocusPolicy(Qt.NoFocus)
-                expand_btn.setCursor(Qt.PointingHandCursor)
-                expand_btn.setToolTip("Show/hide subnet nets (unsolved)")
-                expand_btn.toggled.connect(
-                    lambda exp, n=name: self._on_pending_rail_expand_toggled(
-                        n, exp,
+                expand_btn = self._make_expand_tool_button(
+                    expanded=expanded,
+                    tip="Show/hide subnet nets (unsolved)",
+                    on_toggled=lambda exp, n=name: (
+                        self._on_pending_rail_expand_toggled(n, exp)
                     ),
                 )
                 self._pending_rail_expand_buttons[name] = expand_btn
@@ -20474,15 +20649,35 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         row_idx = self.rail_list.row(after_item) + 1
         t = _T()
         trees = getattr(self, "_pending_rail_trees", {})
-        for net, depth in self._subnet_rows_for_rail(rail, members, trees):
+        indent_px = self._RAIL_SUBNET_INDENT_PX
+        for net, depth, has_children in self._subnet_rows_for_rail(
+            rail, members, trees,
+            node_expanded=self._pending_subnet_node_expanded,
+        ):
             eye = EyeButton(visible=False)
             eye.setEnabled(False)
             is_primary = net == rail
+            expand_btn = None
+            if has_children:
+                key = (rail, net)
+                node_exp = self._pending_subnet_node_expanded.get(
+                    key, net == rail,
+                )
+                self._pending_subnet_node_expanded[key] = node_exp
+                expand_btn = self._make_expand_tool_button(
+                    expanded=node_exp,
+                    tip=f"Show/hide children of {net}",
+                    on_toggled=lambda exp, r=rail, n=net: (
+                        self._on_pending_subnet_node_expand_toggled(r, n, exp)
+                    ),
+                )
+                self._pending_subnet_expand_buttons[key] = expand_btn
             subnet_row = self._build_rail_row_widget(
                 eye,
+                expand_btn=expand_btn,
                 label_text=net,
                 bold=is_primary,
-                indent=18 * depth,
+                indent=indent_px * depth,
             )
             subnet_row.setStyleSheet(
                 f"color: {t['fg_muted']}; font-style: italic;"
@@ -20499,6 +20694,19 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
             row_idx += 1
         self._pending_rail_subnet_items[rail] = items
 
+    def _remove_pending_subnet_rows(self, rail: str) -> None:
+        for key in [
+            k for k in list(self._pending_subnet_expand_buttons)
+            if k[0] == rail
+        ]:
+            btn = self._pending_subnet_expand_buttons.pop(key)
+            if _qt_widget_alive(btn):
+                btn.blockSignals(True)
+        for item in self._pending_rail_subnet_items.pop(rail, []):
+            row = self.rail_list.row(item)
+            if row >= 0:
+                self.rail_list.takeItem(row)
+
     def _on_pending_rail_expand_toggled(self, rail: str, expanded: bool) -> None:
         self._pending_rail_expanded[rail] = expanded
         btn = self._pending_rail_expand_buttons.get(rail)
@@ -20510,10 +20718,21 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         if expanded:
             self._insert_pending_subnet_rows(rail, after_item=parent_item)
         else:
-            for item in self._pending_rail_subnet_items.pop(rail, []):
-                row = self.rail_list.row(item)
-                if row >= 0:
-                    self.rail_list.takeItem(row)
+            self._remove_pending_subnet_rows(rail)
+        self._update_rail_list_height()
+
+    def _on_pending_subnet_node_expand_toggled(
+        self, rail: str, net: str, expanded: bool,
+    ) -> None:
+        self._pending_subnet_node_expanded[(rail, net)] = expanded
+        btn = self._pending_subnet_expand_buttons.get((rail, net))
+        if btn is not None and _qt_widget_alive(btn):
+            btn.setArrowType(Qt.DownArrow if expanded else Qt.RightArrow)
+        parent_item = self._pending_rail_list_items.get(rail)
+        if parent_item is None or not self._pending_rail_expanded.get(rail):
+            return
+        self._remove_pending_subnet_rows(rail)
+        self._insert_pending_subnet_rows(rail, after_item=parent_item)
         self._update_rail_list_height()
 
     def _unnamed_copper_directives(self) -> list:

--- a/fypa/altium_viewer.py
+++ b/fypa/altium_viewer.py
@@ -8616,6 +8616,10 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         self._rail_names, self._rail_to_members = self._compute_rail_groups(
             metadata,
         )
+        from fypa.rail_groups import build_rail_trees
+        self._rail_to_trees = build_rail_trees(
+            metadata, self._rail_to_members,
+        )
 
         _stackup_pos = {
             row["name"]: i
@@ -9059,6 +9063,49 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         """
         from fypa.rail_groups import compute_rail_groups
         return compute_rail_groups(metadata)
+
+    def _series_bridge_metadata(self) -> dict:
+        """Metadata shaped for :func:`build_rail_trees` (RESISTOR edges only).
+
+        Merges solved-metadata RESISTOR directives with unresolved editor
+        SERIES bridges so pending rails get the same spanning-tree shape.
+        """
+        directives: list[dict] = []
+        meta = self.metadata if isinstance(self.metadata, dict) else {}
+        for d in meta.get("directives", []) or []:
+            if d.get("role") == "RESISTOR":
+                directives.append(d)
+        project = getattr(self, "_project", None)
+        if project is not None:
+            for ed in getattr(project, "editor_directives", []) or []:
+                if (
+                    getattr(ed, "role", None) == "SERIES"
+                    and getattr(ed, "p_net", None)
+                    and getattr(ed, "n_net", None)
+                ):
+                    directives.append({
+                        "role": "RESISTOR",
+                        "terminals": {
+                            "P": {"pins": [{"net": ed.p_net}]},
+                            "N": {"pins": [{"net": ed.n_net}]},
+                        },
+                    })
+        out = dict(meta)
+        out["directives"] = directives
+        return out
+
+    def _subnet_rows_for_rail(
+        self,
+        rail: str,
+        members: list[str],
+        trees: dict | None,
+    ) -> list[tuple[str, int]]:
+        """DFS ``(net, depth)`` rows for an expanded rail; flat fallback."""
+        from fypa.rail_groups import flatten_rail_tree
+        tree = (trees or {}).get(rail)
+        if tree is not None:
+            return flatten_rail_tree(tree)
+        return [(net, 1) for net in members]
 
     def showEvent(self, event) -> None:
         """Apply the deferred ``showMaximized`` once Qt has actually shown the
@@ -9884,11 +9931,13 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         self._rail_subnet_items: dict[str, list[QListWidgetItem]] = {}
         self._rail_expanded: dict[str, bool] = {}
         self._rail_list_items: dict[str, QListWidgetItem] = {}
+        self._rail_to_trees: dict = getattr(self, "_rail_to_trees", {})
         self._pending_rail_items: list = []
         self._pending_rail_list_items: dict[str, QListWidgetItem] = {}
         self._pending_rail_expand_buttons: dict[str, QToolButton] = {}
         self._pending_rail_subnet_items: dict[str, list[QListWidgetItem]] = {}
         self._pending_rail_expanded: dict[str, bool] = {}
+        self._pending_rail_trees: dict = {}
 
     def _ground_rail_names(self) -> set[str]:
         return {"0v", "gnd", "ground", "vss"}
@@ -10073,7 +10122,8 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         subnets = self._subnet_eye_buttons.get(rail, {})
         items: list[QListWidgetItem] = []
         row_idx = self.rail_list.row(after_item) + 1
-        for net in members:
+        trees = getattr(self, "_rail_to_trees", {})
+        for net, depth in self._subnet_rows_for_rail(rail, members, trees):
             eye = subnets.get(net)
             if eye is None or not _qt_widget_alive(eye):
                 continue
@@ -10082,7 +10132,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
                 eye,
                 label_text=net,
                 bold=is_primary,
-                indent=18,
+                indent=18 * depth,
             )
             if is_primary:
                 tip = f"Primary net of rail {rail}"
@@ -20375,6 +20425,11 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         self._pending_rail_expand_buttons = {}
         self._pending_rail_subnet_items = {}
         self._pending_rails = self._editor_pending_rails()
+        from fypa.rail_groups import build_rail_trees
+        self._pending_rail_trees = build_rail_trees(
+            self._series_bridge_metadata(),
+            self._pending_rails,
+        )
         t = _T()
         for name in sorted(self._pending_rails):
             members = self._pending_rails[name]
@@ -20432,7 +20487,8 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         items: list[QListWidgetItem] = []
         row_idx = self.rail_list.row(after_item) + 1
         t = _T()
-        for net in members:
+        trees = getattr(self, "_pending_rail_trees", {})
+        for net, depth in self._subnet_rows_for_rail(rail, members, trees):
             eye = EyeButton(visible=False)
             eye.setEnabled(False)
             is_primary = net == rail
@@ -20440,7 +20496,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
                 eye,
                 label_text=net,
                 bold=is_primary,
-                indent=18,
+                indent=18 * depth,
             )
             subnet_row.setStyleSheet(
                 f"color: {t['fg_muted']}; font-style: italic;"

--- a/fypa/altium_viewer.py
+++ b/fypa/altium_viewer.py
@@ -247,7 +247,8 @@ def _load_fypa_text_pixmap(height: int) -> QPixmap | None:
 
 
 from PySide6.QtCore import (
-    QByteArray, QEvent, QObject, QPointF, QRectF, QSize, Qt, QThread, QTimer, QUrl, Signal,
+    QByteArray, QEvent, QMetaMethod, QObject, QPointF, QRectF, QSize, Qt,
+    QThread, QTimer, QUrl, Signal,
 )
 from PySide6.QtGui import (
     QAction,
@@ -1466,15 +1467,29 @@ class EyeButton(QToolButton):
         self._press_mods = event.modifiers()
         super().mousePressEvent(event)
 
+    def _signal_connected(self, signal) -> bool:
+        return self.isSignalConnected(QMetaMethod.fromSignal(signal))
+
     def _on_clicked(self) -> None:
         mods = self._press_mods
         self._press_mods = Qt.NoModifier
-        if mods & Qt.ControlModifier:
+        # Ctrl/partial are opt-in: only subnet eyes wire these signals.
+        # Unwired eyes (rail / layer / All *) keep the default toggle so
+        # Ctrl+Click and partial-clear still work after this branch.
+        # Shift is intentionally unused here (isolate lives on
+        # feature/shift-click-eye-isolate).
+        if (mods & Qt.ControlModifier) and self._signal_connected(
+            self.ctrl_clicked,
+        ):
             self.ctrl_clicked.emit()
             return
         if self._partial:
-            self.setVisibleState(True, partial=False, emit=False)
-            self.partial_activated.emit()
+            if self._signal_connected(self.partial_activated):
+                self.setVisibleState(True, partial=False, emit=False)
+                self.partial_activated.emit()
+                return
+            # Default: clear partial → fully on via toggled_visible.
+            self.setVisibleState(True, partial=False)
             return
         self.setVisibleState(not self._visible, partial=False)
 
@@ -10349,7 +10364,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         Does **not** change each node's own on/off (that is copper for that
         net). Only the partial badge is derived from descendant visibility.
         """
-        from fypa.rail_groups import subtree_net_names
+        from fypa.rail_groups import rail_tree_node_partial_flags
 
         tree = self._subnet_tree_for_rail(rail)
         if tree is None:
@@ -10357,31 +10372,20 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         subnets = self._subnet_eye_buttons.get(rail, {})
         if not subnets:
             return
-
-        def _walk(node) -> None:
-            node_eye = subnets.get(node.name)
-            if node.children and node_eye is not None and _qt_widget_alive(node_eye):
-                desc = subtree_net_names(tree, node.name)[1:]
-                eyes = [
-                    subnets[n] for n in desc
-                    if n in subnets and _qt_widget_alive(subnets[n])
-                ]
-                if eyes:
-                    on_count = sum(e.isVisibleState() for e in eyes)
-                    all_on = on_count == len(eyes)
-                    all_off = on_count == 0
-                    partial = not all_on and not all_off
-                else:
-                    partial = False
-                node_eye.setVisibleState(
-                    node_eye.isVisibleState(),
-                    partial=partial,
-                    emit=False,
-                )
-            for child in node.children:
-                _walk(child)
-
-        _walk(tree)
+        visible = {
+            name: eye.isVisibleState()
+            for name, eye in subnets.items()
+            if _qt_widget_alive(eye)
+        }
+        for name, partial in rail_tree_node_partial_flags(tree, visible).items():
+            eye = subnets.get(name)
+            if eye is None or not _qt_widget_alive(eye):
+                continue
+            eye.setVisibleState(
+                eye.isVisibleState(),
+                partial=partial,
+                emit=False,
+            )
 
     def _sync_rail_eye_from_subnets(self, rail: str) -> None:
         subnets = self._subnet_eye_buttons.get(rail, {})

--- a/fypa/altium_viewer.py
+++ b/fypa/altium_viewer.py
@@ -9069,27 +9069,56 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
 
         Merges solved-metadata RESISTOR directives with unresolved editor
         SERIES bridges so pending rails get the same spanning-tree shape.
+        Editor SERIES pairs already present as RESISTOR pin bridges are skipped.
         """
         directives: list[dict] = []
+        seen_bridges: set[frozenset[str]] = set()
         meta = self.metadata if isinstance(self.metadata, dict) else {}
+
+        def _bridge_key(d: dict) -> frozenset[str] | None:
+            terms = d.get("terminals") or {}
+            nets_per_term: list[set[str]] = []
+            for t in terms.values():
+                nets = {p.get("net") for p in t.get("pins", []) if p.get("net")}
+                if nets:
+                    nets_per_term.append(nets)
+            if len(nets_per_term) != 2:
+                return None
+            # One representative net per side for dedupe of simple 1:1 bridges.
+            a = next(iter(nets_per_term[0]))
+            b = next(iter(nets_per_term[1]))
+            if not a or not b:
+                return None
+            return frozenset((a, b))
+
         for d in meta.get("directives", []) or []:
-            if d.get("role") == "RESISTOR":
-                directives.append(d)
+            if d.get("role") != "RESISTOR":
+                continue
+            directives.append(d)
+            key = _bridge_key(d)
+            if key is not None and len(key) == 2:
+                seen_bridges.add(key)
         project = getattr(self, "_project", None)
         if project is not None:
             for ed in getattr(project, "editor_directives", []) or []:
                 if (
-                    getattr(ed, "role", None) == "SERIES"
-                    and getattr(ed, "p_net", None)
-                    and getattr(ed, "n_net", None)
+                    getattr(ed, "role", None) != "SERIES"
+                    or not getattr(ed, "p_net", None)
+                    or not getattr(ed, "n_net", None)
                 ):
-                    directives.append({
-                        "role": "RESISTOR",
-                        "terminals": {
-                            "P": {"pins": [{"net": ed.p_net}]},
-                            "N": {"pins": [{"net": ed.n_net}]},
-                        },
-                    })
+                    continue
+                key = frozenset((ed.p_net, ed.n_net))
+                if len(key) == 2 and key in seen_bridges:
+                    continue
+                if len(key) == 2:
+                    seen_bridges.add(key)
+                directives.append({
+                    "role": "RESISTOR",
+                    "terminals": {
+                        "P": {"pins": [{"net": ed.p_net}]},
+                        "N": {"pins": [{"net": ed.n_net}]},
+                    },
+                })
         out = dict(meta)
         out["directives"] = directives
         return out

--- a/fypa/altium_viewer.py
+++ b/fypa/altium_viewer.py
@@ -2458,6 +2458,9 @@ class SidebarToggleButton(QToolButton):
         if collapsed == self._collapsed:
             return
         self._collapsed = collapsed
+        self.setCursor(
+            Qt.PointingHandCursor if collapsed else Qt.SizeHorCursor,
+        )
         self.update()
 
     def isCollapsed(self) -> bool:
@@ -8954,6 +8957,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
                     self._solved_since_save = False
                     self._display_dirty = False
                     self._init_overlay_state()
+                    self._load_sidebar_width_from_project()
                     title = (
                         Path(project_path).stem if project_path is not None
                         else getattr(new_solution.problem, "project_name", None)
@@ -9131,37 +9135,12 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         *,
         node_expanded: dict | None = None,
     ) -> list[tuple[str, int, bool]]:
-        """Visible subnet rows as ``(net, depth, has_children)``.
-
-        Walks the SERIES tree but only descends into nodes marked expanded
-        in ``node_expanded`` (defaults: primary expanded, others collapsed).
-        Flat fallback when no tree is available.
-        """
-        from fypa.rail_groups import RailTreeNode
-        expanded_map = node_expanded if node_expanded is not None else {}
+        """Visible subnet rows as ``(net, depth, has_children)``."""
+        from fypa.rail_groups import visible_rail_tree_rows
         tree = (trees or {}).get(rail)
-        if tree is None:
-            return [(net, 1, False) for net in members]
-
-        rows: list[tuple[str, int, bool]] = []
-
-        def _is_expanded(net: str) -> bool:
-            key = (rail, net)
-            if key in expanded_map:
-                return bool(expanded_map[key])
-            # First open: reveal the primary's children; deeper levels stay
-            # collapsed so long SERIES chains don't explode the list.
-            return net == rail
-
-        def _walk(node: RailTreeNode, depth: int) -> None:
-            has_children = bool(node.children)
-            rows.append((node.name, depth, has_children))
-            if has_children and _is_expanded(node.name):
-                for child in node.children:
-                    _walk(child, depth + 1)
-
-        _walk(tree, 1)
-        return rows
+        return visible_rail_tree_rows(
+            rail, members, tree, node_expanded=node_expanded,
+        )
 
     def showEvent(self, event) -> None:
         """Apply the deferred ``showMaximized`` once Qt has actually shown the
@@ -9635,6 +9614,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         self._sidebar_toggle_btn.resizedBy.connect(self._on_sidebar_resized_by)
         self._sidebar_toggle_btn.pressed.connect(self._on_sidebar_resize_press)
         outer.addWidget(self._sidebar_toggle_btn)
+        self._load_sidebar_width_from_project()
 
         # Plot area — custom QOpenGLWidget rendering the FEM mesh directly
         # via shaders (per-vertex colour interpolation, MVP transform on
@@ -10334,6 +10314,13 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         btn = self._subnet_expand_buttons.get((rail, net))
         if btn is not None and _qt_widget_alive(btn):
             btn.setArrowType(Qt.DownArrow if expanded else Qt.RightArrow)
+        # Defer rebuild: this slot runs on the expand button's toggled
+        # signal, and rebuilding destroys that button.
+        QTimer.singleShot(
+            0, lambda r=rail: self._rebuild_rail_subnet_rows(r),
+        )
+
+    def _rebuild_rail_subnet_rows(self, rail: str) -> None:
         parent_item = self._rail_list_items.get(rail)
         if parent_item is None or not self._rail_expanded.get(rail):
             return
@@ -16312,6 +16299,17 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         widget.setFixedWidth(w)
         scroll.setFixedWidth(w + self._SIDEBAR_SCROLLBAR_W)
 
+    def _load_sidebar_width_from_project(self) -> None:
+        """Restore left side-panel width from ``viewer_settings``."""
+        proj = getattr(self, "_project", None)
+        if proj is None:
+            return
+        saved = (getattr(proj, "viewer_settings", None) or {}).get(
+            "sidebar_content_w",
+        )
+        if isinstance(saved, (int, float)) and saved > 0:
+            self._apply_sidebar_content_width(int(saved))
+
     def _hotkey_2d_mode(self) -> None:
         self.view_3d_box.setChecked(False)
 
@@ -20728,6 +20726,11 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         btn = self._pending_subnet_expand_buttons.get((rail, net))
         if btn is not None and _qt_widget_alive(btn):
             btn.setArrowType(Qt.DownArrow if expanded else Qt.RightArrow)
+        QTimer.singleShot(
+            0, lambda r=rail: self._rebuild_pending_subnet_rows(r),
+        )
+
+    def _rebuild_pending_subnet_rows(self, rail: str) -> None:
         parent_item = self._pending_rail_list_items.get(rail)
         if parent_item is None or not self._pending_rail_expanded.get(rail):
             return
@@ -23268,6 +23271,10 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         caploop = getattr(self, "_caploop_settings_obj", None)
         if caploop is not None:
             proj.viewer_settings["caploop"] = caploop.to_dict()
+
+        sidebar_w = getattr(self, "_sidebar_content_w", None)
+        if isinstance(sidebar_w, int) and sidebar_w > 0:
+            proj.viewer_settings["sidebar_content_w"] = int(sidebar_w)
 
         overlay_state = getattr(self, "_overlay_state", None)
         if overlay_state:

--- a/fypa/altium_viewer.py
+++ b/fypa/altium_viewer.py
@@ -1394,18 +1394,30 @@ class EyeButton(QToolButton):
     """Altium-style eye-icon toggle for layer visibility."""
 
     toggled_visible = Signal(bool)
+    # Ctrl+Click — rail-tree subnet eyes use this for SERIES-subtree fan-out.
+    # Shift+Click isolate/invert is wired on feature/shift-click-eye-isolate;
+    # do not consume Shift here so a future merge can own that gesture.
+    ctrl_clicked = Signal()
+    # Emitted when a partial eye is clicked (clears partial → fully on).
+    partial_activated = Signal()
 
     def __init__(self, parent=None, *, visible: bool = True,
                  icon_size: int = 16,
                  tip_show: str = "Show layer",
-                 tip_hide: str = "Hide layer") -> None:
+                 tip_hide: str = "Hide layer",
+                 tip_partial: str | None = None) -> None:
         super().__init__(parent)
         self._visible = bool(visible)
         self._partial = False
         self._icon_size = icon_size
         self._tip_show = tip_show
         self._tip_hide = tip_hide
-        self._tip_partial = "Some subnet nets visible — click to show all"
+        self._tip_partial = (
+            tip_partial
+            if tip_partial is not None
+            else "Some subnet nets visible — click to show all"
+        )
+        self._press_mods: Qt.KeyboardModifiers = Qt.NoModifier
         self.setAutoRaise(True)
         self.setCursor(Qt.PointingHandCursor)
         self.setIconSize(QSize(icon_size, icon_size))
@@ -1424,7 +1436,9 @@ class EyeButton(QToolButton):
         self, on: bool, *, partial: bool = False, emit: bool = True,
     ) -> None:
         on = bool(on)
-        partial = bool(partial) and on
+        # Partial may sit on an off eye (parent off, some descendants on)
+        # so the icon can show "mixed subtree" without enabling this net.
+        partial = bool(partial)
         if on == self._visible and partial == self._partial:
             return
         self._visible = on
@@ -1434,19 +1448,35 @@ class EyeButton(QToolButton):
             self.toggled_visible.emit(self._visible)
 
     def _apply_icon(self) -> None:
+        # Partial uses the open-eye silhouette (muted); closed+partial must
+        # not draw the slash or it reads as fully hidden.
         self.setIcon(QIcon(_eye_pixmap(
-            self._visible, self._icon_size, partial=self._partial,
+            self._visible or self._partial,
+            self._icon_size,
+            partial=self._partial,
         )))
         if self._partial:
             self.setToolTip(self._tip_partial)
         else:
             self.setToolTip(self._tip_hide if self._visible else self._tip_show)
 
+    def mousePressEvent(self, event) -> None:
+        # Capture modifiers at press — clicked fires on release and may
+        # already have cleared Ctrl.
+        self._press_mods = event.modifiers()
+        super().mousePressEvent(event)
+
     def _on_clicked(self) -> None:
+        mods = self._press_mods
+        self._press_mods = Qt.NoModifier
+        if mods & Qt.ControlModifier:
+            self.ctrl_clicked.emit()
+            return
         if self._partial:
-            self.setVisibleState(True, partial=False)
-        else:
-            self.setVisibleState(not self._visible, partial=False)
+            self.setVisibleState(True, partial=False, emit=False)
+            self.partial_activated.emit()
+            return
+        self.setVisibleState(not self._visible, partial=False)
 
 
 # --- Wire-mesh / solid fill toggle icons -----------------------------------
@@ -10160,12 +10190,32 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
                     subnet_eye = EyeButton(
                         parent=self._subnet_eye_holder,
                         visible=False,
-                        tip_show=f"Show {net} copper",
-                        tip_hide=f"Hide {net} copper",
+                        tip_show=(
+                            f"Show {net} copper\n"
+                            f"Ctrl+Click: include SERIES subtree"
+                        ),
+                        tip_hide=(
+                            f"Hide {net} copper\n"
+                            f"Ctrl+Click: include SERIES subtree"
+                        ),
+                        tip_partial=(
+                            f"Some nets in the {net} SERIES subtree are "
+                            f"visible — click to show all"
+                        ),
                     )
                     subnet_eye.toggled_visible.connect(
                         lambda on, r=rail, n=net: self._on_subnet_eye_toggled(
                             r, n, on,
+                        ),
+                    )
+                    subnet_eye.ctrl_clicked.connect(
+                        lambda r=rail, n=net: self._on_subnet_eye_ctrl_clicked(
+                            r, n,
+                        ),
+                    )
+                    subnet_eye.partial_activated.connect(
+                        lambda r=rail, n=net: (
+                            self._on_subnet_eye_partial_activated(r, n)
                         ),
                     )
                     self._subnet_eye_buttons[rail][net] = subnet_eye
@@ -10178,6 +10228,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
                         vis = self._default_rail_visible(rail)
                     subnet_eye.setVisibleState(vis, emit=False)
                 self._sync_rail_eye_from_subnets(rail)
+                self._sync_rail_tree_node_partials(rail)
             else:
                 if preserve_visibility and rail in saved_rails:
                     vis = saved_rails[rail]
@@ -10270,7 +10321,67 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
     def _fan_out_rail_eye_to_subnets(self, rail: str, on: bool) -> None:
         for eye in self._subnet_eye_buttons.get(rail, {}).values():
             if _qt_widget_alive(eye):
-                eye.setVisibleState(on, emit=False)
+                eye.setVisibleState(on, partial=False, emit=False)
+
+    def _subnet_tree_for_rail(self, rail: str):
+        trees = getattr(self, "_rail_to_trees", {}) or {}
+        return trees.get(rail)
+
+    def _fan_out_subnet_subtree(
+        self, rail: str, net: str, on: bool,
+    ) -> None:
+        """Set visibility for ``net`` and all SERIES descendants."""
+        from fypa.rail_groups import subtree_net_names
+
+        tree = self._subnet_tree_for_rail(rail)
+        names = subtree_net_names(tree, net)
+        if not names:
+            names = [net]
+        subnets = self._subnet_eye_buttons.get(rail, {})
+        for name in names:
+            eye = subnets.get(name)
+            if eye is not None and _qt_widget_alive(eye):
+                eye.setVisibleState(on, partial=False, emit=False)
+
+    def _sync_rail_tree_node_partials(self, rail: str) -> None:
+        """Mark intermediate node eyes partial when descendants are mixed.
+
+        Does **not** change each node's own on/off (that is copper for that
+        net). Only the partial badge is derived from descendant visibility.
+        """
+        from fypa.rail_groups import subtree_net_names
+
+        tree = self._subnet_tree_for_rail(rail)
+        if tree is None:
+            return
+        subnets = self._subnet_eye_buttons.get(rail, {})
+        if not subnets:
+            return
+
+        def _walk(node) -> None:
+            node_eye = subnets.get(node.name)
+            if node.children and node_eye is not None and _qt_widget_alive(node_eye):
+                desc = subtree_net_names(tree, node.name)[1:]
+                eyes = [
+                    subnets[n] for n in desc
+                    if n in subnets and _qt_widget_alive(subnets[n])
+                ]
+                if eyes:
+                    on_count = sum(e.isVisibleState() for e in eyes)
+                    all_on = on_count == len(eyes)
+                    all_off = on_count == 0
+                    partial = not all_on and not all_off
+                else:
+                    partial = False
+                node_eye.setVisibleState(
+                    node_eye.isVisibleState(),
+                    partial=partial,
+                    emit=False,
+                )
+            for child in node.children:
+                _walk(child)
+
+        _walk(tree)
 
     def _sync_rail_eye_from_subnets(self, rail: str) -> None:
         subnets = self._subnet_eye_buttons.get(rail, {})
@@ -10292,6 +10403,13 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
                     not all_off, partial=partial, emit=False,
                 )
                 break
+
+    def _refresh_rail_visibility_after_subnet_change(self, rail: str) -> None:
+        self._sync_rail_tree_node_partials(rail)
+        self._sync_rail_eye_from_subnets(rail)
+        self._sync_all_rails_eye()
+        self._sync_rail_only_visibility()
+        self._render_with_busy_popup()
 
     def _on_rail_expand_toggled(self, rail: str, expanded: bool) -> None:
         self._rail_expanded[rail] = expanded
@@ -10332,10 +10450,44 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         eye = self._subnet_eye_buttons.get(rail, {}).get(net)
         if eye is None or not _qt_widget_alive(eye):
             return
-        self._sync_rail_eye_from_subnets(rail)
-        self._sync_all_rails_eye()
-        self._sync_rail_only_visibility()
-        self._render_with_busy_popup()
+        self._refresh_rail_visibility_after_subnet_change(rail)
+
+    def _on_subnet_eye_ctrl_clicked(self, rail: str, net: str) -> None:
+        """Ctrl+Click: toggle this net and its SERIES subtree together."""
+        from fypa.rail_groups import subtree_net_names
+
+        eye = self._subnet_eye_buttons.get(rail, {}).get(net)
+        if eye is None or not _qt_widget_alive(eye):
+            return
+        tree = self._subnet_tree_for_rail(rail)
+        names = subtree_net_names(tree, net) or [net]
+        subnets = self._subnet_eye_buttons.get(rail, {})
+        eyes = [
+            subnets[n] for n in names
+            if n in subnets and _qt_widget_alive(subnets[n])
+        ]
+        if not eyes:
+            return
+        # Same rule as EyeButton: mixed/not-all-on → all on; else all off.
+        on_count = sum(e.isVisibleState() for e in eyes)
+        all_on = on_count == len(eyes)
+        target = not all_on
+        self._fan_out_subnet_subtree(rail, net, target)
+        self._refresh_rail_visibility_after_subnet_change(rail)
+
+    def _on_subnet_eye_partial_activated(self, rail: str, net: str) -> None:
+        """Partial eye click → show entire SERIES subtree (like primary)."""
+        from fypa.rail_groups import find_rail_tree_node
+
+        tree = self._subnet_tree_for_rail(rail)
+        node = find_rail_tree_node(tree, net)
+        if node is not None and node.children:
+            self._fan_out_subnet_subtree(rail, net, True)
+        else:
+            eye = self._subnet_eye_buttons.get(rail, {}).get(net)
+            if eye is not None and _qt_widget_alive(eye):
+                eye.setVisibleState(True, partial=False, emit=False)
+        self._refresh_rail_visibility_after_subnet_change(rail)
 
     def _on_layer_eye_toggled(self, _on: bool) -> None:
         """An individual layer's eye was clicked."""
@@ -10504,10 +10656,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         ):
             return
         self._fan_out_rail_eye_to_subnets(rail, on)
-        self._sync_rail_eye_from_subnets(rail)
-        self._sync_all_rails_eye()
-        self._sync_rail_only_visibility()
-        self._render_with_busy_popup()
+        self._refresh_rail_visibility_after_subnet_change(rail)
 
     def _on_all_rails_toggled(self, on: bool) -> None:
         """The "All Rails" eye was clicked — show or hide every rail."""
@@ -10515,6 +10664,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
             if _qt_widget_alive(eye):
                 eye.setVisibleState(on, partial=False, emit=False)
             self._fan_out_rail_eye_to_subnets(name, on)
+            self._sync_rail_tree_node_partials(name)
         self._sync_all_rails_eye()
         self._sync_rail_only_visibility()
         self._render_with_busy_popup()

--- a/fypa/altium_viewer.py
+++ b/fypa/altium_viewer.py
@@ -10458,7 +10458,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
 
     def _on_subnet_eye_ctrl_clicked(self, rail: str, net: str) -> None:
         """Ctrl+Click: toggle this net and its SERIES subtree together."""
-        from fypa.rail_groups import subtree_net_names
+        from fypa.rail_groups import subtree_net_names, subtree_toggle_target
 
         eye = self._subnet_eye_buttons.get(rail, {}).get(net)
         if eye is None or not _qt_widget_alive(eye):
@@ -10472,10 +10472,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         ]
         if not eyes:
             return
-        # Same rule as EyeButton: mixed/not-all-on → all on; else all off.
-        on_count = sum(e.isVisibleState() for e in eyes)
-        all_on = on_count == len(eyes)
-        target = not all_on
+        target = subtree_toggle_target([e.isVisibleState() for e in eyes])
         self._fan_out_subnet_subtree(rail, net, target)
         self._refresh_rail_visibility_after_subnet_change(rail)
 

--- a/fypa/altium_viewer.py
+++ b/fypa/altium_viewer.py
@@ -9064,45 +9064,21 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         from fypa.rail_groups import compute_rail_groups
         return compute_rail_groups(metadata)
 
-    def _series_bridge_metadata(self) -> dict:
-        """Metadata for :func:`build_rail_trees` on pending / editor rails.
-
-        Keeps SOURCE/SINK/REGULATOR (alias edges) and RESISTOR (SERIES bridges)
-        from solved metadata, then appends unresolved editor SERIES whose pin
-        pairs are not already covered (all bipartite RESISTOR pairs counted).
-        """
-        from fypa.rail_groups import (
-            filter_directives_for_rail_trees,
-            resistor_bridge_pairs,
-        )
+    def _rail_tree_metadata(self) -> dict:
+        """Metadata for :func:`build_rail_trees` on pending / editor rails."""
+        from fypa.rail_groups import merge_rail_tree_metadata
         meta = self.metadata if isinstance(self.metadata, dict) else {}
-        directives = filter_directives_for_rail_trees(meta.get("directives"))
-        seen_bridges: set[frozenset[str]] = set()
-        for d in directives:
-            seen_bridges.update(resistor_bridge_pairs(d))
+        editor_series: list[tuple[str, str]] = []
         project = getattr(self, "_project", None)
         if project is not None:
             for ed in getattr(project, "editor_directives", []) or []:
                 if (
-                    getattr(ed, "role", None) != "SERIES"
-                    or not getattr(ed, "p_net", None)
-                    or not getattr(ed, "n_net", None)
+                    getattr(ed, "role", None) == "SERIES"
+                    and getattr(ed, "p_net", None)
+                    and getattr(ed, "n_net", None)
                 ):
-                    continue
-                key = frozenset((ed.p_net, ed.n_net))
-                if len(key) != 2 or key in seen_bridges:
-                    continue
-                seen_bridges.add(key)
-                directives.append({
-                    "role": "RESISTOR",
-                    "terminals": {
-                        "P": {"pins": [{"net": ed.p_net}]},
-                        "N": {"pins": [{"net": ed.n_net}]},
-                    },
-                })
-        out = dict(meta)
-        out["directives"] = directives
-        return out
+                    editor_series.append((ed.p_net, ed.n_net))
+        return merge_rail_tree_metadata(meta, editor_series)
 
     def _subnet_rows_for_rail(
         self,
@@ -20437,7 +20413,7 @@ class PdnViewer(_SettingsTabMixin, QMainWindow):
         self._pending_rails = self._editor_pending_rails()
         from fypa.rail_groups import build_rail_trees
         self._pending_rail_trees = build_rail_trees(
-            self._series_bridge_metadata(),
+            self._rail_tree_metadata(),
             self._pending_rails,
         )
         t = _T()

--- a/fypa/rail_groups.py
+++ b/fypa/rail_groups.py
@@ -486,6 +486,43 @@ def subtree_net_names(
     return [name for name, _depth in flatten_rail_tree(node, depth=1)]
 
 
+def rail_tree_node_partial_flags(
+    root: RailTreeNode | None,
+    visible: dict[str, bool],
+) -> dict[str, bool]:
+    """Map each tree net to whether its eye should show partial.
+
+    Partial is True only when the node has children and descendant nets
+    present in ``visible`` are mixed (some on, some off). Leaves are
+    always False so a stale partial badge cannot linger. Single-pass
+    post-order walk — O(n) in tree size.
+    """
+    flags: dict[str, bool] = {}
+    if root is None:
+        return flags
+
+    def _walk(node: RailTreeNode) -> tuple[int, int]:
+        on_count = 0
+        total = 0
+        for child in node.children:
+            if child.name in visible:
+                total += 1
+                if visible[child.name]:
+                    on_count += 1
+            d_on, d_total = _walk(child)
+            on_count += d_on
+            total += d_total
+        if node.children:
+            partial = total > 0 and on_count not in (0, total)
+        else:
+            partial = False
+        flags[node.name] = partial
+        return on_count, total
+
+    _walk(root)
+    return flags
+
+
 def resolve_rail_member_nets(
     rail_names: list[str],
     rail_to_members: dict[str, list[str]],

--- a/fypa/rail_groups.py
+++ b/fypa/rail_groups.py
@@ -407,6 +407,43 @@ def build_rail_trees(
     }
 
 
+def visible_rail_tree_rows(
+    rail: str,
+    members: list[str],
+    tree: RailTreeNode | None,
+    node_expanded: dict[tuple[str, str], bool] | None = None,
+) -> list[tuple[str, int, bool]]:
+    """Visible subnet rows as ``(net, depth, has_children)``.
+
+    Walks ``tree`` but only descends into nodes marked expanded in
+    ``node_expanded``. Missing keys default to expanded only for the
+    primary (``net == rail``) so the first level of children appears
+    without exploding deep SERIES chains. Flat fallback when ``tree``
+    is ``None``.
+    """
+    expanded_map = node_expanded if node_expanded is not None else {}
+    if tree is None:
+        return [(net, 1, False) for net in members]
+
+    rows: list[tuple[str, int, bool]] = []
+
+    def _is_expanded(net: str) -> bool:
+        key = (rail, net)
+        if key in expanded_map:
+            return bool(expanded_map[key])
+        return net == rail
+
+    def _walk(node: RailTreeNode, depth: int) -> None:
+        has_children = bool(node.children)
+        rows.append((node.name, depth, has_children))
+        if has_children and _is_expanded(node.name):
+            for child in node.children:
+                _walk(child, depth + 1)
+
+    _walk(tree, 1)
+    return rows
+
+
 def flatten_rail_tree(
     root: RailTreeNode,
     *,

--- a/fypa/rail_groups.py
+++ b/fypa/rail_groups.py
@@ -2,8 +2,19 @@
 
 from __future__ import annotations
 
+from collections import deque
+from dataclasses import dataclass
+
 from fypa.topology.net_aliases import is_gnd_alias
 from fypa.topology.metadata_schema import TopologyMetadata
+
+
+@dataclass(frozen=True)
+class RailTreeNode:
+    """One net in a rail's SERIES spanning tree (root = primary)."""
+
+    name: str
+    children: tuple[RailTreeNode, ...] = ()
 
 
 def compute_rail_groups(
@@ -156,6 +167,113 @@ def compute_rail_groups(
 
     rail_names = sorted(rail_to_members.keys(), key=_rail_sort_key)
     return rail_names, rail_to_members
+
+
+def _series_adjacency(
+    metadata: TopologyMetadata | None,
+) -> dict[str, set[str]]:
+    """Undirected SERIES/RESISTOR edges between terminal pin nets."""
+    adj: dict[str, set[str]] = {}
+    if metadata is None:
+        return adj
+    for d in metadata.get("directives", []):
+        if d.get("role") != "RESISTOR":
+            continue
+        terms = d.get("terminals") or {}
+        nets_per_term: list[set[str]] = []
+        for t in terms.values():
+            nets = {p.get("net") for p in t.get("pins", []) if p.get("net")}
+            if nets:
+                nets_per_term.append(nets)
+        if len(nets_per_term) != 2:
+            continue
+        for a in nets_per_term[0]:
+            for b in nets_per_term[1]:
+                if not a or not b or a == b:
+                    continue
+                adj.setdefault(a, set()).add(b)
+                adj.setdefault(b, set()).add(a)
+    return adj
+
+
+def _spanning_tree_from_primary(
+    primary: str,
+    members: list[str],
+    adj: dict[str, set[str]],
+) -> RailTreeNode:
+    """BFS spanning tree of ``members`` rooted at ``primary`` via SERIES edges.
+
+    Members with no SERIES path to the primary become direct children of the
+    primary (alias / requested-net unions that never got a bridge edge).
+    """
+    member_set = set(members)
+    if not member_set:
+        return RailTreeNode(name=primary)
+
+    root = primary if primary in member_set else sorted(member_set)[0]
+    children_of: dict[str, list[str]] = {n: [] for n in member_set}
+    if root not in children_of:
+        children_of[root] = []
+
+    visited: set[str] = {root}
+    queue: deque[str] = deque([root])
+    while queue:
+        u = queue.popleft()
+        for v in sorted(adj.get(u, set()) & member_set):
+            if v in visited:
+                continue
+            visited.add(v)
+            children_of.setdefault(u, []).append(v)
+            children_of.setdefault(v, [])
+            queue.append(v)
+
+    for n in sorted(member_set):
+        if n not in visited:
+            children_of.setdefault(root, []).append(n)
+            children_of.setdefault(n, [])
+            visited.add(n)
+
+    for parent, kids in list(children_of.items()):
+        children_of[parent] = sorted(kids)
+
+    def _node(name: str) -> RailTreeNode:
+        return RailTreeNode(
+            name=name,
+            children=tuple(_node(c) for c in children_of.get(name, ())),
+        )
+
+    return _node(root)
+
+
+def build_rail_trees(
+    metadata: TopologyMetadata | None,
+    rail_to_members: dict[str, list[str]],
+) -> dict[str, RailTreeNode]:
+    """Build a SERIES spanning tree per rail (BFS from each primary).
+
+    ``rail_to_members`` stays the flat membership used for copper / eyes;
+    this returns the nested display shape only. Rails with a single member
+    yield a leaf root. Missing or empty input yields ``{}``.
+    """
+    if not rail_to_members:
+        return {}
+    adj = _series_adjacency(metadata)
+    return {
+        primary: _spanning_tree_from_primary(primary, members, adj)
+        for primary, members in rail_to_members.items()
+    }
+
+
+def flatten_rail_tree(
+    root: RailTreeNode,
+    *,
+    depth: int = 1,
+) -> list[tuple[str, int]]:
+    """DFS preorder ``(net_name, depth)`` rows for the Rails list indent."""
+    rows: list[tuple[str, int]] = [(root.name, depth)]
+    for child in root.children:
+        rows.extend(flatten_rail_tree(child, depth=depth + 1))
+    return rows
 
 
 def resolve_rail_member_nets(

--- a/fypa/rail_groups.py
+++ b/fypa/rail_groups.py
@@ -486,16 +486,28 @@ def subtree_net_names(
     return [name for name, _depth in flatten_rail_tree(node, depth=1)]
 
 
+def subtree_toggle_target(states: list[bool]) -> bool:
+    """Ctrl+Click fan-out target for a SERIES subtree.
+
+    Mixed or not-all-on → ``True`` (show all); all on → ``False`` (hide all).
+    Empty ``states`` defaults to show-all.
+    """
+    if not states:
+        return True
+    return not all(states)
+
+
 def rail_tree_node_partial_flags(
     root: RailTreeNode | None,
     visible: dict[str, bool],
 ) -> dict[str, bool]:
     """Map each tree net to whether its eye should show partial.
 
-    Partial is True only when the node has children and descendant nets
-    present in ``visible`` are mixed (some on, some off). Leaves are
-    always False so a stale partial badge cannot linger. Single-pass
-    post-order walk — O(n) in tree size.
+    For nodes with children, partial follows the same mixed rule as the
+    primary rail eye over ``{self} ∪ descendants`` present in ``visible``
+    — so parent-off with all children on is partial (muted open), not a
+    plain closed eye. Leaves are always False so a stale badge cannot
+    linger. Single-pass post-order walk — O(n) in tree size.
     """
     flags: dict[str, bool] = {}
     if root is None:
@@ -513,7 +525,13 @@ def rail_tree_node_partial_flags(
             on_count += d_on
             total += d_total
         if node.children:
-            partial = total > 0 and on_count not in (0, total)
+            group_on = on_count
+            group_total = total
+            if node.name in visible:
+                group_total += 1
+                if visible[node.name]:
+                    group_on += 1
+            partial = group_total > 0 and group_on not in (0, group_total)
         else:
             partial = False
         flags[node.name] = partial

--- a/fypa/rail_groups.py
+++ b/fypa/rail_groups.py
@@ -503,11 +503,15 @@ def rail_tree_node_partial_flags(
 ) -> dict[str, bool]:
     """Map each tree net to whether its eye should show partial.
 
-    For nodes with children, partial follows the same mixed rule as the
-    primary rail eye over ``{self} ∪ descendants`` present in ``visible``
-    — so parent-off with all children on is partial (muted open), not a
-    plain closed eye. Leaves are always False so a stale badge cannot
-    linger. Single-pass post-order walk — O(n) in tree size.
+    For nodes with children:
+
+    * mixed descendants → partial
+    * all descendants on while this net is off → partial (muted open;
+      copper stays off until the user activates)
+    * all descendants off → never partial, even if this net is on, so a
+      plain click still toggles this net instead of fan-out-on
+
+    Leaves are always False. Single-pass post-order — O(n).
     """
     flags: dict[str, bool] = {}
     if root is None:
@@ -524,14 +528,14 @@ def rail_tree_node_partial_flags(
             d_on, d_total = _walk(child)
             on_count += d_on
             total += d_total
-        if node.children:
-            group_on = on_count
-            group_total = total
-            if node.name in visible:
-                group_total += 1
-                if visible[node.name]:
-                    group_on += 1
-            partial = group_total > 0 and group_on not in (0, group_total)
+        if node.children and total > 0:
+            if on_count not in (0, total):
+                partial = True
+            elif on_count == total:
+                # All descendants on: badge only if this net itself is off.
+                partial = node.name in visible and not visible[node.name]
+            else:
+                partial = False
         else:
             partial = False
         flags[node.name] = partial

--- a/fypa/rail_groups.py
+++ b/fypa/rail_groups.py
@@ -169,31 +169,82 @@ def compute_rail_groups(
     return rail_names, rail_to_members
 
 
-def _series_adjacency(
+def _add_undirected_edge(adj: dict[str, set[str]], a: str, b: str) -> None:
+    if not a or not b or a == b:
+        return
+    adj.setdefault(a, set()).add(b)
+    adj.setdefault(b, set()).add(a)
+
+
+def _rail_tree_adjacency(
     metadata: TopologyMetadata | None,
 ) -> dict[str, set[str]]:
-    """Undirected SERIES/RESISTOR edges between terminal pin nets."""
+    """Undirected graph for rail subnet trees.
+
+    Includes:
+
+    * **RESISTOR/SERIES** pin-to-pin bridges
+    * **Alias** edges: ``requested_net`` ↔ pin nets (same unions the
+      rail grouper uses), plus each name ↔ its ``net_canonical`` form
+
+    Alias edges let BFS start at the primary and still walk bridges that
+    were annotated only on a local label.
+    """
     adj: dict[str, set[str]] = {}
     if metadata is None:
         return adj
+    canon_map: dict[str, str] = metadata.get("net_canonical") or {}
+
+    def _canonical(net: str) -> str:
+        if not net:
+            return net
+        return canon_map.get(net.upper(), net)
+
+    def _note_aliases(*nets: str) -> None:
+        for net in nets:
+            if not net:
+                continue
+            _add_undirected_edge(adj, net, _canonical(net))
+
     for d in metadata.get("directives", []):
-        if d.get("role") != "RESISTOR":
-            continue
+        role = d.get("role", "")
         terms = d.get("terminals") or {}
         nets_per_term: list[set[str]] = []
         for t in terms.values():
             nets = {p.get("net") for p in t.get("pins", []) if p.get("net")}
+            req = t.get("requested_net")
             if nets:
                 nets_per_term.append(nets)
-        if len(nets_per_term) != 2:
-            continue
-        for a in nets_per_term[0]:
-            for b in nets_per_term[1]:
-                if not a or not b or a == b:
-                    continue
-                adj.setdefault(a, set()).add(b)
-                adj.setdefault(b, set()).add(a)
+            _note_aliases(*(nets or set()), req or "")
+            if req:
+                for n in nets:
+                    _add_undirected_edge(adj, req, n)
+        if role == "RESISTOR" and len(nets_per_term) == 2:
+            for a in nets_per_term[0]:
+                for b in nets_per_term[1]:
+                    _add_undirected_edge(adj, a, b)
     return adj
+
+
+def _bfs_attach_children(
+    root: str,
+    *,
+    allowed: set[str],
+    adj: dict[str, set[str]],
+    visited: set[str],
+    children_of: dict[str, list[str]],
+) -> None:
+    """BFS from ``root`` through ``allowed`` nets; record tree edges."""
+    queue: deque[str] = deque([root])
+    while queue:
+        u = queue.popleft()
+        for v in sorted(adj.get(u, set()) & allowed):
+            if v in visited:
+                continue
+            visited.add(v)
+            children_of.setdefault(u, []).append(v)
+            children_of.setdefault(v, [])
+            queue.append(v)
 
 
 def _spanning_tree_from_primary(
@@ -201,10 +252,12 @@ def _spanning_tree_from_primary(
     members: list[str],
     adj: dict[str, set[str]],
 ) -> RailTreeNode:
-    """BFS spanning tree of ``members`` rooted at ``primary`` via SERIES edges.
+    """BFS spanning tree of ``members`` rooted at ``primary``.
 
-    Members with no SERIES path to the primary become direct children of the
-    primary (alias / requested-net unions that never got a bridge edge).
+    Walks SERIES and alias edges. Any remaining connected components (nets
+    with no path to the primary) are attached under the primary as their
+    own BFS subtrees — not flattened — so SERIES chains among orphans keep
+    their nesting.
     """
     member_set = set(members)
     if not member_set:
@@ -216,22 +269,29 @@ def _spanning_tree_from_primary(
         children_of[root] = []
 
     visited: set[str] = {root}
-    queue: deque[str] = deque([root])
-    while queue:
-        u = queue.popleft()
-        for v in sorted(adj.get(u, set()) & member_set):
-            if v in visited:
-                continue
-            visited.add(v)
-            children_of.setdefault(u, []).append(v)
-            children_of.setdefault(v, [])
-            queue.append(v)
+    _bfs_attach_children(
+        root,
+        allowed=member_set,
+        adj=adj,
+        visited=visited,
+        children_of=children_of,
+    )
 
-    for n in sorted(member_set):
-        if n not in visited:
-            children_of.setdefault(root, []).append(n)
-            children_of.setdefault(n, [])
-            visited.add(n)
+    while True:
+        remaining = member_set - visited
+        if not remaining:
+            break
+        seed = sorted(remaining)[0]
+        visited.add(seed)
+        children_of.setdefault(root, []).append(seed)
+        children_of.setdefault(seed, [])
+        _bfs_attach_children(
+            seed,
+            allowed=remaining,
+            adj=adj,
+            visited=visited,
+            children_of=children_of,
+        )
 
     for parent, kids in list(children_of.items()):
         children_of[parent] = sorted(kids)
@@ -257,7 +317,7 @@ def build_rail_trees(
     """
     if not rail_to_members:
         return {}
-    adj = _series_adjacency(metadata)
+    adj = _rail_tree_adjacency(metadata)
     return {
         primary: _spanning_tree_from_primary(primary, members, adj)
         for primary, members in rail_to_members.items()

--- a/fypa/rail_groups.py
+++ b/fypa/rail_groups.py
@@ -184,6 +184,11 @@ def filter_directives_for_rail_trees(
     ]
 
 
+def bridge_pair_key(a: str, b: str) -> frozenset[str]:
+    """Case-insensitive undirected key for a SERIES/RESISTOR pin pair."""
+    return frozenset((a.upper(), b.upper()))
+
+
 def resistor_bridge_pairs(directive: dict) -> list[frozenset[str]]:
     """All undirected pin-net pairs from a RESISTOR's two terminals."""
     if directive.get("role") != "RESISTOR":
@@ -202,6 +207,44 @@ def resistor_bridge_pairs(directive: dict) -> list[frozenset[str]]:
             if a and b and a != b:
                 pairs.append(frozenset((a, b)))
     return pairs
+
+
+def merge_rail_tree_metadata(
+    metadata: TopologyMetadata | None,
+    editor_series: list[tuple[str, str]] | None = None,
+) -> dict:
+    """Build metadata for :func:`build_rail_trees` (pending / editor rails).
+
+    Keeps SOURCE/SINK/REGULATOR (alias edges) and RESISTOR (SERIES bridges)
+    from ``metadata``, then appends editor SERIES ``(p_net, n_net)`` pairs
+    whose bridges are not already covered (case-insensitive; all bipartite
+    RESISTOR pin pairs counted).
+    """
+    meta = dict(metadata) if isinstance(metadata, dict) else {}
+    directives = filter_directives_for_rail_trees(meta.get("directives"))
+    seen_bridges: set[frozenset[str]] = set()
+    for d in directives:
+        for pair in resistor_bridge_pairs(d):
+            if len(pair) == 2:
+                a, b = tuple(pair)
+                seen_bridges.add(bridge_pair_key(a, b))
+    for p_net, n_net in editor_series or ():
+        if not p_net or not n_net:
+            continue
+        key = bridge_pair_key(p_net, n_net)
+        if len(key) != 2 or key in seen_bridges:
+            continue
+        seen_bridges.add(key)
+        directives.append({
+            "role": "RESISTOR",
+            "terminals": {
+                "P": {"pins": [{"net": p_net}]},
+                "N": {"pins": [{"net": n_net}]},
+            },
+        })
+    out = dict(meta)
+    out["directives"] = directives
+    return out
 
 
 def _add_undirected_edge(adj: dict[str, set[str]], a: str, b: str) -> None:

--- a/fypa/rail_groups.py
+++ b/fypa/rail_groups.py
@@ -456,6 +456,36 @@ def flatten_rail_tree(
     return rows
 
 
+def find_rail_tree_node(
+    root: RailTreeNode | None,
+    net: str,
+) -> RailTreeNode | None:
+    """Return the node named ``net`` in ``root``, or ``None``."""
+    if root is None:
+        return None
+    if root.name == net:
+        return root
+    for child in root.children:
+        found = find_rail_tree_node(child, net)
+        if found is not None:
+            return found
+    return None
+
+
+def subtree_net_names(
+    root: RailTreeNode | None,
+    net: str,
+) -> list[str]:
+    """DFS preorder names for ``net`` and all SERIES descendants.
+
+    Empty list when ``net`` is not in ``root``. A leaf returns ``[net]``.
+    """
+    node = find_rail_tree_node(root, net)
+    if node is None:
+        return []
+    return [name for name, _depth in flatten_rail_tree(node, depth=1)]
+
+
 def resolve_rail_member_nets(
     rail_names: list[str],
     rail_to_members: dict[str, list[str]],

--- a/fypa/rail_groups.py
+++ b/fypa/rail_groups.py
@@ -169,6 +169,41 @@ def compute_rail_groups(
     return rail_names, rail_to_members
 
 
+TREE_DIRECTIVE_ROLES = frozenset({
+    "RESISTOR", "SOURCE", "SINK", "REGULATOR",
+})
+
+
+def filter_directives_for_rail_trees(
+    directives: list[dict] | None,
+) -> list[dict]:
+    """Keep directives that contribute SERIES or alias edges for rail trees."""
+    return [
+        d for d in (directives or [])
+        if d.get("role") in TREE_DIRECTIVE_ROLES
+    ]
+
+
+def resistor_bridge_pairs(directive: dict) -> list[frozenset[str]]:
+    """All undirected pin-net pairs from a RESISTOR's two terminals."""
+    if directive.get("role") != "RESISTOR":
+        return []
+    terms = directive.get("terminals") or {}
+    nets_per_term: list[set[str]] = []
+    for t in terms.values():
+        nets = {p.get("net") for p in t.get("pins", []) if p.get("net")}
+        if nets:
+            nets_per_term.append(nets)
+    if len(nets_per_term) != 2:
+        return []
+    pairs: list[frozenset[str]] = []
+    for a in nets_per_term[0]:
+        for b in nets_per_term[1]:
+            if a and b and a != b:
+                pairs.append(frozenset((a, b)))
+    return pairs
+
+
 def _add_undirected_edge(adj: dict[str, set[str]], a: str, b: str) -> None:
     if not a or not b or a == b:
         return
@@ -314,6 +349,11 @@ def build_rail_trees(
     ``rail_to_members`` stays the flat membership used for copper / eyes;
     this returns the nested display shape only. Rails with a single member
     yield a leaf root. Missing or empty input yields ``{}``.
+
+    Members listed under a primary but with no SERIES/alias path to that
+    primary are attached as BFS subtrees under the primary (orphan
+    components), so callers may pass an explicit membership map to exercise
+    that path without going through :func:`compute_rail_groups`.
     """
     if not rail_to_members:
         return {}

--- a/scripts/test-combined.example.json
+++ b/scripts/test-combined.example.json
@@ -1,0 +1,9 @@
+{
+  "baseBranch": "main",
+  "testBranch": "test/combined",
+  "deleteTestBranchFirst": true,
+  "extraFeatureBranches": [
+    "feature/example-a",
+    "fix/example-b"
+  ]
+}

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -10,6 +10,7 @@
 #   pwsh scripts/test-combined.ps1
 #   pwsh scripts/test-combined.ps1 --local-only
 #   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
+#   pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
 #
 # By default baseBranch and extraFeatureBranches are fetched from origin and merged
 # via origin/<branch>. Pass --local-only to use local branches only.
@@ -30,7 +31,8 @@ param(
     [string] $BaseBranch,
     [string] $TestBranch,
     [string[]] $ExtraFeatureBranches,
-    [bool] $DeleteTestBranchFirst
+    [bool] $DeleteTestBranchFirst,
+    [string] $PrjPcb
 )
 
 $ErrorActionPreference = "Stop"
@@ -341,6 +343,14 @@ else {
     $false
 }
 
+$PrjPcbPath = $null
+if ($PrjPcb) {
+    if (-not (Test-Path -LiteralPath $PrjPcb)) {
+        throw "PrjPcb not found: $PrjPcb"
+    }
+    $PrjPcbPath = (Resolve-Path -LiteralPath $PrjPcb).Path
+}
+
 if (-not $BaseBranch) { throw "baseBranch is empty." }
 if (-not $TestBranch) { throw "testBranch is empty." }
 
@@ -434,7 +444,13 @@ try {
     }
 
     Write-Host "==> uv run FYPA.py"
-    & uv run --extra spacemouse FYPA.py
+    if ($PrjPcbPath) {
+        Write-Host "    Project: $PrjPcbPath"
+        & uv run --extra spacemouse FYPA.py gui $PrjPcbPath
+    }
+    else {
+        & uv run --extra spacemouse FYPA.py
+    }
     $FypaExit = $LASTEXITCODE
 }
 catch {

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -1,0 +1,463 @@
+# Build a local combined test branch from a base branch + feature branches, run tests/FYPA, then switch back.
+#
+# Config (first match wins):
+#   scripts/test-combined.json          local override (gitignored)
+#   team/test-combined.json             working tree
+#   team/local:team/test-combined.json  from team/local branch via git show (no checkout)
+#   scripts/test-combined.example.json  fallback
+#
+# Usage (from repo root, any branch):
+#   pwsh scripts/test-combined.ps1
+#   pwsh scripts/test-combined.ps1 --local-only
+#   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
+#
+# By default baseBranch and extraFeatureBranches are fetched from origin and merged
+# via origin/<branch>. Pass --local-only to use local branches only.
+#
+# Workflow:
+#   1. Remember current branch
+#   2. Optionally delete the test branch, then recreate it from the base branch
+#   3. Merge every extra feature branch (.gitignore conflicts auto-resolved with --ours)
+#   4. Run pytest topology suite, then uv run FYPA.py
+#   5. Return to the branch you started on (even if a step exits with an error)
+
+[CmdletBinding()]
+param(
+    [string] $ConfigPath,
+    [string] $TeamConfigRef = "team/local",
+    [string] $Remote = "origin",
+    [switch] $LocalOnly,
+    [string] $BaseBranch,
+    [string] $TestBranch,
+    [string[]] $ExtraFeatureBranches,
+    [bool] $DeleteTestBranchFirst
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+Set-Location $RepoRoot
+
+function Invoke-GitCore {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs,
+        [switch] $Quiet
+    )
+    if ($GitArgs.Count -eq 0) {
+        throw "Invoke-GitCore: no arguments"
+    }
+
+    $Output = @(& git.exe @GitArgs 2>&1)
+    $ExitCode = $LASTEXITCODE
+
+    if (-not $Quiet) {
+        foreach ($Line in $Output) {
+            if ($Line -is [System.Management.Automation.ErrorRecord]) {
+                Write-Warning $Line.ToString()
+            }
+            else {
+                Write-Host $Line
+            }
+        }
+    }
+
+    $Stdout = @(
+        $Output |
+            Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] } |
+            ForEach-Object { [string] $_ }
+    )
+
+    return @{
+        ExitCode = $ExitCode
+        Output   = $Stdout
+    }
+}
+
+function Invoke-Git {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs
+    )
+    $Result = Invoke-GitCore @GitArgs
+    if ($Result.ExitCode -ne 0) {
+        throw "git $($GitArgs -join ' ') failed (exit $($Result.ExitCode))"
+    }
+    return $Result.Output
+}
+
+function Invoke-GitSoft {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs
+    )
+    return (Invoke-GitCore @GitArgs).ExitCode
+}
+
+function Test-GitRef {
+    param([string] $Ref)
+    & git show-ref --verify --quiet $Ref
+    return $LASTEXITCODE -eq 0
+}
+
+function Get-BranchMergeRef {
+    param(
+        [string] $Branch,
+        [string] $RemoteName,
+        [bool] $UseLocalOnly
+    )
+
+    if ($UseLocalOnly) {
+        return $Branch
+    }
+    return "$RemoteName/$Branch"
+}
+
+function Test-BranchAvailable {
+    param(
+        [string] $Branch,
+        [string] $RemoteName,
+        [bool] $UseLocalOnly
+    )
+
+    if ($UseLocalOnly) {
+        return Test-GitRef "refs/heads/$Branch"
+    }
+    return Test-GitRef "refs/remotes/$RemoteName/$Branch"
+}
+
+function Sync-RemoteBranches {
+    param(
+        [string] $RemoteName,
+        [string[]] $Branches
+    )
+
+    $UniqueBranches = @($Branches | Where-Object { $_ } | Select-Object -Unique)
+    if ($UniqueBranches.Count -eq 0) {
+        return
+    }
+
+    Write-Host "==> Fetch $RemoteName $($UniqueBranches -join ', ')"
+    Invoke-Git @(@('fetch', $RemoteName) + $UniqueBranches)
+}
+
+function Test-MergeInProgress {
+    $MergeHead = & git.exe rev-parse -q --verify MERGE_HEAD 2>$null
+    return [bool] $MergeHead
+}
+
+function Get-UnmergedPaths {
+    $Output = & git.exe diff --name-only --diff-filter=U 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        return @()
+    }
+    return @($Output | Where-Object { $_ })
+}
+
+function Resolve-IgnoredMergeConflicts {
+    param(
+        [string[]] $IgnoredPaths,
+        [ValidateSet('ours', 'theirs')]
+        [string] $Prefer = 'ours'
+    )
+
+    foreach ($Path in (Get-UnmergedPaths)) {
+        if ($Path -in $IgnoredPaths) {
+            Write-Host "==> Auto-resolve merge conflict in $Path ($Prefer)"
+            Invoke-Git @('checkout', "--$Prefer", '--', $Path)
+            Invoke-Git @('add', '--', $Path)
+        }
+    }
+
+    return @(Get-UnmergedPaths)
+}
+
+function Merge-FeatureBranch {
+    param(
+        [string] $MergeRef,
+        [string] $ExtraBranch,
+        [string[]] $IgnoredPaths
+    )
+
+    $MergeMessage = "test: merge $ExtraBranch for local testing"
+    $ExitCode = Invoke-GitSoft @(
+        'merge', $MergeRef, '--no-edit', '-m', $MergeMessage
+    )
+    if ($ExitCode -eq 0) {
+        return
+    }
+
+    if (-not (Test-MergeInProgress)) {
+        throw "git merge $MergeRef failed (exit $ExitCode)"
+    }
+
+    $Remaining = Resolve-IgnoredMergeConflicts -IgnoredPaths $IgnoredPaths -Prefer 'ours'
+    if ($Remaining.Count -gt 0) {
+        throw "Merge conflict in: $($Remaining -join ', ')"
+    }
+
+    Invoke-Git @('commit', '--no-edit')
+}
+
+function Get-CurrentBranch {
+    return ([string] (Invoke-Git @('branch', '--show-current') | Select-Object -First 1)).Trim()
+}
+
+function Restore-DevBranch {
+    param([string] $Branch)
+    if ($Branch) {
+        Invoke-Git @('checkout', $Branch)
+    }
+}
+
+function Get-GitConfigJson {
+    param(
+        [string[]] $Refs,
+        [string] $RepoPath = "team/test-combined.json"
+    )
+
+    foreach ($Ref in $Refs) {
+        if (-not $Ref) { continue }
+        $Spec = "${Ref}:${RepoPath}"
+        $Json = & git show $Spec 2>$null
+        if ($LASTEXITCODE -eq 0 -and $Json) {
+            return @{ Source = $Spec; Json = [string] $Json }
+        }
+    }
+
+    return $null
+}
+
+function Resolve-ConfigSource {
+    param(
+        [string] $ExplicitPath,
+        [string] $TeamRef
+    )
+
+    if ($ExplicitPath) {
+        if (Test-Path $ExplicitPath) {
+            return @{
+                Source = (Resolve-Path $ExplicitPath).Path
+                Json   = $null
+            }
+        }
+        if ($ExplicitPath -match ':') {
+            $Json = & git show $ExplicitPath 2>$null
+            if ($LASTEXITCODE -eq 0 -and $Json) {
+                return @{ Source = $ExplicitPath; Json = [string] $Json }
+            }
+        }
+        throw "Config file not found: $ExplicitPath"
+    }
+
+    $LocalCandidates = @(
+        (Join-Path $RepoRoot "scripts/test-combined.json"),
+        (Join-Path $RepoRoot "team/test-combined.json")
+    )
+
+    foreach ($Candidate in $LocalCandidates) {
+        if (Test-Path $Candidate) {
+            return @{
+                Source = (Resolve-Path $Candidate).Path
+                Json   = $null
+            }
+        }
+    }
+
+    $GitRefs = @(
+        $TeamRef,
+        "origin/$TeamRef"
+    )
+    $FromGit = Get-GitConfigJson -Refs $GitRefs
+    if ($FromGit) {
+        return $FromGit
+    }
+
+    $Example = Join-Path $RepoRoot "scripts/test-combined.example.json"
+    if (Test-Path $Example) {
+        Write-Warning "Using example config ($Example). Copy to scripts/test-combined.json or update team/local."
+        return @{
+            Source = (Resolve-Path $Example).Path
+            Json   = $null
+        }
+    }
+
+    throw @"
+No test-combined config found.
+Fetch team/local (git fetch origin team/local) or create scripts/test-combined.json from scripts/test-combined.example.json.
+"@
+}
+
+function Read-TestCombinedConfig {
+    param(
+        [string] $Source,
+        [string] $Json
+    )
+
+    try {
+        if ($Json) {
+            $Config = $Json | ConvertFrom-Json
+        }
+        else {
+            $Config = Get-Content -Raw -Path $Source | ConvertFrom-Json
+        }
+    }
+    catch {
+        throw "Failed to parse config JSON at '$Source': $_"
+    }
+
+    foreach ($Required in @("baseBranch", "testBranch", "extraFeatureBranches")) {
+        if (-not ($Config.PSObject.Properties.Name -contains $Required)) {
+            throw "Config '$Source' is missing required field '$Required'."
+        }
+    }
+
+    return $Config
+}
+
+if (-not (Test-Path "FYPA.py")) {
+    throw "FYPA.py not found in $RepoRoot — run this script from the FYPA repo."
+}
+
+$ConfigSource = Resolve-ConfigSource -ExplicitPath $ConfigPath -TeamRef $TeamConfigRef
+Write-Host "==> Config: $($ConfigSource.Source)"
+$Config = Read-TestCombinedConfig -Source $ConfigSource.Source -Json $ConfigSource.Json
+
+$BaseBranch = if ($PSBoundParameters.ContainsKey("BaseBranch")) { $BaseBranch } else { [string] $Config.baseBranch }
+$TestBranch = if ($PSBoundParameters.ContainsKey("TestBranch")) { $TestBranch } else { [string] $Config.testBranch }
+$ExtraFeatureBranches = if ($PSBoundParameters.ContainsKey("ExtraFeatureBranches")) {
+    $ExtraFeatureBranches
+}
+else {
+    @($Config.extraFeatureBranches | ForEach-Object { [string] $_ })
+}
+$DeleteTestBranchFirst = if ($PSBoundParameters.ContainsKey("DeleteTestBranchFirst")) {
+    $DeleteTestBranchFirst
+}
+elseif ($Config.PSObject.Properties.Name -contains "deleteTestBranchFirst") {
+    [bool] $Config.deleteTestBranchFirst
+}
+else {
+    $false
+}
+
+if (-not $BaseBranch) { throw "baseBranch is empty." }
+if (-not $TestBranch) { throw "testBranch is empty." }
+
+$UseLocalOnly = [bool] $LocalOnly
+if ($UseLocalOnly) {
+    Write-Host "==> Branch source: local only"
+}
+else {
+    Write-Host "==> Branch source: $Remote (fetch + merge remote-tracking refs)"
+}
+
+$ReturnBranch = Get-CurrentBranch
+if (-not $ReturnBranch) {
+    throw "Could not determine the current branch."
+}
+
+if ($UseLocalOnly) {
+    if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $true)) {
+        throw "Base branch '$BaseBranch' not found locally."
+    }
+}
+else {
+    Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
+    if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $false)) {
+        throw "Remote branch '$Remote/$BaseBranch' not found after fetch."
+    }
+}
+
+$BaseRef = Get-BranchMergeRef -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+
+$IgnoredPaths = @('.gitignore', 'FYPA.code-workspace')
+$Status = @(Invoke-Git @('status', '--porcelain'))
+$BlockingStatus = @($Status | Where-Object {
+    $path = $_.Substring(3).Trim()
+    if ($path -match ' -> ') { $path = ($path -split ' -> ', 2)[-1].Trim() }
+    elseif ($path -match "`t") { $path = ($path -split "`t", 2)[-1].Trim() }
+    $path -notin $IgnoredPaths
+})
+if ($BlockingStatus.Count -gt 0) {
+    throw @"
+Uncommitted changes detected on '$ReturnBranch'.
+Commit or stash them before running the test script.
+"@
+}
+
+$Returned = $false
+$FypaExit = 0
+try {
+    if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
+        Write-Host "==> Delete $TestBranch"
+        if (Get-CurrentBranch -eq $TestBranch) {
+            Invoke-Git @('checkout', $ReturnBranch)
+        }
+        Invoke-Git @('branch', '-D', $TestBranch)
+    }
+
+    if (Test-GitRef "refs/heads/$TestBranch") {
+        Write-Host "==> Recreate $TestBranch from $BaseRef"
+        Invoke-Git @('branch', '-f', $TestBranch, $BaseRef)
+        Invoke-Git @('checkout', $TestBranch)
+    }
+    else {
+        Write-Host "==> Create $TestBranch from $BaseRef"
+        Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
+    }
+
+    foreach ($ExtraBranch in $ExtraFeatureBranches) {
+        if (-not $ExtraBranch) { continue }
+
+        $MergeRef = Get-BranchMergeRef -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+        if (Test-BranchAvailable -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly) {
+            Write-Host "==> Merge $MergeRef into $TestBranch"
+            Merge-FeatureBranch -MergeRef $MergeRef -ExtraBranch $ExtraBranch -IgnoredPaths $IgnoredPaths
+        }
+        else {
+            $Label = if ($UseLocalOnly) { "local branch" } else { "remote branch" }
+            Write-Warning "Extra feature $Label '$ExtraBranch' not found — continuing without it."
+        }
+    }
+
+    Write-Host "==> pytest topology tests"
+    & uv run python -m pytest `
+        tests/test_topology_invariants.py `
+        tests/test_topology_regressions.py `
+        tests/test_topology_layout.py `
+        tests/test_topology_geometry.py `
+        tests/test_topology_labels.py `
+        tests/test_pdn_topology.py -q
+    if ($LASTEXITCODE -ne 0) {
+        throw "pytest failed (exit $LASTEXITCODE)"
+    }
+
+    Write-Host "==> uv run FYPA.py"
+    & uv run --extra spacemouse FYPA.py
+    $FypaExit = $LASTEXITCODE
+}
+catch {
+    if (Get-CurrentBranch -ne $ReturnBranch) {
+        & git merge --abort 2>$null | Out-Null
+        & git rebase --abort 2>$null | Out-Null
+    }
+    throw
+}
+finally {
+    $Current = Get-CurrentBranch
+    if ($Current -ne $ReturnBranch) {
+        Write-Host "==> Return to $ReturnBranch"
+        Restore-DevBranch -Branch $ReturnBranch
+        $Returned = $true
+    }
+}
+
+if (-not $Returned) {
+    Write-Host "==> Return to $ReturnBranch"
+    Restore-DevBranch -Branch $ReturnBranch
+}
+
+if ($FypaExit -and $FypaExit -ne 0) {
+    exit $FypaExit
+}

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -1,36 +1,112 @@
-# Build a local combined test branch from a base branch + feature branches, run tests/FYPA, then switch back.
-#
-# Config (first match wins):
-#   scripts/test-combined.json          local override (gitignored)
-#   team/test-combined.json             working tree
-#   team/local:team/test-combined.json  from team/local branch via git show (no checkout)
-#   scripts/test-combined.example.json  fallback
-#
-# Usage (from repo root, any branch):
-#   pwsh scripts/test-combined.ps1
-#   pwsh scripts/test-combined.ps1 -LocalOnly
-#   pwsh scripts/test-combined.ps1 -Rebuild
-#   pwsh scripts/test-combined.ps1 -SkipTests
-#   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
-#   pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
-#
-# By default baseBranch and extraFeatureBranches are soft-fetched from origin.
-# Each input is resolved to the tip that includes local work: if the local branch
-# is ahead of (or diverged from) origin/<branch>, the local tip is merged; if
-# local is behind, origin/<branch> is used; local-only or remote-only branches
-# are accepted either way. If fetch fails (offline), existing refs are resolved
-# the same way. When input SHAs match the stamp on an existing test branch, that
-# branch is reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
-# Pass -LocalOnly to skip fetch and use local branches only.
-#
-# Workflow:
-#   1. Remember current branch
-#   2. Soft-fetch inputs (or local-only); resolve tips (prefer local when ahead);
-#      reuse test branch if stamp matches
-#   3. Otherwise optionally delete, recreate from base, merge feature branches
-#      (.gitignore conflicts auto-resolved with --ours); write stamp note
-#   4. Optionally run pytest topology suite (-SkipTests to skip), then uv run FYPA.py
-#   5. Return to the branch you started on (even if a step exits with an error)
+<#
+.SYNOPSIS
+    Build a local combined test branch, run tests/FYPA, then switch back.
+
+.DESCRIPTION
+    Merges a base branch plus feature branches into a disposable test branch,
+    optionally runs the pytest topology suite and FYPA.py, then returns to the
+    branch you started on (even if a step exits with an error).
+
+    Config resolution (first match wins):
+      scripts/test-combined.json          local override (gitignored)
+      team/test-combined.json             working tree
+      team/local:team/test-combined.json  from team/local via git show (no checkout)
+      scripts/test-combined.example.json  fallback
+
+    By default baseBranch and extraFeatureBranches are soft-fetched from origin.
+    Each input is resolved to the tip that includes local work: if the local
+    branch is ahead of (or diverged from) origin/<branch>, the local tip is
+    merged; if local is behind, origin/<branch> is used; local-only or
+    remote-only branches are accepted either way. If fetch fails (offline),
+    existing refs are resolved the same way.
+
+    When input SHAs match the stamp on an existing test branch, that branch is
+    reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
+    Pass -LocalOnly to skip fetch and use local branches only.
+
+    Workflow:
+      1. Remember current branch
+      2. Soft-fetch inputs (or local-only); resolve tips (prefer local when ahead);
+         reuse test branch if stamp matches
+      3. Otherwise optionally delete, recreate from base, merge feature branches
+         (.gitignore conflicts auto-resolved with --ours); write stamp note
+      4. Optionally run pytest topology suite (-SkipTests to skip), then uv run FYPA.py
+      5. Return to the starting branch
+
+.PARAMETER ConfigPath
+    Path to a JSON config file. Overrides the default config search order.
+
+.PARAMETER TeamConfigRef
+    Git ref used when reading team/test-combined.json via git show.
+    Default: team/local
+
+.PARAMETER Remote
+    Remote name used for soft-fetch and tip resolution. Default: origin
+
+.PARAMETER LocalOnly
+    Skip fetch; resolve and merge local branches only.
+
+.PARAMETER Rebuild
+    Force delete/recreate of the test branch even when the stamp matches.
+
+.PARAMETER SkipTests
+    Skip the pytest topology suite; still runs FYPA.py unless the script exits earlier.
+
+.PARAMETER BaseBranch
+    Override config baseBranch (branch the test branch is created from).
+
+.PARAMETER TestBranch
+    Override config testBranch (name of the disposable combined branch).
+
+.PARAMETER ExtraFeatureBranches
+    Override config extraFeatureBranches (branches merged onto the base).
+
+.PARAMETER DeleteTestBranchFirst
+    Override config deleteTestBranchFirst. When true, delete the existing test
+    branch before recreating it.
+
+.PARAMETER PrjPcb
+    Path to a .PrjPcb passed through to FYPA.py.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1
+
+    Use default config resolution, soft-fetch, reuse or rebuild the test branch,
+    run tests and FYPA, then switch back.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1 -LocalOnly
+
+    Skip remote fetch; use local branch tips only.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1 -Rebuild
+
+    Force a clean recreate of the test branch.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1 -SkipTests
+
+    Build/reuse the test branch and run FYPA without pytest.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
+
+    Use an explicit local config file.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
+
+    Pass a project file through to FYPA.py.
+
+.EXAMPLE
+    Get-Help .\scripts\test-combined.ps1 -Full
+
+    Show this help. Equivalent: pwsh scripts/test-combined.ps1 -?
+
+.NOTES
+    Run from the repo root (or any branch); the script cds to the repo root itself.
+#>
 
 [CmdletBinding()]
 param(

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -9,17 +9,23 @@
 # Usage (from repo root, any branch):
 #   pwsh scripts/test-combined.ps1
 #   pwsh scripts/test-combined.ps1 --local-only
+#   pwsh scripts/test-combined.ps1 -Rebuild
+#   pwsh scripts/test-combined.ps1 -SkipTests
 #   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
 #   pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
 #
-# By default baseBranch and extraFeatureBranches are fetched from origin and merged
-# via origin/<branch>. Pass --local-only to use local branches only.
+# By default baseBranch and extraFeatureBranches are soft-fetched from origin and
+# merged via origin/<branch>. If fetch fails (offline), local refs are used.
+# When input SHAs match the stamp on an existing test branch, that branch is
+# reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
+# Pass --local-only to skip fetch and use local branches only.
 #
 # Workflow:
 #   1. Remember current branch
-#   2. Optionally delete the test branch, then recreate it from the base branch
-#   3. Merge every extra feature branch (.gitignore conflicts auto-resolved with --ours)
-#   4. Run pytest topology suite, then uv run FYPA.py
+#   2. Soft-fetch inputs (or local-only); reuse test branch if stamp matches
+#   3. Otherwise optionally delete, recreate from base, merge feature branches
+#      (.gitignore conflicts auto-resolved with --ours); write stamp note
+#   4. Optionally run pytest topology suite (-SkipTests to skip), then uv run FYPA.py
 #   5. Return to the branch you started on (even if a step exits with an error)
 
 [CmdletBinding()]
@@ -28,6 +34,8 @@ param(
     [string] $TeamConfigRef = "team/local",
     [string] $Remote = "origin",
     [switch] $LocalOnly,
+    [switch] $Rebuild,
+    [switch] $SkipTests,
     [string] $BaseBranch,
     [string] $TestBranch,
     [string[]] $ExtraFeatureBranches,
@@ -140,7 +148,78 @@ function Sync-RemoteBranches {
     }
 
     Write-Host "==> Fetch $RemoteName $($UniqueBranches -join ', ')"
-    Invoke-Git @(@('fetch', $RemoteName) + $UniqueBranches)
+    # git writes progress to stderr; don't surface it as PowerShell warnings.
+    $Result = Invoke-GitCore -Quiet @(@('fetch', $RemoteName) + $UniqueBranches)
+    if ($Result.ExitCode -ne 0) {
+        $Detail = ($Result.Output -join "`n").Trim()
+        if ($Detail) {
+            throw "git fetch $RemoteName failed (exit $($Result.ExitCode)): $Detail"
+        }
+        throw "git fetch $RemoteName failed (exit $($Result.ExitCode))"
+    }
+}
+
+function Get-RefSha {
+    param([string] $Ref)
+    $Sha = ([string] (& git.exe rev-parse --verify "$Ref^{commit}" 2>$null)).Trim()
+    if ($LASTEXITCODE -ne 0 -or -not $Sha) {
+        return $null
+    }
+    return $Sha
+}
+
+function Get-InputStamp {
+    param(
+        [string] $ConfigIdentity,
+        [string] $BaseName,
+        [string] $BaseSha,
+        [string[]] $ExtraPairs
+    )
+
+    # Single-line stamp: PowerShell [string] casts of multi-line git output join
+    # with spaces and would break equality checks if we used newlines.
+    $Parts = [System.Collections.Generic.List[string]]::new()
+    $Parts.Add("config=$ConfigIdentity")
+    $Parts.Add("base=$BaseName=$BaseSha")
+    foreach ($Pair in $ExtraPairs) {
+        if ($Pair) { $Parts.Add("extra=$Pair") }
+    }
+    return ($Parts -join '|')
+}
+
+function Get-TestCombinedStamp {
+    param([string] $Commit)
+    if (-not $Commit) { return $null }
+    $Lines = @(& git.exe notes --ref=test-combined show $Commit 2>$null)
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+    # Join exactly as written; Trim only outer whitespace.
+    return (($Lines -join "`n").Trim())
+}
+
+function Set-TestCombinedStamp {
+    param(
+        [string] $Commit,
+        [string] $Stamp
+    )
+    $ExitCode = Invoke-GitSoft @(
+        'notes', '--ref=test-combined', 'add', '-f', '-m', $Stamp, $Commit
+    )
+    if ($ExitCode -ne 0) {
+        Write-Warning "Could not write test-combined stamp note on $Commit"
+    }
+}
+
+function ConvertTo-NormalizedStamp {
+    param([string] $Stamp)
+    if (-not $Stamp) { return $null }
+    # Accept legacy multiline notes (joined with `n) and new single-line (`|`) form.
+    $Normalized = $Stamp.Trim() -replace "`r`n", "`n" -replace "`r", "`n"
+    if ($Normalized.Contains("`n")) {
+        $Normalized = (($Normalized -split "`n") | ForEach-Object { $_.Trim() } | Where-Object { $_ }) -join '|'
+    }
+    return $Normalized
 }
 
 function Test-MergeInProgress {
@@ -359,7 +438,7 @@ if ($UseLocalOnly) {
     Write-Host "==> Branch source: local only"
 }
 else {
-    Write-Host "==> Branch source: $Remote (fetch + merge remote-tracking refs)"
+    Write-Host "==> Branch source: $Remote (soft-fetch + merge remote-tracking refs)"
 }
 
 $ReturnBranch = Get-CurrentBranch
@@ -373,13 +452,87 @@ if ($UseLocalOnly) {
     }
 }
 else {
-    Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
-    if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $false)) {
-        throw "Remote branch '$Remote/$BaseBranch' not found after fetch."
+    try {
+        Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
+        if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $false)) {
+            throw "Remote branch '$Remote/$BaseBranch' not found after fetch."
+        }
+    }
+    catch {
+        Write-Warning "Fetch from $Remote failed or remote base missing; falling back to local refs."
+        Write-Warning "$_"
+        $UseLocalOnly = $true
+        if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $true)) {
+            throw "Base branch '$BaseBranch' not found locally after soft-fetch fallback."
+        }
+        Write-Host "==> Branch source: local only (fallback)"
     }
 }
 
 $BaseRef = Get-BranchMergeRef -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+$BaseSha = Get-RefSha -Ref $BaseRef
+if (-not $BaseSha) {
+    throw "Could not resolve SHA for base ref '$BaseRef'."
+}
+
+$ExtraStampPairs = [System.Collections.Generic.List[string]]::new()
+$ResolvedExtras = [System.Collections.Generic.List[hashtable]]::new()
+foreach ($ExtraBranch in $ExtraFeatureBranches) {
+    if (-not $ExtraBranch) { continue }
+    $MergeRef = Get-BranchMergeRef -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+    if (Test-BranchAvailable -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly) {
+        $ExtraSha = Get-RefSha -Ref $MergeRef
+        if (-not $ExtraSha) {
+            Write-Warning "Could not resolve SHA for '$MergeRef' — continuing without it."
+            continue
+        }
+        $ExtraStampPairs.Add("$ExtraBranch=$ExtraSha")
+        $ResolvedExtras.Add(@{
+            Branch   = $ExtraBranch
+            MergeRef = $MergeRef
+        })
+    }
+    else {
+        $Label = if ($UseLocalOnly) { "local branch" } else { "remote branch" }
+        Write-Warning "Extra feature $Label '$ExtraBranch' not found — continuing without it."
+    }
+}
+
+$ConfigIdentity = @(
+    "base=$BaseBranch",
+    "test=$TestBranch",
+    "deleteFirst=$DeleteTestBranchFirst",
+    "extras=$($ExtraFeatureBranches -join ',')"
+) -join ';'
+
+$DesiredStamp = ConvertTo-NormalizedStamp (Get-InputStamp `
+    -ConfigIdentity $ConfigIdentity `
+    -BaseName $BaseBranch `
+    -BaseSha $BaseSha `
+    -ExtraPairs @($ExtraStampPairs))
+
+$TestBranchExists = Test-GitRef "refs/heads/$TestBranch"
+$ExistingTip = if ($TestBranchExists) { Get-RefSha -Ref $TestBranch } else { $null }
+$ExistingStampRaw = $null
+if ($ExistingTip) {
+    $ExistingStampRaw = Get-TestCombinedStamp -Commit $ExistingTip
+}
+$ExistingStamp = ConvertTo-NormalizedStamp $ExistingStampRaw
+$CanReuse = (
+    -not $Rebuild -and
+    $TestBranchExists -and
+    $ExistingStamp -and
+    ($ExistingStamp -eq $DesiredStamp)
+)
+
+if (-not $CanReuse -and $TestBranchExists -and -not $Rebuild) {
+    if (-not $ExistingStamp) {
+        Write-Host "==> No reuse stamp on $TestBranch — will rebuild"
+    }
+    else {
+        Write-Host "==> Stamp mismatch on $TestBranch — will rebuild"
+    }
+}
 
 $IgnoredPaths = @('.gitignore', 'FYPA.code-workspace')
 $Status = @(Invoke-Git @('status', '--porcelain'))
@@ -399,48 +552,68 @@ Commit or stash them before running the test script.
 $Returned = $false
 $FypaExit = 0
 try {
-    if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
-        Write-Host "==> Delete $TestBranch"
-        if (Get-CurrentBranch -eq $TestBranch) {
-            Invoke-Git @('checkout', $ReturnBranch)
+    if ($CanReuse) {
+        Write-Host "==> Reuse $TestBranch (inputs unchanged)"
+        if ((Get-CurrentBranch) -ne $TestBranch) {
+            Invoke-Git @('checkout', $TestBranch)
         }
-        Invoke-Git @('branch', '-D', $TestBranch)
-    }
-
-    if (Test-GitRef "refs/heads/$TestBranch") {
-        Write-Host "==> Recreate $TestBranch from $BaseRef"
-        Invoke-Git @('branch', '-f', $TestBranch, $BaseRef)
-        Invoke-Git @('checkout', $TestBranch)
     }
     else {
-        Write-Host "==> Create $TestBranch from $BaseRef"
-        Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
-    }
-
-    foreach ($ExtraBranch in $ExtraFeatureBranches) {
-        if (-not $ExtraBranch) { continue }
-
-        $MergeRef = Get-BranchMergeRef -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
-        if (Test-BranchAvailable -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly) {
-            Write-Host "==> Merge $MergeRef into $TestBranch"
-            Merge-FeatureBranch -MergeRef $MergeRef -ExtraBranch $ExtraBranch -IgnoredPaths $IgnoredPaths
+        if ($Rebuild) {
+            Write-Host "==> Rebuild requested — recreating $TestBranch"
+        }
+        elseif (-not $TestBranchExists) {
+            Write-Host "==> $TestBranch missing — creating from $BaseRef"
         }
         else {
-            $Label = if ($UseLocalOnly) { "local branch" } else { "remote branch" }
-            Write-Warning "Extra feature $Label '$ExtraBranch' not found — continuing without it."
+            Write-Host "==> Inputs changed — recreating $TestBranch from $BaseRef"
+        }
+
+        if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
+            Write-Host "==> Delete $TestBranch"
+            if ((Get-CurrentBranch) -eq $TestBranch) {
+                Invoke-Git @('checkout', $ReturnBranch)
+            }
+            Invoke-Git @('branch', '-D', $TestBranch)
+        }
+
+        if (Test-GitRef "refs/heads/$TestBranch") {
+            Write-Host "==> Recreate $TestBranch from $BaseRef"
+            Invoke-Git @('branch', '-f', $TestBranch, $BaseRef)
+            Invoke-Git @('checkout', $TestBranch)
+        }
+        else {
+            Write-Host "==> Create $TestBranch from $BaseRef"
+            Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
+        }
+
+        foreach ($Extra in $ResolvedExtras) {
+            Write-Host "==> Merge $($Extra.MergeRef) into $TestBranch"
+            Merge-FeatureBranch -MergeRef $Extra.MergeRef -ExtraBranch $Extra.Branch -IgnoredPaths $IgnoredPaths
+        }
+
+        $NewTip = Get-RefSha -Ref 'HEAD'
+        if ($NewTip) {
+            Set-TestCombinedStamp -Commit $NewTip -Stamp $DesiredStamp
+            Write-Host "==> Stamp written for $TestBranch"
         }
     }
 
-    Write-Host "==> pytest topology tests"
-    & uv run python -m pytest `
-        tests/test_topology_invariants.py `
-        tests/test_topology_regressions.py `
-        tests/test_topology_layout.py `
-        tests/test_topology_geometry.py `
-        tests/test_topology_labels.py `
-        tests/test_pdn_topology.py -q
-    if ($LASTEXITCODE -ne 0) {
-        throw "pytest failed (exit $LASTEXITCODE)"
+    if ($SkipTests) {
+        Write-Host "==> Skip pytest (-SkipTests)"
+    }
+    else {
+        Write-Host "==> pytest topology tests"
+        & uv run python -m pytest `
+            tests/test_topology_invariants.py `
+            tests/test_topology_regressions.py `
+            tests/test_topology_layout.py `
+            tests/test_topology_geometry.py `
+            tests/test_topology_labels.py `
+            tests/test_pdn_topology.py -q
+        if ($LASTEXITCODE -ne 0) {
+            throw "pytest failed (exit $LASTEXITCODE)"
+        }
     }
 
     Write-Host "==> uv run FYPA.py"

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -8,7 +8,7 @@
 #
 # Usage (from repo root, any branch):
 #   pwsh scripts/test-combined.ps1
-#   pwsh scripts/test-combined.ps1 --local-only
+#   pwsh scripts/test-combined.ps1 -LocalOnly
 #   pwsh scripts/test-combined.ps1 -Rebuild
 #   pwsh scripts/test-combined.ps1 -SkipTests
 #   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
@@ -21,7 +21,7 @@
 # are accepted either way. If fetch fails (offline), existing refs are resolved
 # the same way. When input SHAs match the stamp on an existing test branch, that
 # branch is reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
-# Pass --local-only to skip fetch and use local branches only.
+# Pass -LocalOnly to skip fetch and use local branches only.
 #
 # Workflow:
 #   1. Remember current branch

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -14,15 +14,19 @@
 #   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
 #   pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
 #
-# By default baseBranch and extraFeatureBranches are soft-fetched from origin and
-# merged via origin/<branch>. If fetch fails (offline), local refs are used.
-# When input SHAs match the stamp on an existing test branch, that branch is
-# reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
+# By default baseBranch and extraFeatureBranches are soft-fetched from origin.
+# Each input is resolved to the tip that includes local work: if the local branch
+# is ahead of (or diverged from) origin/<branch>, the local tip is merged; if
+# local is behind, origin/<branch> is used; local-only or remote-only branches
+# are accepted either way. If fetch fails (offline), existing refs are resolved
+# the same way. When input SHAs match the stamp on an existing test branch, that
+# branch is reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
 # Pass --local-only to skip fetch and use local branches only.
 #
 # Workflow:
 #   1. Remember current branch
-#   2. Soft-fetch inputs (or local-only); reuse test branch if stamp matches
+#   2. Soft-fetch inputs (or local-only); resolve tips (prefer local when ahead);
+#      reuse test branch if stamp matches
 #   3. Otherwise optionally delete, recreate from base, merge feature branches
 #      (.gitignore conflicts auto-resolved with --ours); write stamp note
 #   4. Optionally run pytest topology suite (-SkipTests to skip), then uv run FYPA.py
@@ -110,30 +114,120 @@ function Test-GitRef {
     return $LASTEXITCODE -eq 0
 }
 
-function Get-BranchMergeRef {
+function Test-GitAncestor {
     param(
-        [string] $Branch,
-        [string] $RemoteName,
-        [bool] $UseLocalOnly
+        [string] $Ancestor,
+        [string] $Descendant
     )
-
-    if ($UseLocalOnly) {
-        return $Branch
-    }
-    return "$RemoteName/$Branch"
+    & git.exe merge-base --is-ancestor $Ancestor $Descendant 2>$null | Out-Null
+    return $LASTEXITCODE -eq 0
 }
 
-function Test-BranchAvailable {
+function Resolve-BranchMergeTarget {
     param(
         [string] $Branch,
         [string] $RemoteName,
         [bool] $UseLocalOnly
     )
 
+    $LocalRef = $Branch
+    $RemoteRef = "$RemoteName/$Branch"
+    $HasLocal = Test-GitRef "refs/heads/$Branch"
+    $HasRemote = Test-GitRef "refs/remotes/$RemoteName/$Branch"
+
     if ($UseLocalOnly) {
-        return Test-GitRef "refs/heads/$Branch"
+        if (-not $HasLocal) { return $null }
+        $Sha = Get-RefSha -Ref $LocalRef
+        if (-not $Sha) { return $null }
+        return @{
+            Branch   = $Branch
+            MergeRef = $LocalRef
+            Sha      = $Sha
+            Source   = 'local'
+        }
     }
-    return Test-GitRef "refs/remotes/$RemoteName/$Branch"
+
+    if ($HasLocal -and $HasRemote) {
+        $LocalSha = Get-RefSha -Ref $LocalRef
+        $RemoteSha = Get-RefSha -Ref $RemoteRef
+        if (-not $LocalSha -and -not $RemoteSha) { return $null }
+        if (-not $LocalSha) {
+            return @{
+                Branch   = $Branch
+                MergeRef = $RemoteRef
+                Sha      = $RemoteSha
+                Source   = 'remote'
+            }
+        }
+        if (-not $RemoteSha) {
+            return @{
+                Branch   = $Branch
+                MergeRef = $LocalRef
+                Sha      = $LocalSha
+                Source   = 'local'
+            }
+        }
+        if ($LocalSha -eq $RemoteSha) {
+            return @{
+                Branch   = $Branch
+                MergeRef = $LocalRef
+                Sha      = $LocalSha
+                Source   = 'local'
+            }
+        }
+        # Local contains remote → unpushed local commits; keep them.
+        if (Test-GitAncestor -Ancestor $RemoteSha -Descendant $LocalSha) {
+            Write-Host "==> ${Branch}: using local (ahead of $RemoteRef)"
+            return @{
+                Branch   = $Branch
+                MergeRef = $LocalRef
+                Sha      = $LocalSha
+                Source   = 'local'
+            }
+        }
+        # Remote contains local → local checkout is stale; take remote.
+        if (Test-GitAncestor -Ancestor $LocalSha -Descendant $RemoteSha) {
+            return @{
+                Branch   = $Branch
+                MergeRef = $RemoteRef
+                Sha      = $RemoteSha
+                Source   = 'remote'
+            }
+        }
+        # Diverged: never drop local work.
+        Write-Warning "${Branch}: local and $RemoteRef have diverged — using local tip"
+        return @{
+            Branch   = $Branch
+            MergeRef = $LocalRef
+            Sha      = $LocalSha
+            Source   = 'local'
+        }
+    }
+
+    if ($HasLocal) {
+        $Sha = Get-RefSha -Ref $LocalRef
+        if (-not $Sha) { return $null }
+        Write-Host "==> ${Branch}: no $RemoteRef — using local"
+        return @{
+            Branch   = $Branch
+            MergeRef = $LocalRef
+            Sha      = $Sha
+            Source   = 'local'
+        }
+    }
+
+    if ($HasRemote) {
+        $Sha = Get-RefSha -Ref $RemoteRef
+        if (-not $Sha) { return $null }
+        return @{
+            Branch   = $Branch
+            MergeRef = $RemoteRef
+            Sha      = $Sha
+            Source   = 'remote'
+        }
+    }
+
+    return $null
 }
 
 function Sync-RemoteBranches {
@@ -438,7 +532,7 @@ if ($UseLocalOnly) {
     Write-Host "==> Branch source: local only"
 }
 else {
-    Write-Host "==> Branch source: $Remote (soft-fetch + merge remote-tracking refs)"
+    Write-Host "==> Branch source: $Remote (soft-fetch; prefer local when ahead/diverged)"
 }
 
 $ReturnBranch = Get-CurrentBranch
@@ -446,56 +540,42 @@ if (-not $ReturnBranch) {
     throw "Could not determine the current branch."
 }
 
-if ($UseLocalOnly) {
-    if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $true)) {
-        throw "Base branch '$BaseBranch' not found locally."
-    }
-}
-else {
+if (-not $UseLocalOnly) {
     try {
         Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
-        if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $false)) {
-            throw "Remote branch '$Remote/$BaseBranch' not found after fetch."
-        }
     }
     catch {
-        Write-Warning "Fetch from $Remote failed or remote base missing; falling back to local refs."
+        Write-Warning "Fetch from $Remote failed; resolving from existing local/remote-tracking refs."
         Write-Warning "$_"
-        $UseLocalOnly = $true
-        if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $true)) {
-            throw "Base branch '$BaseBranch' not found locally after soft-fetch fallback."
-        }
-        Write-Host "==> Branch source: local only (fallback)"
     }
 }
 
-$BaseRef = Get-BranchMergeRef -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
-$BaseSha = Get-RefSha -Ref $BaseRef
-if (-not $BaseSha) {
-    throw "Could not resolve SHA for base ref '$BaseRef'."
+$BaseTarget = Resolve-BranchMergeTarget -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+if (-not $BaseTarget) {
+    $Where = if ($UseLocalOnly) { "locally" } else { "locally or as $Remote/$BaseBranch" }
+    throw "Base branch '$BaseBranch' not found $Where."
 }
+
+$BaseRef = $BaseTarget.MergeRef
+$BaseSha = $BaseTarget.Sha
+Write-Host "==> Base: $BaseRef ($($BaseTarget.Source))"
 
 $ExtraStampPairs = [System.Collections.Generic.List[string]]::new()
 $ResolvedExtras = [System.Collections.Generic.List[hashtable]]::new()
 foreach ($ExtraBranch in $ExtraFeatureBranches) {
     if (-not $ExtraBranch) { continue }
-    $MergeRef = Get-BranchMergeRef -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
-    if (Test-BranchAvailable -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly) {
-        $ExtraSha = Get-RefSha -Ref $MergeRef
-        if (-not $ExtraSha) {
-            Write-Warning "Could not resolve SHA for '$MergeRef' — continuing without it."
-            continue
-        }
-        $ExtraStampPairs.Add("$ExtraBranch=$ExtraSha")
-        $ResolvedExtras.Add(@{
-            Branch   = $ExtraBranch
-            MergeRef = $MergeRef
-        })
+    $ExtraTarget = Resolve-BranchMergeTarget -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+    if (-not $ExtraTarget) {
+        $Where = if ($UseLocalOnly) { "locally" } else { "locally or on $Remote" }
+        Write-Warning "Extra feature branch '$ExtraBranch' not found $Where — continuing without it."
+        continue
     }
-    else {
-        $Label = if ($UseLocalOnly) { "local branch" } else { "remote branch" }
-        Write-Warning "Extra feature $Label '$ExtraBranch' not found — continuing without it."
-    }
+    Write-Host "==> Extra: $($ExtraTarget.MergeRef) ($($ExtraTarget.Source))"
+    $ExtraStampPairs.Add("$ExtraBranch=$($ExtraTarget.Sha)")
+    $ResolvedExtras.Add(@{
+        Branch   = $ExtraTarget.Branch
+        MergeRef = $ExtraTarget.MergeRef
+    })
 }
 
 $ConfigIdentity = @(

--- a/tests/test_eye_button.py
+++ b/tests/test_eye_button.py
@@ -1,0 +1,89 @@
+"""EyeButton click / modifier / partial fallbacks (shared by layers + rails)."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtCore import Qt  # noqa: E402
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+from fypa.altium_viewer import EyeButton  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+def _click(eye: EyeButton, *, modifiers: Qt.KeyboardModifiers = Qt.NoModifier) -> None:
+    """Invoke the click handler with press-time modifiers already captured."""
+    eye._press_mods = modifiers
+    eye._on_clicked()
+
+
+def test_plain_click_toggles(qapp):
+    eye = EyeButton(visible=True)
+    seen: list[bool] = []
+    eye.toggled_visible.connect(seen.append)
+    _click(eye)
+    assert eye.isVisibleState() is False
+    assert seen == [False]
+
+
+def test_ctrl_without_receiver_falls_back_to_toggle(qapp):
+    eye = EyeButton(visible=True)
+    seen: list[bool] = []
+    eye.toggled_visible.connect(seen.append)
+    _click(eye, modifiers=Qt.ControlModifier)
+    assert eye.isVisibleState() is False
+    assert seen == [False]
+
+
+def test_ctrl_with_receiver_emits_ctrl_only(qapp):
+    eye = EyeButton(visible=True)
+    toggled: list[bool] = []
+    ctrls: list[int] = []
+    eye.toggled_visible.connect(toggled.append)
+    eye.ctrl_clicked.connect(lambda: ctrls.append(1))
+    _click(eye, modifiers=Qt.ControlModifier)
+    assert ctrls == [1]
+    assert toggled == []
+    assert eye.isVisibleState() is True  # unchanged
+
+
+def test_partial_without_receiver_emits_toggled_visible(qapp):
+    eye = EyeButton(visible=False)
+    eye.setVisibleState(False, partial=True, emit=False)
+    seen: list[bool] = []
+    eye.toggled_visible.connect(seen.append)
+    _click(eye)
+    assert eye.isVisibleState() is True
+    assert eye.isPartialState() is False
+    assert seen == [True]
+
+
+def test_partial_with_receiver_emits_partial_activated(qapp):
+    eye = EyeButton(visible=False)
+    eye.setVisibleState(False, partial=True, emit=False)
+    toggled: list[bool] = []
+    partials: list[int] = []
+    eye.toggled_visible.connect(toggled.append)
+    eye.partial_activated.connect(lambda: partials.append(1))
+    _click(eye)
+    assert partials == [1]
+    assert toggled == []
+    assert eye.isVisibleState() is True
+    assert eye.isPartialState() is False
+
+
+def test_partial_may_sit_on_off_eye(qapp):
+    eye = EyeButton(visible=False)
+    eye.setVisibleState(False, partial=True, emit=False)
+    assert eye.isVisibleState() is False
+    assert eye.isPartialState() is True

--- a/tests/test_rail_subnet_eye_handlers.py
+++ b/tests/test_rail_subnet_eye_handlers.py
@@ -1,0 +1,97 @@
+"""Subnet eye Ctrl/partial handlers (fan-out without full PdnViewer init)."""
+from __future__ import annotations
+
+import os
+import types
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+import fypa.altium_viewer as av  # noqa: E402
+from fypa.altium_viewer import EyeButton  # noqa: E402
+from fypa.rail_groups import RailTreeNode  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+def _eye(on: bool) -> EyeButton:
+    eye = EyeButton(visible=on)
+    eye.setVisibleState(on, emit=False)
+    return eye
+
+
+def _viewer_stub(tree: RailTreeNode, states: dict[str, bool]):
+    """Minimal stand-in with the attrs subnet fan-out handlers need."""
+    v = types.SimpleNamespace()
+    v._rail_to_trees = {"VIN": tree}
+    v._subnet_eye_buttons = {
+        "VIN": {name: _eye(on) for name, on in states.items()},
+    }
+    v._refreshed: list[str] = []
+    v._refresh_rail_visibility_after_subnet_change = (
+        lambda rail: v._refreshed.append(rail)
+    )
+    # Bind real helpers so handlers can call them as instance methods.
+    v._subnet_tree_for_rail = (
+        lambda rail, _v=v: av.PdnViewer._subnet_tree_for_rail(_v, rail)
+    )
+    v._fan_out_subnet_subtree = (
+        lambda rail, net, on, _v=v: av.PdnViewer._fan_out_subnet_subtree(
+            _v, rail, net, on,
+        )
+    )
+    return v
+
+
+_TREE = RailTreeNode(
+    name="VIN",
+    children=(
+        RailTreeNode(name="A"),
+        RailTreeNode(name="B"),
+    ),
+)
+
+
+def test_ctrl_click_mixed_turns_subtree_on(qapp):
+    v = _viewer_stub(_TREE, {"VIN": True, "A": True, "B": False})
+    av.PdnViewer._on_subnet_eye_ctrl_clicked(v, "VIN", "VIN")
+    eyes = v._subnet_eye_buttons["VIN"]
+    assert all(e.isVisibleState() for e in eyes.values())
+    assert v._refreshed == ["VIN"]
+
+
+def test_ctrl_click_all_on_turns_subtree_off(qapp):
+    v = _viewer_stub(_TREE, {"VIN": True, "A": True, "B": True})
+    av.PdnViewer._on_subnet_eye_ctrl_clicked(v, "VIN", "VIN")
+    eyes = v._subnet_eye_buttons["VIN"]
+    assert all(not e.isVisibleState() for e in eyes.values())
+    assert v._refreshed == ["VIN"]
+
+
+def test_partial_activated_fans_out_children(qapp):
+    v = _viewer_stub(_TREE, {"VIN": False, "A": True, "B": False})
+    eye = v._subnet_eye_buttons["VIN"]["VIN"]
+    eye.setVisibleState(False, partial=True, emit=False)
+    av.PdnViewer._on_subnet_eye_partial_activated(v, "VIN", "VIN")
+    eyes = v._subnet_eye_buttons["VIN"]
+    assert all(e.isVisibleState() for e in eyes.values())
+    assert all(not e.isPartialState() for e in eyes.values())
+    assert v._refreshed == ["VIN"]
+
+
+def test_partial_activated_leaf_only_turns_self_on(qapp):
+    v = _viewer_stub(_TREE, {"VIN": False, "A": False, "B": False})
+    av.PdnViewer._on_subnet_eye_partial_activated(v, "VIN", "A")
+    eyes = v._subnet_eye_buttons["VIN"]
+    assert eyes["A"].isVisibleState() is True
+    assert eyes["VIN"].isVisibleState() is False
+    assert eyes["B"].isVisibleState() is False

--- a/tests/test_rail_subnet_eye_handlers.py
+++ b/tests/test_rail_subnet_eye_handlers.py
@@ -36,11 +36,14 @@ def _viewer_stub(tree: RailTreeNode, states: dict[str, bool]):
     v._subnet_eye_buttons = {
         "VIN": {name: _eye(on) for name, on in states.items()},
     }
-    v._refreshed: list[str] = []
-    v._refresh_rail_visibility_after_subnet_change = (
-        lambda rail: v._refreshed.append(rail)
-    )
-    # Bind real helpers so handlers can call them as instance methods.
+    v._refreshed = []
+
+    def _refresh(rail: str) -> None:
+        # Real post-fan-out partial sync; skip render / rail-list sync.
+        av.PdnViewer._sync_rail_tree_node_partials(v, rail)
+        v._refreshed.append(rail)
+
+    v._refresh_rail_visibility_after_subnet_change = _refresh
     v._subnet_tree_for_rail = (
         lambda rail, _v=v: av.PdnViewer._subnet_tree_for_rail(_v, rail)
     )
@@ -66,6 +69,7 @@ def test_ctrl_click_mixed_turns_subtree_on(qapp):
     av.PdnViewer._on_subnet_eye_ctrl_clicked(v, "VIN", "VIN")
     eyes = v._subnet_eye_buttons["VIN"]
     assert all(e.isVisibleState() for e in eyes.values())
+    assert all(not e.isPartialState() for e in eyes.values())
     assert v._refreshed == ["VIN"]
 
 
@@ -74,6 +78,7 @@ def test_ctrl_click_all_on_turns_subtree_off(qapp):
     av.PdnViewer._on_subnet_eye_ctrl_clicked(v, "VIN", "VIN")
     eyes = v._subnet_eye_buttons["VIN"]
     assert all(not e.isVisibleState() for e in eyes.values())
+    assert all(not e.isPartialState() for e in eyes.values())
     assert v._refreshed == ["VIN"]
 
 
@@ -95,3 +100,23 @@ def test_partial_activated_leaf_only_turns_self_on(qapp):
     assert eyes["A"].isVisibleState() is True
     assert eyes["VIN"].isVisibleState() is False
     assert eyes["B"].isVisibleState() is False
+    # Parent off + one child on → intermediate partial after sync.
+    assert eyes["VIN"].isPartialState() is True
+    assert eyes["A"].isPartialState() is False
+
+
+def test_sync_parent_off_all_children_on_is_partial(qapp):
+    v = _viewer_stub(_TREE, {"VIN": False, "A": True, "B": True})
+    av.PdnViewer._sync_rail_tree_node_partials(v, "VIN")
+    eyes = v._subnet_eye_buttons["VIN"]
+    assert eyes["VIN"].isVisibleState() is False
+    assert eyes["VIN"].isPartialState() is True
+    assert eyes["A"].isPartialState() is False
+
+
+def test_sync_parent_on_all_children_off_is_not_partial(qapp):
+    v = _viewer_stub(_TREE, {"VIN": True, "A": False, "B": False})
+    av.PdnViewer._sync_rail_tree_node_partials(v, "VIN")
+    eyes = v._subnet_eye_buttons["VIN"]
+    assert eyes["VIN"].isVisibleState() is True
+    assert eyes["VIN"].isPartialState() is False

--- a/tests/test_rail_trees.py
+++ b/tests/test_rail_trees.py
@@ -376,3 +376,24 @@ def test_visible_rail_tree_rows_flat_fallback():
 def test_build_rail_trees_empty_input():
     assert build_rail_trees(None, {}) == {}
     assert build_rail_trees({"directives": []}, {}) == {}
+
+
+def test_subtree_net_names_includes_descendants():
+    from fypa.rail_groups import find_rail_tree_node, subtree_net_names
+
+    tree = RailTreeNode(
+        name="A",
+        children=(
+            RailTreeNode(
+                name="A.1",
+                children=(RailTreeNode(name="A.1.1"),),
+            ),
+            RailTreeNode(name="A.2"),
+        ),
+    )
+    assert subtree_net_names(tree, "A") == ["A", "A.1", "A.1.1", "A.2"]
+    assert subtree_net_names(tree, "A.1") == ["A.1", "A.1.1"]
+    assert subtree_net_names(tree, "A.1.1") == ["A.1.1"]
+    assert subtree_net_names(tree, "missing") == []
+    assert find_rail_tree_node(tree, "A.2").children == ()
+    assert find_rail_tree_node(None, "A") is None

--- a/tests/test_rail_trees.py
+++ b/tests/test_rail_trees.py
@@ -450,7 +450,7 @@ def test_rail_tree_node_partial_flags_mixed_descendants():
         "A.1.2": False,
         "A.2": False,
     }
-    # Parent off + all descendants on → partial (like primary mixed group).
+    # Parent off + all descendants on → partial (muted open, copper stays off).
     assert rail_tree_node_partial_flags(
         tree,
         {
@@ -467,7 +467,7 @@ def test_rail_tree_node_partial_flags_mixed_descendants():
         "A.1.2": False,
         "A.2": False,
     }
-    # Parent on + all descendants off → partial.
+    # Parent on + all descendants off → not partial (plain click toggles parent).
     assert rail_tree_node_partial_flags(
         tree,
         {
@@ -477,7 +477,7 @@ def test_rail_tree_node_partial_flags_mixed_descendants():
             "A.1.2": False,
             "A.2": False,
         },
-    )["A"] is True
+    )["A"] is False
     assert rail_tree_node_partial_flags(None, {}) == {}
     assert rail_tree_node_partial_flags(
         RailTreeNode(name="X"), {"X": True},

--- a/tests/test_rail_trees.py
+++ b/tests/test_rail_trees.py
@@ -8,6 +8,7 @@ from fypa.rail_groups import (
     flatten_rail_tree,
     merge_rail_tree_metadata,
     resistor_bridge_pairs,
+    visible_rail_tree_rows,
 )
 
 
@@ -322,6 +323,54 @@ def test_resistor_bridge_pairs_covers_bipartite_terminals():
         frozenset(("VIN", "LED_G")),
         frozenset(("VIN", "LED_R")),
     }
+
+
+def test_visible_rail_tree_rows_respects_node_expanded():
+    """Primary defaults open; deeper nodes stay collapsed until expanded."""
+    tree = RailTreeNode(
+        name="A",
+        children=(
+            RailTreeNode(
+                name="A.1",
+                children=(
+                    RailTreeNode(name="A.1.1"),
+                    RailTreeNode(name="A.1.2"),
+                ),
+            ),
+            RailTreeNode(name="A.2"),
+        ),
+    )
+    members = ["A", "A.1", "A.1.1", "A.1.2", "A.2"]
+    # Default: primary expanded → children visible, grandchildren hidden.
+    assert visible_rail_tree_rows("A", members, tree) == [
+        ("A", 1, True),
+        ("A.1", 2, True),
+        ("A.2", 2, False),
+    ]
+    # Expand A.1 → grandchildren appear.
+    assert visible_rail_tree_rows(
+        "A", members, tree,
+        node_expanded={("A", "A"): True, ("A", "A.1"): True},
+    ) == [
+        ("A", 1, True),
+        ("A.1", 2, True),
+        ("A.1.1", 3, False),
+        ("A.1.2", 3, False),
+        ("A.2", 2, False),
+    ]
+    # Collapse primary → only the primary row.
+    assert visible_rail_tree_rows(
+        "A", members, tree,
+        node_expanded={("A", "A"): False},
+    ) == [
+        ("A", 1, True),
+    ]
+
+
+def test_visible_rail_tree_rows_flat_fallback():
+    assert visible_rail_tree_rows(
+        "A", ["A", "B"], None,
+    ) == [("A", 1, False), ("B", 1, False)]
 
 
 def test_build_rail_trees_empty_input():

--- a/tests/test_rail_trees.py
+++ b/tests/test_rail_trees.py
@@ -433,7 +433,7 @@ def test_rail_tree_node_partial_flags_mixed_descendants():
         "A.1.2": False,
         "A.2": False,
     }
-    # All descendants on → no partials.
+    # Uniform all-on including self → no partials.
     assert rail_tree_node_partial_flags(
         tree,
         {
@@ -450,8 +450,44 @@ def test_rail_tree_node_partial_flags_mixed_descendants():
         "A.1.2": False,
         "A.2": False,
     }
-    # Parent off + all descendants off → not partial; leaf always False.
+    # Parent off + all descendants on → partial (like primary mixed group).
+    assert rail_tree_node_partial_flags(
+        tree,
+        {
+            "A": False,
+            "A.1": True,
+            "A.1.1": True,
+            "A.1.2": True,
+            "A.2": True,
+        },
+    ) == {
+        "A": True,
+        "A.1": False,
+        "A.1.1": False,
+        "A.1.2": False,
+        "A.2": False,
+    }
+    # Parent on + all descendants off → partial.
+    assert rail_tree_node_partial_flags(
+        tree,
+        {
+            "A": True,
+            "A.1": False,
+            "A.1.1": False,
+            "A.1.2": False,
+            "A.2": False,
+        },
+    )["A"] is True
     assert rail_tree_node_partial_flags(None, {}) == {}
     assert rail_tree_node_partial_flags(
         RailTreeNode(name="X"), {"X": True},
     ) == {"X": False}
+
+
+def test_subtree_toggle_target():
+    from fypa.rail_groups import subtree_toggle_target
+
+    assert subtree_toggle_target([]) is True
+    assert subtree_toggle_target([True, True]) is False
+    assert subtree_toggle_target([False, False]) is True
+    assert subtree_toggle_target([True, False]) is True

--- a/tests/test_rail_trees.py
+++ b/tests/test_rail_trees.py
@@ -147,6 +147,79 @@ def test_rail_tree_orphan_attaches_under_primary():
     assert all(c.children == () for c in tree.children)
 
 
+def test_rail_tree_local_label_series_nests_via_alias():
+    """SERIES on a local label still nests under the canonical primary."""
+    metadata = {
+        "net_canonical": {
+            "VIN_LOCAL": "VIN",
+            "VIN": "VIN",
+        },
+        "directives": [
+            {
+                "role": "SOURCE",
+                "terminals": {
+                    "P": {
+                        "requested_net": "VIN_LOCAL",
+                        "resolved_via_local": True,
+                        "pins": [{"net": "VIN"}],
+                    },
+                    "N": {
+                        "requested_net": "GND",
+                        "pins": [{"net": "GND"}],
+                    },
+                },
+            },
+            {
+                "role": "RESISTOR",
+                "terminals": {
+                    "P": {
+                        "requested_net": "VIN_LOCAL",
+                        "pins": [{"net": "VIN_LOCAL"}],
+                    },
+                    "N": {"pins": [{"net": "VOUT"}]},
+                },
+            },
+            _resistor("VOUT", "VOUT_FB"),
+        ],
+    }
+    _, members = compute_rail_groups(metadata)
+    assert flatten_rail_tree(build_rail_trees(metadata, members)["VIN"]) == [
+        ("VIN", 1),
+        ("VIN_LOCAL", 2),
+        ("VOUT", 3),
+        ("VOUT_FB", 4),
+    ]
+
+
+def test_rail_tree_orphan_component_keeps_series_nesting():
+    """SERIES chain unreachable from primary stays nested under an orphan root."""
+    # No alias edge from PRIMARY to the chain — only UF membership via a
+    # shared requested_net union that we simulate by listing all members
+    # explicitly after grouping would have merged them. Build the tree
+    # directly so the adjacency has SERIES only among the orphan chain.
+    from fypa.rail_groups import _rail_tree_adjacency, _spanning_tree_from_primary
+
+    metadata = {
+        "directives": [
+            _resistor("X", "Y"),
+            _resistor("Y", "Z"),
+        ],
+    }
+    adj = _rail_tree_adjacency(metadata)
+    # PRIMARY is in the member set but has no SERIES/alias edge to X/Y/Z.
+    tree = _spanning_tree_from_primary(
+        "PRIMARY",
+        ["PRIMARY", "X", "Y", "Z"],
+        adj,
+    )
+    assert flatten_rail_tree(tree) == [
+        ("PRIMARY", 1),
+        ("X", 2),
+        ("Y", 3),
+        ("Z", 4),
+    ]
+
+
 def test_build_rail_trees_empty_input():
     assert build_rail_trees(None, {}) == {}
     assert build_rail_trees({"directives": []}, {}) == {}

--- a/tests/test_rail_trees.py
+++ b/tests/test_rail_trees.py
@@ -4,7 +4,9 @@ from fypa.rail_groups import (
     RailTreeNode,
     build_rail_trees,
     compute_rail_groups,
+    filter_directives_for_rail_trees,
     flatten_rail_tree,
+    resistor_bridge_pairs,
 )
 
 
@@ -193,31 +195,86 @@ def test_rail_tree_local_label_series_nests_via_alias():
 
 def test_rail_tree_orphan_component_keeps_series_nesting():
     """SERIES chain unreachable from primary stays nested under an orphan root."""
-    # No alias edge from PRIMARY to the chain — only UF membership via a
-    # shared requested_net union that we simulate by listing all members
-    # explicitly after grouping would have merged them. Build the tree
-    # directly so the adjacency has SERIES only among the orphan chain.
-    from fypa.rail_groups import _rail_tree_adjacency, _spanning_tree_from_primary
-
+    # Explicit membership (not from compute_rail_groups): PRIMARY shares the
+    # member list but has no SERIES/alias edge to the X—Y—Z chain.
     metadata = {
         "directives": [
             _resistor("X", "Y"),
             _resistor("Y", "Z"),
         ],
     }
-    adj = _rail_tree_adjacency(metadata)
-    # PRIMARY is in the member set but has no SERIES/alias edge to X/Y/Z.
-    tree = _spanning_tree_from_primary(
-        "PRIMARY",
-        ["PRIMARY", "X", "Y", "Z"],
-        adj,
-    )
+    tree = build_rail_trees(
+        metadata,
+        {"PRIMARY": ["PRIMARY", "X", "Y", "Z"]},
+    )["PRIMARY"]
     assert flatten_rail_tree(tree) == [
         ("PRIMARY", 1),
         ("X", 2),
         ("Y", 3),
         ("Z", 4),
     ]
+
+
+def test_rail_tree_pending_style_metadata_keeps_source_aliases():
+    """SOURCE aliases in filtered tree metadata attach local-label SERIES."""
+    metadata = {
+        "directives": [
+            {
+                "role": "SOURCE",
+                "terminals": {
+                    "P": {
+                        "requested_net": "VIN_LOCAL",
+                        "resolved_via_local": True,
+                        "pins": [{"net": "VIN"}],
+                    },
+                    "N": {
+                        "requested_net": "GND",
+                        "pins": [{"net": "GND"}],
+                    },
+                },
+            },
+            {
+                "role": "RESISTOR",
+                "terminals": {
+                    "P": {
+                        "requested_net": "VIN_LOCAL",
+                        "pins": [{"net": "VIN_LOCAL"}],
+                    },
+                    "N": {"pins": [{"net": "VOUT"}]},
+                },
+            },
+            {"role": "OTHER", "terminals": {}},
+            _resistor("VOUT", "VOUT_FB"),
+        ],
+    }
+    tree_meta = {
+        **metadata,
+        "directives": filter_directives_for_rail_trees(metadata["directives"]),
+    }
+    assert all(d.get("role") != "OTHER" for d in tree_meta["directives"])
+    members = {"VIN": ["VIN", "VIN_LOCAL", "VOUT", "VOUT_FB"]}
+    assert flatten_rail_tree(build_rail_trees(tree_meta, members)["VIN"]) == [
+        ("VIN", 1),
+        ("VIN_LOCAL", 2),
+        ("VOUT", 3),
+        ("VOUT_FB", 4),
+    ]
+
+
+def test_resistor_bridge_pairs_covers_bipartite_terminals():
+    d = {
+        "role": "RESISTOR",
+        "terminals": {
+            "P": {"pins": [{"net": "VIN"}]},
+            "N": {"pins": [{"net": "LED_B"}, {"net": "LED_G"}, {"net": "LED_R"}]},
+        },
+    }
+    pairs = set(resistor_bridge_pairs(d))
+    assert pairs == {
+        frozenset(("VIN", "LED_B")),
+        frozenset(("VIN", "LED_G")),
+        frozenset(("VIN", "LED_R")),
+    }
 
 
 def test_build_rail_trees_empty_input():

--- a/tests/test_rail_trees.py
+++ b/tests/test_rail_trees.py
@@ -397,3 +397,61 @@ def test_subtree_net_names_includes_descendants():
     assert subtree_net_names(tree, "missing") == []
     assert find_rail_tree_node(tree, "A.2").children == ()
     assert find_rail_tree_node(None, "A") is None
+
+
+def test_rail_tree_node_partial_flags_mixed_descendants():
+    from fypa.rail_groups import rail_tree_node_partial_flags
+
+    tree = RailTreeNode(
+        name="A",
+        children=(
+            RailTreeNode(
+                name="A.1",
+                children=(
+                    RailTreeNode(name="A.1.1"),
+                    RailTreeNode(name="A.1.2"),
+                ),
+            ),
+            RailTreeNode(name="A.2"),
+        ),
+    )
+    # A.1.1 on / A.1.2 off → A.1 mixed; A.2 on → A mixed; leaves never partial.
+    flags = rail_tree_node_partial_flags(
+        tree,
+        {
+            "A": False,
+            "A.1": True,
+            "A.1.1": True,
+            "A.1.2": False,
+            "A.2": True,
+        },
+    )
+    assert flags == {
+        "A": True,
+        "A.1": True,
+        "A.1.1": False,
+        "A.1.2": False,
+        "A.2": False,
+    }
+    # All descendants on → no partials.
+    assert rail_tree_node_partial_flags(
+        tree,
+        {
+            "A": True,
+            "A.1": True,
+            "A.1.1": True,
+            "A.1.2": True,
+            "A.2": True,
+        },
+    ) == {
+        "A": False,
+        "A.1": False,
+        "A.1.1": False,
+        "A.1.2": False,
+        "A.2": False,
+    }
+    # Parent off + all descendants off → not partial; leaf always False.
+    assert rail_tree_node_partial_flags(None, {}) == {}
+    assert rail_tree_node_partial_flags(
+        RailTreeNode(name="X"), {"X": True},
+    ) == {"X": False}

--- a/tests/test_rail_trees.py
+++ b/tests/test_rail_trees.py
@@ -1,0 +1,152 @@
+"""SERIES spanning trees for the expandable Rails list."""
+
+from fypa.rail_groups import (
+    RailTreeNode,
+    build_rail_trees,
+    compute_rail_groups,
+    flatten_rail_tree,
+)
+
+
+def _source(net: str) -> dict:
+    return {
+        "role": "SOURCE",
+        "terminals": {
+            "P": {"requested_net": net, "pins": [{"net": net}]},
+            "N": {"requested_net": "GND", "pins": [{"net": "GND"}]},
+        },
+    }
+
+
+def _resistor(a: str, b: str) -> dict:
+    return {
+        "role": "RESISTOR",
+        "terminals": {
+            "P": {"pins": [{"net": a}]},
+            "N": {"pins": [{"net": b}]},
+        },
+    }
+
+
+def test_rail_tree_chain_nests_by_series_hops():
+    """A—R—A.1—R—A.1.1 nests as A → A.1 → A.1.1."""
+    metadata = {
+        "directives": [
+            _source("A"),
+            _resistor("A", "A.1"),
+            _resistor("A.1", "A.1.1"),
+        ],
+    }
+    names, members = compute_rail_groups(metadata)
+    assert "A" in names
+    trees = build_rail_trees(metadata, members)
+    tree = trees["A"]
+    assert tree == RailTreeNode(
+        name="A",
+        children=(
+            RailTreeNode(
+                name="A.1",
+                children=(RailTreeNode(name="A.1.1"),),
+            ),
+        ),
+    )
+    assert flatten_rail_tree(tree) == [
+        ("A", 1),
+        ("A.1", 2),
+        ("A.1.1", 3),
+    ]
+
+
+def test_rail_tree_star_splits_under_primary():
+    """A—R—A.1 and A—R—A.2 are siblings under A."""
+    metadata = {
+        "directives": [
+            _source("A"),
+            _resistor("A", "A.1"),
+            _resistor("A", "A.2"),
+        ],
+    }
+    _, members = compute_rail_groups(metadata)
+    tree = build_rail_trees(metadata, members)["A"]
+    assert tree.name == "A"
+    assert [c.name for c in tree.children] == ["A.1", "A.2"]
+    assert all(c.children == () for c in tree.children)
+    assert flatten_rail_tree(tree) == [
+        ("A", 1),
+        ("A.1", 2),
+        ("A.2", 2),
+    ]
+
+
+def test_rail_tree_branch_matches_example_shape():
+    """A → A.1 → {A.1.1, A.1.2} and A → A.2."""
+    metadata = {
+        "directives": [
+            _source("A"),
+            _resistor("A", "A.1"),
+            _resistor("A", "A.2"),
+            _resistor("A.1", "A.1.1"),
+            _resistor("A.1", "A.1.2"),
+        ],
+    }
+    _, members = compute_rail_groups(metadata)
+    tree = build_rail_trees(metadata, members)["A"]
+    assert flatten_rail_tree(tree) == [
+        ("A", 1),
+        ("A.1", 2),
+        ("A.1.1", 3),
+        ("A.1.2", 3),
+        ("A.2", 2),
+    ]
+
+
+def test_rail_tree_cycle_is_spanning_tree_without_duplicates():
+    """A cycle yields a BFS tree; every member appears once."""
+    metadata = {
+        "directives": [
+            _source("A"),
+            _resistor("A", "B"),
+            _resistor("B", "C"),
+            _resistor("C", "A"),
+        ],
+    }
+    _, members = compute_rail_groups(metadata)
+    tree = build_rail_trees(metadata, members)["A"]
+    rows = flatten_rail_tree(tree)
+    names = [n for n, _ in rows]
+    assert names[0] == "A"
+    assert sorted(names) == sorted(members["A"])
+    assert len(names) == len(set(names))
+
+
+def test_rail_tree_orphan_attaches_under_primary():
+    """Member joined only via alias union (no SERIES edge) hangs under primary."""
+    metadata = {
+        "directives": [
+            {
+                "role": "SOURCE",
+                "terminals": {
+                    "P": {
+                        "requested_net": "VIN",
+                        "pins": [{"net": "VIN"}, {"net": "VIN_ALIAS"}],
+                    },
+                    "N": {
+                        "requested_net": "GND",
+                        "pins": [{"net": "GND"}],
+                    },
+                },
+            },
+            _resistor("VIN", "VOUT"),
+        ],
+    }
+    _, members = compute_rail_groups(metadata)
+    tree = build_rail_trees(metadata, members)["VIN"]
+    child_names = {c.name for c in tree.children}
+    assert "VOUT" in child_names
+    assert "VIN_ALIAS" in child_names
+    assert all(c.children == () for c in tree.children)
+
+
+def test_build_rail_trees_empty_input():
+    assert build_rail_trees(None, {}) == {}
+    assert build_rail_trees({"directives": []}, {}) == {}

--- a/tests/test_rail_trees.py
+++ b/tests/test_rail_trees.py
@@ -2,10 +2,11 @@
 
 from fypa.rail_groups import (
     RailTreeNode,
+    bridge_pair_key,
     build_rail_trees,
     compute_rail_groups,
-    filter_directives_for_rail_trees,
     flatten_rail_tree,
+    merge_rail_tree_metadata,
     resistor_bridge_pairs,
 )
 
@@ -247,11 +248,9 @@ def test_rail_tree_pending_style_metadata_keeps_source_aliases():
             _resistor("VOUT", "VOUT_FB"),
         ],
     }
-    tree_meta = {
-        **metadata,
-        "directives": filter_directives_for_rail_trees(metadata["directives"]),
-    }
+    tree_meta = merge_rail_tree_metadata(metadata)
     assert all(d.get("role") != "OTHER" for d in tree_meta["directives"])
+    assert any(d.get("role") == "SOURCE" for d in tree_meta["directives"])
     members = {"VIN": ["VIN", "VIN_LOCAL", "VOUT", "VOUT_FB"]}
     assert flatten_rail_tree(build_rail_trees(tree_meta, members)["VIN"]) == [
         ("VIN", 1),
@@ -259,6 +258,54 @@ def test_rail_tree_pending_style_metadata_keeps_source_aliases():
         ("VOUT", 3),
         ("VOUT_FB", 4),
     ]
+
+
+def test_merge_rail_tree_metadata_dedupes_editor_series_case_insensitive():
+    """Editor SERIES matching an existing RESISTOR pair (any case) is skipped."""
+    metadata = {
+        "directives": [
+            {
+                "role": "RESISTOR",
+                "terminals": {
+                    "P": {"pins": [{"net": "VIN"}]},
+                    "N": {
+                        "pins": [
+                            {"net": "LED_B"},
+                            {"net": "LED_G"},
+                            {"net": "LED_R"},
+                        ],
+                    },
+                },
+            },
+            {"role": "OTHER", "terminals": {}},
+        ],
+    }
+    merged = merge_rail_tree_metadata(
+        metadata,
+        editor_series=[
+            ("vin", "led_r"),       # already covered (case-insensitive)
+            ("VIN", "VOUT_EXTRA"),  # new bridge
+            ("VIN", "VOUT_EXTRA"),  # duplicate of the new bridge
+        ],
+    )
+    roles = [d.get("role") for d in merged["directives"]]
+    assert "OTHER" not in roles
+    assert roles.count("RESISTOR") == 2  # original + one editor
+    added = [
+        d for d in merged["directives"]
+        if d.get("role") == "RESISTOR"
+        and any(
+            p.get("net") == "VOUT_EXTRA"
+            for t in (d.get("terminals") or {}).values()
+            for p in t.get("pins", [])
+        )
+    ]
+    assert len(added) == 1
+
+
+def test_bridge_pair_key_is_case_insensitive():
+    assert bridge_pair_key("Vin", "gnd") == bridge_pair_key("VIN", "GND")
+    assert bridge_pair_key("A", "B") == bridge_pair_key("B", "A")
 
 
 def test_resistor_bridge_pairs_covers_bipartite_terminals():


### PR DESCRIPTION
## Motivation
Rails joined by SERIES bridges were a flat member list, so hierarchy and per-net visibility were hard to see or control. Authors need the spanning tree in the sidebar and fast show/hide of a net plus its SERIES descendants.

## Summary
- Build a nested spanning tree over SERIES (RESISTOR) edges from each rail primary
- Per-node expand, lighter indent, resizable rails sidebar
- Subnet eyes: plain click = one net; Ctrl+Click = SERIES subtree; intermediate partial (mixed / parent-off with children on)
- Shift+Click isolate left for the existing isolate branch (merge carefully)

## Test plan
- [ ] `pytest tests/test_rail_trees.py tests/test_eye_button.py tests/test_rail_subnet_eye_handlers.py`
- [ ] Multi-net rail: tree indent + expand matches SERIES hops
- [ ] Ctrl+Click toggles subtree; partial click shows whole subtree; parent-on/children-off still toggles parent only
