### PR TITLE
Inherit unindexed PDN_* as templates for indexed channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,8 @@ ExampleDesigns/Sandbox/*
 # would re-leak exactly what it removes. Run it before each commit.
 sanitize_sandbox.ps1
 wiring.json
-scripts/test-*.ps1
+# Local override for test-combined (team config is on team/local branch)
+scripts/test-combined.json
+# Fork-local team config (team/test-combined.json is tracked on team/local only)
+team/*
+!team/test-combined.json

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ sanitize_sandbox.ps1
 wiring.json
 # Local override for test-combined (team config is on team/local branch)
 scripts/test-combined.json
+scripts/py314.local.json
 # Fork-local team config (team/test-combined.json is tracked on team/local only)
 team/*
 !team/test-combined.json

--- a/README.md
+++ b/README.md
@@ -204,10 +204,11 @@ is set; unset indexed params inherit from the matching unindexed
 channel — a channel can override it with `PDN<n>_ROLE` (see [Mixed-role
 parts](#mixed-role-parts-a-source-and-a-sink-on-one-component) below).
 
-**Templates:** when indexed channels exist and the unindexed form has no
-channel-defining terminals (P/N or single-net for SOURCE/SINK/SERIES;
-`OUT_*` only for REGULATOR), unindexed `PDN_*` values are defaults only —
-no legacy directive is emitted. Example — shared SERIES resistance:
+**Templates:** when indexed channels exist and the unindexed form lacks a
+*complete* terminal set (both P and N for SOURCE/SINK/SERIES; both `OUT_*`
+sides for REGULATOR), unindexed `PDN_*` values are defaults only — no
+legacy directive is emitted. A shared `PDN_N_NET = GND` or `PDN_IN_*` alone
+is a template. Example — shared SERIES resistance:
 
 ```text
 SW1:

--- a/README.md
+++ b/README.md
@@ -208,7 +208,11 @@ parts](#mixed-role-parts-a-source-and-a-sink-on-one-component) below).
 *complete* terminal set (both P and N for SOURCE/SINK/SERIES; both `OUT_*`
 sides for REGULATOR), unindexed `PDN_*` values are defaults only — no
 legacy directive is emitted. A shared `PDN_N_NET = GND` or `PDN_IN_*` alone
-is a template. Example — shared SERIES resistance:
+is a template. Unindexed `PDN_NET` / `PDN_PINS` is a complete single-net
+channel and is kept alongside indexed channels (not template-only).
+Indexed-only parts (`PDNn_ROLE` without `PDN_ROLE`) always treat unindexed
+values as templates when indexed channels exist. Example — shared SERIES
+resistance:
 
 ```text
 SW1:

--- a/README.md
+++ b/README.md
@@ -191,16 +191,31 @@ a positive integer to `PDN` in the parameter prefix:
 | 2       | `PDN2_V` | `PDN2_I` | `PDN2_R` | `PDN2_P_NET`, … |
 | …       | … | … | … | … |
 
-REGULATOR channels also require `PDN<n>_GAIN` and the four `PDN<n>_OUT_*` /
-`PDN<n>_IN_*` net (or pin) parameters per channel.
+REGULATOR channels also require the four `PDN<n>_OUT_*` / `PDN<n>_IN_*` net
+(or pin) parameters per channel (IN may be inherited from unindexed
+`PDN_IN_*`; see templates below).
 
-The legacy unindexed channel and any number of indexed channels coexist
-as independent directives. Indices are sparse — gaps are allowed (e.g.
-just `PDN_V` + `PDN2_V`). A channel is "present" iff its value parameter
-is set; the per-channel `*_NET` and `*_PINS` parameters use the matching
-index. The part-wide `PDN_ROLE` is the **default** role for every channel —
-a channel can override it with `PDN<n>_ROLE` (see [Mixed-role
+The legacy unindexed channel and any number of indexed channels can coexist
+as independent directives when the unindexed form has its own terminals.
+Indices are sparse — gaps are allowed (e.g. just `PDN_V` + `PDN2_V`). A
+channel is present when its value parameter or a channel-defining terminal
+is set; unset indexed params inherit from the matching unindexed
+`PDN_*` template. The part-wide `PDN_ROLE` is the **default** role for every
+channel — a channel can override it with `PDN<n>_ROLE` (see [Mixed-role
 parts](#mixed-role-parts-a-source-and-a-sink-on-one-component) below).
+
+**Templates:** when indexed channels exist and the unindexed form has no
+channel-defining terminals (P/N or single-net for SOURCE/SINK/SERIES;
+`OUT_*` only for REGULATOR), unindexed `PDN_*` values are defaults only —
+no legacy directive is emitted. Example — shared SERIES resistance:
+
+```text
+SW1:
+  PDN_ROLE   = SERIES
+  PDN_R      = 0.05
+  PDN1_P_NET = VIN_A     PDN1_N_NET = VOUT_A
+  PDN2_P_NET = VIN_B     PDN2_N_NET = VOUT_B
+```
 
 Example — a SINK with three independent supply rails:
 

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -1,0 +1,50 @@
+# Fork workflow (team/local)
+
+This fork keeps upstream-ready work separate from local team tooling.
+
+## Branches
+
+| Branch | Purpose |
+|--------|---------|
+| `main` | Tracks upstream; use as the base for upstream pull requests |
+| `team/local` | Shared fork config (combined-test branch list, etc.) |
+
+Daily development can use `team/local` or feature branches. **Do not merge `team/local` into branches you open upstream.**
+
+## Combined local test
+
+`scripts/test-combined.ps1` builds a throwaway branch, merges configured feature branches, runs topology tests and FYPA, then returns to your previous branch. Run it from **any** branch — config is read from `team/local` via `git show` when the file is not in your working tree.
+
+Config lives in `team/test-combined.json` on the `team/local` branch:
+
+```json
+{
+  "baseBranch": "main",
+  "testBranch": "test/combined",
+  "deleteTestBranchFirst": true,
+  "extraFeatureBranches": ["feature/example-a", "fix/example-b"]
+}
+```
+
+- `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate).
+- By default, `baseBranch` and `extraFeatureBranches` are **fetched from `origin`** and merged via `origin/<branch>`. Use `--local-only` to use local branches only.
+- Override any field on the command line, e.g. `-DeleteTestBranchFirst:$false`.
+
+```powershell
+pwsh scripts/test-combined.ps1
+pwsh scripts/test-combined.ps1 --local-only
+```
+
+Resolution order: `scripts/test-combined.json` (local override) → `team/test-combined.json` → `team/local:team/test-combined.json` → example file.
+
+For a one-off local config, copy `scripts/test-combined.example.json` to `scripts/test-combined.json` (gitignored).
+
+## Upstream pull requests
+
+Create the PR branch from upstream, not from `team/local`:
+
+```powershell
+git fetch upstream
+git checkout -b feature/my-fix upstream/main
+git cherry-pick <commit>   # feature commits only
+```

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -14,7 +14,7 @@ Daily development can use `team/local` or feature branches. **Do not merge `team
 
 ## Combined test (`test/combined`)
 
-Feature branches listed in `team/test-combined.json` on `team/local` are merged **once** into the shared `test/combined` branch and pushed to GitHub. Machines only fetch and check out that tip — they do not merge at Altium/FYPA start.
+Feature branches listed in `team/test-combined.json` on `team/local` are merged into the shared `test/combined` branch and pushed to GitHub. Machines only fetch and check out that tip — they do not merge at Altium/FYPA start.
 
 Config on `team/local`:
 
@@ -27,53 +27,54 @@ Config on `team/local`:
 }
 ```
 
-### Maintain (rebuild + publish)
+### Maintain (update + publish)
 
-Uses **origin tips only** (unpushed local commits are ignored). Missing remotes abort.
+Uses **origin tips only**. Prefer **incremental** updates (default): check out `origin/test/combined` and merge only extras not already in that tip. That keeps prior conflict resolutions.
 
 ```powershell
-pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+pwsh scripts/maintain-test-combined.ps1 -Push          # incremental
+pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push # clean recreate from main
+pwsh scripts/maintain-test-combined.ps1 -Abort         # escape stuck merge
 ```
 
-Omit `-Push` to rebuild locally while resolving merge conflicts, then push when clean.
+Omit `-Push` while resolving conflicts locally, then `-Push` when clean.
 
-On conflict, only `.gitignore` and `FYPA.code-workspace` auto-resolve with `--ours`; other conflicts stop the script.
+**Conflicts:** only `.gitignore` / `FYPA.code-workspace` auto-resolve. On a real conflict the script stays on `test/combined` — do not `git switch` away. Either finish (`git add` + `git commit`, then `-Push`) or run `-Abort` to hard-reset to `origin/test/combined` and return to your previous branch.
 
-Config resolution for maintain: `scripts/test-combined.json` (gitignored override) → `team/test-combined.json` → `team/local:team/test-combined.json` → example file.
+Use `-Rebuild` only when `main` moved a lot, extras were removed/reordered, or the tip is broken. Expect to resolve the same conflicts again.
+
+Config resolution: `scripts/test-combined.json` (gitignored) → `team/test-combined.json` → `team/local:team/test-combined.json` → example file.
 
 ### GitHub Action (fork only)
 
-`.github/workflows/maintain-test-combined.yml` lives **only on `team/local`** — never commit it to `main` or to branches destined for an upstream PR.
+`.github/workflows/maintain-test-combined.yml` lives **only on `team/local`** — never commit it to `main` or upstream PR branches.
 
-Triggers: `workflow_dispatch` (use `--ref team/local`) and pushes to `team/local` that touch `team/test-combined.json`. The job runs maintain with `-Rebuild -Push`.
+Triggers: `workflow_dispatch` (`--ref team/local`) and pushes to `team/local` that touch `team/test-combined.json`.
 
 ### Launch (no merge)
 
 ```powershell
 pwsh scripts/test-combined.ps1
-pwsh scripts/test-combined.ps1 -SkipTests
 pwsh scripts/test-combined.ps1 -SkipTests -PrjPcb path\to\Board.PrjPcb
 ```
 
-Checks out `origin/test/combined`, optionally runs topology pytest, then FYPA. `-Rebuild` is not supported here — use maintain.
+Checks out `origin/test/combined` only. `-Rebuild` is not supported — use maintain.
 
-Altium bootstrap (`Run_FYPA.ps1`) calls `scripts/launch-combined-gui.ps1` after clone/`uv sync`: fetch + hard-reset to `origin/test/combined`, then `Launch_GUI.py`.
+Altium (`Run_FYPA.ps1`) calls `scripts/launch-combined-gui.ps1`.
 
 ### Typical flow
 
 1. Push the feature branch to `origin`.
 2. Add it to `team/test-combined.json` on `team/local` and push `team/local`.
-3. Run maintain (or let the Action rebuild) so `origin/test/combined` updates.
-4. On any machine: Altium → Run FYPA → fetch + checkout — done.
+3. `pwsh scripts/maintain-test-combined.ps1 -Push` (incremental).
+4. On any machine: Altium / `test-combined.ps1` → `origin/test/combined`.
 
 Prefer clean feature branches in the JSON (not pre-merged `*-combined` stacks).
 
 ## Upstream pull requests
 
-Create the PR branch from upstream, not from `team/local`:
-
 ```powershell
 git fetch upstream
 git checkout -b feature/my-fix upstream/main
-git cherry-pick <commit>   # feature commits only
+git cherry-pick <commit>
 ```

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -7,15 +7,16 @@ This fork keeps upstream-ready work separate from local team tooling.
 | Branch | Purpose |
 |--------|---------|
 | `main` | Tracks upstream; use as the base for upstream pull requests |
-| `team/local` | Shared fork config (combined-test branch list, etc.) |
+| `team/local` | Shared fork config (combined-test branch list, GH Action for maintain) |
+| `test/combined` | Published integration tip built from the JSON list (force-pushed) |
 
 Daily development can use `team/local` or feature branches. **Do not merge `team/local` into branches you open upstream.**
 
-## Combined local test
+## Combined test (`test/combined`)
 
-`scripts/test-combined.ps1` builds a throwaway branch, merges configured feature branches, optionally runs topology tests and FYPA, then returns to your previous branch. Run it from **any** branch — config is read from `team/local` via `git show` when the file is not in your working tree.
+Feature branches listed in `team/test-combined.json` on `team/local` are merged **once** into the shared `test/combined` branch and pushed to GitHub. Machines only fetch and check out that tip — they do not merge at Altium/FYPA start.
 
-Config lives in `team/test-combined.json` on the `team/local` branch:
+Config on `team/local`:
 
 ```json
 {
@@ -26,22 +27,46 @@ Config lives in `team/test-combined.json` on the `team/local` branch:
 }
 ```
 
-- `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate). Only applies when the branch is rebuilt, not when it is reused.
-- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`**. Each input tip is resolved so **local work is never dropped**: if the local branch is ahead of or diverged from `origin/<branch>`, the local tip is used; if local is behind, `origin/<branch>` is used; branches that exist only locally or only on the remote are accepted either way. If fetch fails (offline), the same resolution runs against existing refs. Use `-LocalOnly` to skip fetch and use local branches only.
-- When the existing `testBranch` tip has a matching stamp (input SHAs + config identity stored as a git note), the branch is **reused** instead of rebuilt. Pass `-Rebuild` to force a clean recreate.
-- Topology pytest runs by default. Pass `-SkipTests` to skip them (the Altium launcher always passes `-SkipTests`).
-- Override any field on the command line, e.g. `-DeleteTestBranchFirst:$false`.
+### Maintain (rebuild + publish)
+
+Uses **origin tips only** (unpushed local commits are ignored). Missing remotes abort.
+
+```powershell
+pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+```
+
+Omit `-Push` to rebuild locally while resolving merge conflicts, then push when clean.
+
+On conflict, only `.gitignore` and `FYPA.code-workspace` auto-resolve with `--ours`; other conflicts stop the script.
+
+Config resolution for maintain: `scripts/test-combined.json` (gitignored override) → `team/test-combined.json` → `team/local:team/test-combined.json` → example file.
+
+### GitHub Action (fork only)
+
+`.github/workflows/maintain-test-combined.yml` lives **only on `team/local`** — never commit it to `main` or to branches destined for an upstream PR.
+
+Triggers: `workflow_dispatch` (use `--ref team/local`) and pushes to `team/local` that touch `team/test-combined.json`. The job runs maintain with `-Rebuild -Push`.
+
+### Launch (no merge)
 
 ```powershell
 pwsh scripts/test-combined.ps1
-pwsh scripts/test-combined.ps1 -LocalOnly
-pwsh scripts/test-combined.ps1 -Rebuild
 pwsh scripts/test-combined.ps1 -SkipTests
+pwsh scripts/test-combined.ps1 -SkipTests -PrjPcb path\to\Board.PrjPcb
 ```
 
-Resolution order: `scripts/test-combined.json` (local override) → `team/test-combined.json` → `team/local:team/test-combined.json` → example file.
+Checks out `origin/test/combined`, optionally runs topology pytest, then FYPA. `-Rebuild` is not supported here — use maintain.
 
-For a one-off local config, copy `scripts/test-combined.example.json` to `scripts/test-combined.json` (gitignored).
+Altium bootstrap (`Run_FYPA.ps1`) calls `scripts/launch-combined-gui.ps1` after clone/`uv sync`: fetch + hard-reset to `origin/test/combined`, then `Launch_GUI.py`.
+
+### Typical flow
+
+1. Push the feature branch to `origin`.
+2. Add it to `team/test-combined.json` on `team/local` and push `team/local`.
+3. Run maintain (or let the Action rebuild) so `origin/test/combined` updates.
+4. On any machine: Altium → Run FYPA → fetch + checkout — done.
+
+Prefer clean feature branches in the JSON (not pre-merged `*-combined` stacks).
 
 ## Upstream pull requests
 

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -27,7 +27,7 @@ Config lives in `team/test-combined.json` on the `team/local` branch:
 ```
 
 - `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate). Only applies when the branch is rebuilt, not when it is reused.
-- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`** and merged via `origin/<branch>`. If fetch fails (offline), local refs are used instead. Use `--local-only` to skip fetch entirely.
+- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`**. Each input tip is resolved so **local work is never dropped**: if the local branch is ahead of or diverged from `origin/<branch>`, the local tip is used; if local is behind, `origin/<branch>` is used; branches that exist only locally or only on the remote are accepted either way. If fetch fails (offline), the same resolution runs against existing refs. Use `--local-only` to skip fetch and use local branches only.
 - When the existing `testBranch` tip has a matching stamp (input SHAs + config identity stored as a git note), the branch is **reused** instead of rebuilt. Pass `-Rebuild` to force a clean recreate.
 - Topology pytest runs by default. Pass `-SkipTests` to skip them (the Altium launcher always passes `-SkipTests`).
 - Override any field on the command line, e.g. `-DeleteTestBranchFirst:$false`.

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -27,14 +27,14 @@ Config lives in `team/test-combined.json` on the `team/local` branch:
 ```
 
 - `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate). Only applies when the branch is rebuilt, not when it is reused.
-- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`**. Each input tip is resolved so **local work is never dropped**: if the local branch is ahead of or diverged from `origin/<branch>`, the local tip is used; if local is behind, `origin/<branch>` is used; branches that exist only locally or only on the remote are accepted either way. If fetch fails (offline), the same resolution runs against existing refs. Use `--local-only` to skip fetch and use local branches only.
+- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`**. Each input tip is resolved so **local work is never dropped**: if the local branch is ahead of or diverged from `origin/<branch>`, the local tip is used; if local is behind, `origin/<branch>` is used; branches that exist only locally or only on the remote are accepted either way. If fetch fails (offline), the same resolution runs against existing refs. Use `-LocalOnly` to skip fetch and use local branches only.
 - When the existing `testBranch` tip has a matching stamp (input SHAs + config identity stored as a git note), the branch is **reused** instead of rebuilt. Pass `-Rebuild` to force a clean recreate.
 - Topology pytest runs by default. Pass `-SkipTests` to skip them (the Altium launcher always passes `-SkipTests`).
 - Override any field on the command line, e.g. `-DeleteTestBranchFirst:$false`.
 
 ```powershell
 pwsh scripts/test-combined.ps1
-pwsh scripts/test-combined.ps1 --local-only
+pwsh scripts/test-combined.ps1 -LocalOnly
 pwsh scripts/test-combined.ps1 -Rebuild
 pwsh scripts/test-combined.ps1 -SkipTests
 ```

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -13,7 +13,7 @@ Daily development can use `team/local` or feature branches. **Do not merge `team
 
 ## Combined local test
 
-`scripts/test-combined.ps1` builds a throwaway branch, merges configured feature branches, runs topology tests and FYPA, then returns to your previous branch. Run it from **any** branch — config is read from `team/local` via `git show` when the file is not in your working tree.
+`scripts/test-combined.ps1` builds a throwaway branch, merges configured feature branches, optionally runs topology tests and FYPA, then returns to your previous branch. Run it from **any** branch — config is read from `team/local` via `git show` when the file is not in your working tree.
 
 Config lives in `team/test-combined.json` on the `team/local` branch:
 
@@ -26,13 +26,17 @@ Config lives in `team/test-combined.json` on the `team/local` branch:
 }
 ```
 
-- `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate).
-- By default, `baseBranch` and `extraFeatureBranches` are **fetched from `origin`** and merged via `origin/<branch>`. Use `--local-only` to use local branches only.
+- `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate). Only applies when the branch is rebuilt, not when it is reused.
+- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`** and merged via `origin/<branch>`. If fetch fails (offline), local refs are used instead. Use `--local-only` to skip fetch entirely.
+- When the existing `testBranch` tip has a matching stamp (input SHAs + config identity stored as a git note), the branch is **reused** instead of rebuilt. Pass `-Rebuild` to force a clean recreate.
+- Topology pytest runs by default. Pass `-SkipTests` to skip them (the Altium launcher always passes `-SkipTests`).
 - Override any field on the command line, e.g. `-DeleteTestBranchFirst:$false`.
 
 ```powershell
 pwsh scripts/test-combined.ps1
 pwsh scripts/test-combined.ps1 --local-only
+pwsh scripts/test-combined.ps1 -Rebuild
+pwsh scripts/test-combined.ps1 -SkipTests
 ```
 
 Resolution order: `scripts/test-combined.json` (local override) → `team/test-combined.json` → `team/local:team/test-combined.json` → example file.

--- a/docs/user-guide/01-sources-and-sinks.md
+++ b/docs/user-guide/01-sources-and-sinks.md
@@ -206,6 +206,15 @@ emit a legacy directive. A shared return such as `PDN_N_NET = GND` alone
 is a template. Keep a full unindexed terminal pair if you want both a
 legacy channel and indexed ones (as in the table above).
 
+> Unindexed `PDN_NET` / `PDN_PINS` counts as a complete single-net channel.
+> If indexed channels are also present, that legacy single-net directive is
+> kept — there is no "shared `PDN_NET` template only" mode. Put `PDNn_NET`
+> on each indexed channel (or inherit a two-terminal `PDN_N_NET`) instead.
+
+Parts that use only `PDNn_ROLE` (no part-wide `PDN_ROLE`) may still put
+shared values on unindexed `PDN_R` / `PDN_V` / `PDN_I`; those stay
+templates for the indexed channels.
+
 > You only need channels for **different** rails. An IC with many pins on
 > the *same* rail is still one directive — FYPA already groups every pad
 > on `PDN_P_NET` into one terminal (see [Multi-pin parts](#14-multi-pin-parts)

--- a/docs/user-guide/01-sources-and-sinks.md
+++ b/docs/user-guide/01-sources-and-sinks.md
@@ -191,11 +191,18 @@ value and its own P/N nets:
 |             |         | `PDN2_N_NET` | `GND`  |
 
 Each channel becomes its own directive; the viewer labels them `U7`,
-`U7#1`, `U7#2`. A channel exists as soon as its value parameter
-(`PDN<n>_I` here) is set. Indices can be sparse (gaps allowed). The same
-scheme works for every role — use `PDN<n>_V` for sources/regulators,
-`PDN<n>_R` for series parts. See the [main README](../../README.md#multi-channel-directives)
-for the full reference.
+`U7#1`, `U7#2`. A channel exists when its value parameter (`PDN<n>_I`
+here) or a channel-defining terminal param is set; the value may be
+inherited from the unindexed template (`PDN_I` when `PDN1_I` is omitted).
+Indices can be sparse (gaps allowed). The same scheme works for every
+role — use `PDN<n>_V` for sources/regulators, `PDN<n>_R` for series parts.
+See the [main README](../../README.md#multi-channel-directives) for the
+full reference.
+
+When indexed channels exist and the unindexed form has **no** terminals of
+its own (`PDN_P_NET` / …), unindexed parameters are template-only — FYPA
+does not also emit a legacy directive. Keep unindexed terminals if you want
+both a legacy channel and indexed ones (as in the table above).
 
 > You only need channels for **different** rails. An IC with many pins on
 > the *same* rail is still one directive — FYPA already groups every pad

--- a/docs/user-guide/01-sources-and-sinks.md
+++ b/docs/user-guide/01-sources-and-sinks.md
@@ -199,10 +199,12 @@ role — use `PDN<n>_V` for sources/regulators, `PDN<n>_R` for series parts.
 See the [main README](../../README.md#multi-channel-directives) for the
 full reference.
 
-When indexed channels exist and the unindexed form has **no** terminals of
-its own (`PDN_P_NET` / …), unindexed parameters are template-only — FYPA
-does not also emit a legacy directive. Keep unindexed terminals if you want
-both a legacy channel and indexed ones (as in the table above).
+When indexed channels exist and the unindexed form has **no complete**
+terminal pair of its own (`PDN_P_NET` **and** `PDN_N_NET`, or single-net
+`PDN_NET`), unindexed parameters are template-only — FYPA does not also
+emit a legacy directive. A shared return such as `PDN_N_NET = GND` alone
+is a template. Keep a full unindexed terminal pair if you want both a
+legacy channel and indexed ones (as in the table above).
 
 > You only need channels for **different** rails. An IC with many pins on
 > the *same* rail is still one directive — FYPA already groups every pad

--- a/docs/user-guide/03-series-elements.md
+++ b/docs/user-guide/03-series-elements.md
@@ -87,8 +87,9 @@ bead array) uses indexed parameters, the same way multi-rail SINKs use
 
 Unindexed `PDN_*` values are **templates** for indexed channels: `PDNn_X`
 wins when set, otherwise `PDN_X` is used. When indexed channels exist and
-the unindexed form has no P/N nets or pins of its own, the legacy channel
-is not emitted — only the indexed paths become directives.
+the unindexed form does not carry a **complete** P/N (or pin) pair, the
+legacy channel is not emitted — a shared `PDN_P_NET` or `PDN_R` alone is
+template-only.
 
 Auto-inference from pad connectivity applies only when the part carries
 **one** SERIES channel. With two or more channels you must name each
@@ -102,6 +103,17 @@ SW1:
   PDN_R       = 0.05
   PDN1_P_NET  = VIN_A     PDN1_N_NET = VOUT_A
   PDN2_P_NET  = VIN_B     PDN2_N_NET = VOUT_B
+```
+
+Example — shared P-side net, per-channel N side:
+
+```text
+SW1:
+  PDN_ROLE    = SERIES
+  PDN_R       = 0.05
+  PDN_P_NET   = VIN
+  PDN1_N_NET  = VOUT_A
+  PDN2_N_NET  = VOUT_B
 ```
 
 Example — per-channel resistance and pin overrides:

--- a/docs/user-guide/03-series-elements.md
+++ b/docs/user-guide/03-series-elements.md
@@ -85,11 +85,26 @@ bead array) uses indexed parameters, the same way multi-rail SINKs use
 | 1       | `PDN1_R` | `PDN1_P_NET`, `PDN1_N_NET` or `PDN1_P_PINS` / `PDN1_N_PINS` |
 | 2       | `PDN2_R` | … |
 
+Unindexed `PDN_*` values are **templates** for indexed channels: `PDNn_X`
+wins when set, otherwise `PDN_X` is used. When indexed channels exist and
+the unindexed form has no P/N nets or pins of its own, the legacy channel
+is not emitted — only the indexed paths become directives.
+
 Auto-inference from pad connectivity applies only when the part carries
 **one** SERIES channel. With two or more channels you must name each
 channel's nets or pin overrides explicitly.
 
-Example — a 4-pad ferrite array bridging two net pairs per channel:
+Example — shared resistance, two net pairs (multi-pin switch / ferrite):
+
+```text
+SW1:
+  PDN_ROLE    = SERIES
+  PDN_R       = 0.05
+  PDN1_P_NET  = VIN_A     PDN1_N_NET = VOUT_A
+  PDN2_P_NET  = VIN_B     PDN2_N_NET = VOUT_B
+```
+
+Example — per-channel resistance and pin overrides:
 
 ```text
 FB1:

--- a/docs/user-guide/04-regulators.md
+++ b/docs/user-guide/04-regulators.md
@@ -67,8 +67,8 @@ multi-rail SINKs use `PDN1_I`:
 Unindexed parameters are templates for indexed channels (`PDNn_X` overrides
 `PDN_X`). Shared input nets, voltage, type, and quiescent current can stay
 on `PDN_*` while each output names only `PDNn_OUT_*`. When indexed
-channels exist and the unindexed form has **no** `PDN_OUT_*` terminals, the
-legacy channel is not emitted.
+channels exist and the unindexed form lacks a **complete** `OUT_*` pair,
+the legacy channel is not emitted.
 
 Example — dual LDO outputs with shared Vin / Vout / type:
 

--- a/docs/user-guide/04-regulators.md
+++ b/docs/user-guide/04-regulators.md
@@ -64,7 +64,27 @@ multi-rail SINKs use `PDN1_I`:
 | 1       | `PDN1_V`, `PDN1_REGULATOR_TYPE`, `PDN1_QUIESCENT`, … | `PDN1_OUT_P_NET`, … |
 | 2       | `PDN2_V`, … | … |
 
-Example — 3.3 V and 1.8 V outputs from a shared 5 V input:
+Unindexed parameters are templates for indexed channels (`PDNn_X` overrides
+`PDN_X`). Shared input nets, voltage, type, and quiescent current can stay
+on `PDN_*` while each output names only `PDNn_OUT_*`. When indexed
+channels exist and the unindexed form has **no** `PDN_OUT_*` terminals, the
+legacy channel is not emitted.
+
+Example — dual LDO outputs with shared Vin / Vout / type:
+
+```text
+U2:
+  PDN_ROLE           = REGULATOR
+  PDN_V              = 3.3
+  PDN_REGULATOR_TYPE = LDO
+  PDN_QUIESCENT      = 390uA
+  PDN_IN_P_NET       = VIN        PDN_IN_N_NET  = GND
+  PDN1_OUT_P_NET     = VOUT_P     PDN1_OUT_N_NET = GND
+  PDN2_OUT_P_NET     = GND        PDN2_OUT_N_NET = VOUT_N
+```
+
+Example — 3.3 V and 1.8 V outputs, each fully specified (legacy + indexed
+both real because each has its own `OUT_*`):
 
 ```text
 U4:

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -66,10 +66,42 @@ Example — a SINK with three independent supply rails::
     PDN1_I     = 250mA     PDN1_P_NET = +1V8   PDN1_N_NET = GND
     PDN2_I     = 50mA      PDN2_P_NET = +5V    PDN2_N_NET = GND
 
-Indices are sparse (any positive integer; gaps allowed); a channel is
-"present" iff its value param (``PDNn_V`` for SOURCE / REGULATOR,
-``PDNn_I`` for SINK, ``PDNn_R`` for SERIES) is set. All four roles support
-the same indexed-prefix scheme.
+Indices are sparse (any positive integer; gaps allowed). A channel is
+"present" when it has a value param for its role (``PDNn_V`` / ``PDNn_I`` /
+``PDNn_R``), a channel-defining terminal param, or an indexed ``PDNn_ROLE``
+— and the value may be **inherited** from the unindexed template (``PDN_V``
+when ``PDN1_V`` is omitted). All four roles support the same indexed-prefix
+scheme.
+
+Unindexed template inheritance
+------------------------------
+Unindexed ``PDN_*`` parameters act as defaults for indexed channels: for
+channel *n*, ``PDNn_X`` wins when set, otherwise ``PDN_X`` is used. When at
+least one indexed channel exists and the unindexed form has **no**
+channel-defining terminals of its own, the legacy ``index=None`` channel is
+*not* emitted — unindexed values are template-only. Channel-defining
+terminals are the P/N (or single-net) nets/pins for SOURCE/SINK/SERIES, and
+**OUT_*** only for REGULATOR (so shared ``PDN_IN_*`` can be a template).
+
+Example — dual SERIES paths sharing one resistance::
+
+    PDN_ROLE   = SERIES
+    PDN_R      = 0.05
+    PDN1_P_NET = VIN_A     PDN1_N_NET = VOUT_A
+    PDN2_P_NET = VIN_B     PDN2_N_NET = VOUT_B
+
+Example — dual REGULATOR outputs sharing Vin / type / voltage::
+
+    PDN_ROLE           = REGULATOR
+    PDN_V              = 3.3
+    PDN_REGULATOR_TYPE = LDO
+    PDN_IN_P_NET       = VIN       PDN_IN_N_NET = GND
+    PDN1_OUT_P_NET     = VOUT_P    PDN1_OUT_N_NET = GND
+    PDN2_OUT_P_NET     = GND       PDN2_OUT_N_NET = VOUT_N
+
+The classic pattern with a real unindexed channel *plus* indexed ones
+(``PDN_I`` + ``PDN_P_NET`` alongside ``PDN1_I`` + …) is unchanged: unindexed
+keeps its own terminals, so it remains a directive.
 
 Values support SI prefixes and units (``500mA``, ``3V3``, ``1.5k``, ``0.1``).
 
@@ -189,6 +221,22 @@ _KNOWN_SUFFIXES_BY_ROLE: dict[str, frozenset[str]] = {
     }),
     "SERIES": frozenset({"R", "P_NET", "N_NET", "P_PINS", "N_PINS"}),
 }
+
+# Terminals that make the *unindexed* channel a real directive alongside
+# indexed ones (as opposed to template-only defaults). REGULATOR channels
+# are defined by their outputs — shared IN_* may stay on PDN_IN_*.
+_CHANNEL_DEFINING_SUFFIXES_BY_ROLE: dict[str, frozenset[str]] = {
+    "SOURCE": _COMMON_TERMINAL_SUFFIXES,
+    "SINK": _COMMON_TERMINAL_SUFFIXES,
+    "SERIES": frozenset({"P_NET", "N_NET", "P_PINS", "N_PINS"}),
+    "REGULATOR": frozenset({
+        "OUT_P_NET", "OUT_N_NET", "OUT_P_PINS", "OUT_N_PINS",
+    }),
+}
+
+_ALL_INHERITABLE_SUFFIXES: frozenset[str] = frozenset().union(
+    *(_KNOWN_SUFFIXES_BY_ROLE.values())
+)
 
 
 # --- SI value parsing ---------------------------------------------------------
@@ -372,6 +420,61 @@ def _channel_key(suffix: str, index: int | None) -> str:
     return f"PDN_{suffix}" if index is None else f"PDN{index}_{suffix}"
 
 
+def _channel_get(
+    params: dict[str, str],
+    suffix: str,
+    index: int | None,
+) -> str | None:
+    """Read ``PDN<n>_<suffix>``, falling back to unindexed ``PDN_<suffix>``.
+
+    Indexed channels inherit unset parameters from the unindexed template.
+    The legacy channel (``index is None``) never falls back — there is no
+    further parent. ``PDN_ROLE`` is *not* read through this helper; use
+    :func:`_effective_role` for role resolution.
+    """
+    direct = _ci_get(params, _channel_key(suffix, index))
+    if direct is not None or index is None:
+        return direct
+    return _ci_get(params, _channel_key(suffix, None))
+
+
+def _materialize_channel_params(
+    params: dict[str, str],
+    index: int | None,
+) -> dict[str, str]:
+    """Copy ``params`` with unindexed templates written into indexed keys.
+
+    For ``index is None`` returns a shallow copy unchanged. For an indexed
+    channel, every inheritable suffix missing as ``PDNn_X`` but present as
+    ``PDN_X`` is copied onto ``PDNn_X`` so downstream helpers that look up
+    exact channel keys (``_ci_get`` / ``_require_value``) see the effective
+    value. Does not invent a ``PDNn_ROLE`` from ``PDN_ROLE``.
+    """
+    out = dict(params)
+    if index is None:
+        return out
+    for suffix in _ALL_INHERITABLE_SUFFIXES:
+        indexed_key = _channel_key(suffix, index)
+        if _ci_get(out, indexed_key) is not None:
+            continue
+        template = _ci_get(params, _channel_key(suffix, None))
+        if template is not None:
+            out[indexed_key] = template
+    return out
+
+
+def _unindexed_has_defining_terminals(
+    params: dict[str, str],
+    role: str,
+) -> bool:
+    """True when the legacy channel carries role-defining terminal params."""
+    suffixes = _CHANNEL_DEFINING_SUFFIXES_BY_ROLE.get(role, frozenset())
+    return any(
+        _ci_get(params, _channel_key(suffix, None)) is not None
+        for suffix in suffixes
+    )
+
+
 def _discover_channel_indices(params: dict[str, str],
                               value_suffix: str) -> list[int | None]:
     """Return channel indices for which a value parameter is present.
@@ -403,10 +506,8 @@ def _channel_label(designator: str, index: int | None) -> str:
     return designator if index is None else f"{designator}#{index}"
 
 
-# Value parameter suffix that makes a channel "present" for each role. A
-# channel exists iff the value param for its (effective) role is set —
-# ``PDN<n>_V`` for SOURCE / REGULATOR, ``PDN<n>_I`` for SINK, ``PDN<n>_R``
-# for SERIES.
+# Value parameter suffix for each role. A channel needs this value (on the
+# channel itself or inherited from the unindexed template) to be present.
 _VALUE_SUFFIX_BY_ROLE: dict[str, str] = {
     "SOURCE": "V", "SINK": "I", "SERIES": "R", "REGULATOR": "V",
 }
@@ -1481,23 +1582,28 @@ def _pads_by_component_all(proj: ExtractedProject) -> dict[int, list[RawPad]]:
 
 def _series_channel_indices(
     comp: PdnParameterSource,
-) -> list[int]:
-    """Indexed SERIES (resistor-like) channel numbers on one parameter source."""
+) -> list[int | None]:
+    """SERIES (resistor-like) channel indices on one parameter source.
+
+    Uses the same discovery / template-only rules as
+    :func:`_resolve_channel_roles` so bridge validation sees the same
+    channels the SERIES parser will emit.
+    """
     part_role = _part_role_default(comp.parameters)
-    return [
-        idx for idx in _discover_channel_indices(comp.parameters, "R")
-        if _effective_role(comp.parameters, idx, part_role)
-        in _RESISTOR_LIKE_ROLES
-    ]
+    scratch = AnnotationResult()
+    grouped = _resolve_channel_roles(
+        comp.parameters, part_role, comp.designator, scratch,
+    )
+    return list(grouped.get("SERIES", []))
 
 
 def _series_channel_has_net_params(
     comp: PdnParameterSource,
-    ch_idx: int,
+    ch_idx: int | None,
 ) -> bool:
     return (
-        _ci_get(comp.parameters, _channel_key("P_PINS", ch_idx)) is not None
-        or _ci_get(comp.parameters, _channel_key("N_PINS", ch_idx)) is not None
+        _channel_get(comp.parameters, "P_PINS", ch_idx) is not None
+        or _channel_get(comp.parameters, "N_PINS", ch_idx) is not None
     )
 
 
@@ -1555,9 +1661,9 @@ def _series_channel_side_net(
 def _resolve_series_channel_nets(
     comp: PdnParameterSource,
     proj: ExtractedProject,
-    ch_idx: int,
+    ch_idx: int | None,
     pcb_idx: int,
-    ch_indices: list[int],
+    ch_indices: list[int | None],
 ) -> tuple[str, str, bool] | None:
     """P/N net names for one SERIES channel on one PCB placement.
 
@@ -1567,8 +1673,8 @@ def _resolve_series_channel_nets(
     Callers that only need the unordered pair (bridge unioning) ignore the flag;
     :func:`_collect_series_upstream_map` must not read power flow out of it.
     """
-    p_net = _ci_get(comp.parameters, _channel_key("P_NET", ch_idx))
-    n_net = _ci_get(comp.parameters, _channel_key("N_NET", ch_idx))
+    p_net = _channel_get(comp.parameters, "P_NET", ch_idx)
+    n_net = _channel_get(comp.parameters, "N_NET", ch_idx)
     if p_net is None and n_net is None and not _series_channel_has_net_params(
         comp, ch_idx,
     ):
@@ -2145,10 +2251,11 @@ def _parse_source(comp, proj, enabled_layers, result,
     specs: list[SourceSpec] = []
     for idx in indices:
         role_diag = f"SOURCE on {_channel_label(comp.designator, idx)}"
-        v = _require_value(comp.parameters, _channel_key("V", idx), role_diag, result)
+        params = _materialize_channel_params(comp.parameters, idx)
+        v = _require_value(params, _channel_key("V", idx), role_diag, result)
         if v is None:
             continue
-        mode = _terminal_mode(comp.parameters, idx, role_diag, result)
+        mode = _terminal_mode(params, idx, role_diag, result)
         if mode is None:
             continue
         for pcb_idx in pcb_indices:
@@ -2159,7 +2266,7 @@ def _parse_source(comp, proj, enabled_layers, result,
             )
             if mode == "single":
                 p = _resolve_single_terminal(
-                    proj, pcb_idx, comp.parameters,
+                    proj, pcb_idx, params,
                     _channel_key("NET", idx), _channel_key("PINS", idx),
                     enabled_layers, inst_diag, result,
                     net_remap=net_remap,
@@ -2174,7 +2281,7 @@ def _parse_source(comp, proj, enabled_layers, result,
                 ))
                 continue
             pair = _resolve_two_terminal(
-                proj, pcb_idx, comp.parameters,
+                proj, pcb_idx, params,
                 _channel_key("P_NET", idx), _channel_key("N_NET", idx),
                 _channel_key("P_PINS", idx), _channel_key("N_PINS", idx),
                 enabled_layers, inst_diag, result,
@@ -2222,14 +2329,15 @@ def _parse_sink(comp, proj, enabled_layers, result,
     specs: list[SinkSpec] = []
     for idx in indices:
         role_diag = f"SINK on {_channel_label(comp.designator, idx)}"
-        i = _require_value(comp.parameters, _channel_key("I", idx), role_diag, result)
+        params = _materialize_channel_params(comp.parameters, idx)
+        i = _require_value(params, _channel_key("I", idx), role_diag, result)
         if i is None:
             continue
-        mode = _terminal_mode(comp.parameters, idx, role_diag, result)
+        mode = _terminal_mode(params, idx, role_diag, result)
         if mode is None:
             continue
         min_v = _optional_value(
-            comp.parameters, _channel_key("MIN_V", idx), role_diag, result,
+            params, _channel_key("MIN_V", idx), role_diag, result,
         )
         for pcb_idx in pcb_indices:
             pcb_des = proj.pcb_components[pcb_idx].designator
@@ -2239,7 +2347,7 @@ def _parse_sink(comp, proj, enabled_layers, result,
             )
             if mode == "single":
                 p = _resolve_single_terminal(
-                    proj, pcb_idx, comp.parameters,
+                    proj, pcb_idx, params,
                     _channel_key("NET", idx), _channel_key("PINS", idx),
                     enabled_layers, inst_diag, result,
                     net_remap=net_remap,
@@ -2255,7 +2363,7 @@ def _parse_sink(comp, proj, enabled_layers, result,
                 ))
                 continue
             pair = _resolve_two_terminal(
-                proj, pcb_idx, comp.parameters,
+                proj, pcb_idx, params,
                 _channel_key("P_NET", idx), _channel_key("N_NET", idx),
                 _channel_key("P_PINS", idx), _channel_key("N_PINS", idx),
                 enabled_layers, inst_diag, result,
@@ -2315,8 +2423,9 @@ def _parse_resistance(comp, proj, enabled_layers, result,
     specs: list[ResistorSpec] = []
     for idx in indices:
         role_diag = f"{role_raw} on {_channel_label(comp.designator, idx)}"
+        params = _materialize_channel_params(comp.parameters, idx)
         r = _require_value(
-            comp.parameters, _channel_key("R", idx), role_diag, result,
+            params, _channel_key("R", idx), role_diag, result,
         )
         if r is None:
             continue
@@ -2332,10 +2441,10 @@ def _parse_resistance(comp, proj, enabled_layers, result,
                 if len(pcb_indices) > 1 else role_diag
             )
             given = any(
-                _ci_get(comp.parameters, _channel_key(k, idx)) is not None
+                _ci_get(params, _channel_key(k, idx)) is not None
                 for k in ("P_NET", "N_NET", "P_PINS", "N_PINS")
             )
-            params = dict(comp.parameters)
+            resolve_params = dict(params)
             if not given:
                 if len(indices) > 1:
                     result.errors.append(
@@ -2357,8 +2466,8 @@ def _parse_resistance(comp, proj, enabled_layers, result,
                         f"{_channel_key('N_PINS', idx)})"
                     )
                     continue
-                params[_channel_key("P_NET", idx)] = inferred[0]
-                params[_channel_key("N_NET", idx)] = inferred[1]
+                resolve_params[_channel_key("P_NET", idx)] = inferred[0]
+                resolve_params[_channel_key("N_NET", idx)] = inferred[1]
                 result.warnings.append(
                     f"{inst_diag}: auto-inferred "
                     f"{_channel_key('P_NET', idx)}={inferred[0]!r}, "
@@ -2366,7 +2475,7 @@ def _parse_resistance(comp, proj, enabled_layers, result,
                     f"from 2-pin connectivity"
                 )
             pair = _resolve_two_terminal(
-                proj, pcb_idx, params,
+                proj, pcb_idx, resolve_params,
                 _channel_key("P_NET", idx), _channel_key("N_NET", idx),
                 _channel_key("P_PINS", idx), _channel_key("N_PINS", idx),
                 enabled_layers, inst_diag, result,
@@ -2417,25 +2526,29 @@ def _collect_supply_voltages_by_net(
         pcb_indices = _pcb_indices_for_source(comp, proj)
         # Both SOURCE and REGULATOR carry PDN<n>_V; switch on each channel's
         # effective role so a SOURCE (or REGULATOR) channel on a mixed-role
-        # part still contributes its nominal rail voltage.
-        for idx in _discover_channel_indices(comp.parameters, "V"):
-            eff = _effective_role(comp.parameters, idx, part_role)
-            if eff not in ("SOURCE", "REGULATOR"):
-                continue
-            v_raw = _ci_get(comp.parameters, _channel_key("V", idx))
-            if v_raw is None or not str(v_raw).strip():
-                continue
-            try:
-                v = parse_si_value(v_raw)
-            except ValueError:
-                continue
-            if eff == "SOURCE":
-                p_net = _ci_get(comp.parameters, _channel_key("P_NET", idx))
-                single_net = _ci_get(comp.parameters, _channel_key("NET", idx))
-                _register(p_net or single_net, v, pcb_indices)
-            else:  # REGULATOR
-                out_net = _ci_get(comp.parameters, _channel_key("OUT_P_NET", idx))
-                _register(out_net, v, pcb_indices)
+        # part still contributes its nominal rail voltage. Template inheritance
+        # goes through :func:`_resolve_channel_roles` + materialize.
+        scratch = AnnotationResult()
+        grouped = _resolve_channel_roles(
+            comp.parameters, part_role, comp.designator, scratch,
+        )
+        for role in ("SOURCE", "REGULATOR"):
+            for idx in grouped.get(role, []):
+                params = _materialize_channel_params(comp.parameters, idx)
+                v_raw = _ci_get(params, _channel_key("V", idx))
+                if v_raw is None or not str(v_raw).strip():
+                    continue
+                try:
+                    v = parse_si_value(v_raw)
+                except ValueError:
+                    continue
+                if role == "SOURCE":
+                    p_net = _ci_get(params, _channel_key("P_NET", idx))
+                    single_net = _ci_get(params, _channel_key("NET", idx))
+                    _register(p_net or single_net, v, pcb_indices)
+                else:  # REGULATOR
+                    out_net = _ci_get(params, _channel_key("OUT_P_NET", idx))
+                    _register(out_net, v, pcb_indices)
     out: dict[str, float] = {}
     for net, voltages in raw.items():
         if len(voltages) == 1:
@@ -2813,12 +2926,13 @@ def _parse_regulator(comp, proj, enabled_layers, result,
     specs: list[RegulatorSpec] = []
     for idx in indices:
         role_diag = f"REGULATOR on {_channel_label(comp.designator, idx)}"
+        params = _materialize_channel_params(comp.parameters, idx)
         v = _require_value(
-            comp.parameters, _channel_key("V", idx), role_diag, result,
+            params, _channel_key("V", idx), role_diag, result,
         )
-        in_p_net = _ci_get(comp.parameters, _channel_key("IN_P_NET", idx))
+        in_p_net = _ci_get(params, _channel_key("IN_P_NET", idx))
         resolved = _resolve_regulator_gain(
-            comp.parameters, idx, v, in_p_net,
+            params, idx, v, in_p_net,
             supply_map, role_diag, result,
             series_graph=series_graph, proj=proj, net_remap=net_remap,
         ) if v is not None else None
@@ -2826,10 +2940,10 @@ def _parse_regulator(comp, proj, enabled_layers, result,
             continue
         g, reg_type, eff, adaptive = resolved
         q_key = _channel_key("QUIESCENT", idx)
-        if _ci_get(comp.parameters, q_key) is None:
+        if _ci_get(params, q_key) is None:
             quiescent = 0.0
         else:
-            iq_raw = _optional_value(comp.parameters, q_key, role_diag, result)
+            iq_raw = _optional_value(params, q_key, role_diag, result)
             if iq_raw is None:
                 # Present but unparseable — error already recorded; skip the
                 # spec rather than building it with a silent quiescent=0.
@@ -2845,7 +2959,7 @@ def _parse_regulator(comp, proj, enabled_layers, result,
                 if len(pcb_indices) > 1 else role_diag
             )
             out = _resolve_two_terminal(
-                proj, pcb_idx, comp.parameters,
+                proj, pcb_idx, params,
                 _channel_key("OUT_P_NET", idx), _channel_key("OUT_N_NET", idx),
                 _channel_key("OUT_P_PINS", idx), _channel_key("OUT_N_PINS", idx),
                 enabled_layers, f"{inst_diag} OUT", result,
@@ -2854,7 +2968,7 @@ def _parse_regulator(comp, proj, enabled_layers, result,
                 schdoc_name=comp.schdoc_name,
             )
             in_ = _resolve_two_terminal(
-                proj, pcb_idx, comp.parameters,
+                proj, pcb_idx, params,
                 _channel_key("IN_P_NET", idx), _channel_key("IN_N_NET", idx),
                 _channel_key("IN_P_PINS", idx), _channel_key("IN_N_PINS", idx),
                 enabled_layers, f"{inst_diag} IN", result,
@@ -3071,23 +3185,25 @@ def _resolve_channel_roles(
 
     Each channel's effective role is its ``PDN<n>_ROLE`` override (validated
     against :data:`VALID_ROLES`) or the part-wide ``part_role``. A channel is
-    *present* iff the value parameter for its effective role is set
-    (``PDN<n>_V`` / ``PDN<n>_I`` / ``PDN<n>_R``). Returns ``{role: [index,
-    …]}`` in discovery order (unindexed first, then ascending index) so a
-    mixed part — e.g. a DAC that SINKs on its supply rail and SOURCEs on its
-    outputs — dispatches each channel to the right per-role parser.
+    *present* when it carries a value param, a channel-defining terminal
+    param, or an indexed ``PDNn_ROLE`` — the value may be inherited from the
+    unindexed template via :func:`_channel_get`. Returns ``{role: [index,
+    …]}`` in discovery order (unindexed first, then ascending index).
 
-    A part that carries a uniform role (the common case) needs no
-    ``PDN<n>_ROLE`` at all: every channel simply inherits ``part_role``, and
-    two sinks stay ``{"SINK": [None, 1]}``. Only channels that diverge from
-    the default carry an override.
+    When indexed channels exist and the unindexed form has no
+    channel-defining terminals for its role, ``None`` is omitted (template-
+    only). A real unindexed channel alongside indexed ones (own terminals)
+    is kept.
 
-    A channel that declares a role (or a cross-role value parameter) but is
-    missing the value parameter its role needs produces an error and is
-    dropped.
+    A channel that declares a role (or a cross-role value / terminal) but is
+    missing the value parameter its role needs — even after template
+    inheritance — produces an error and is dropped.
     """
     candidates: set[int | None] = set()
-    for suffix in set(_VALUE_SUFFIX_BY_ROLE.values()):
+    marking_suffixes: set[str] = set(_VALUE_SUFFIX_BY_ROLE.values())
+    for role_suffixes in _KNOWN_SUFFIXES_BY_ROLE.values():
+        marking_suffixes |= set(role_suffixes)
+    for suffix in marking_suffixes:
         candidates.update(_discover_channel_indices(params, suffix))
     # An indexed PDN<n>_ROLE override also marks its channel present, so a
     # channel that declares a role but omits its value param gets a clear
@@ -3096,6 +3212,14 @@ def _resolve_channel_roles(
     for idx in _discover_channel_indices(params, "ROLE"):
         if idx is not None:
             candidates.add(idx)
+
+    has_indexed = any(idx is not None for idx in candidates)
+    if has_indexed and None in candidates:
+        if part_role in VALID_ROLES and not _unindexed_has_defining_terminals(
+            params, part_role,
+        ):
+            candidates.discard(None)
+
     ordered = sorted(candidates, key=lambda x: (x is not None, x or 0))
 
     grouped: dict[str, list[int | None]] = {}
@@ -3118,12 +3242,19 @@ def _resolve_channel_roles(
                 )
                 continue
             eff = part_role
-        value_key = _channel_key(_VALUE_SUFFIX_BY_ROLE[eff], idx)
-        if _ci_get(params, value_key) is None:
-            result.errors.append(
-                f"{eff} on {_channel_label(designator, idx)}: missing "
-                f"{value_key}"
-            )
+        value_suffix = _VALUE_SUFFIX_BY_ROLE[eff]
+        if _channel_get(params, value_suffix, idx) is None:
+            value_key = _channel_key(value_suffix, idx)
+            if idx is not None:
+                result.errors.append(
+                    f"{eff} on {_channel_label(designator, idx)}: missing "
+                    f"{value_key} (or template {_channel_key(value_suffix, None)})"
+                )
+            else:
+                result.errors.append(
+                    f"{eff} on {_channel_label(designator, idx)}: missing "
+                    f"{value_key}"
+                )
             continue
         grouped.setdefault(eff, []).append(idx)
     return grouped

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -81,8 +81,11 @@ least one indexed channel exists and the unindexed form does **not** carry a
 *complete* terminal set for its role, the legacy ``index=None`` channel is
 *not* emitted — unindexed values are template-only. A complete set means
 both sides of a two-terminal pair (or ``PDN_NET`` / ``PDN_PINS`` for
-single-net SOURCE/SINK); for REGULATOR, both ``OUT_*`` sides (so shared
-``PDN_IN_*`` / ``PDN_N_NET`` / one SERIES side can be templates).
+single-net SOURCE/SINK — those keep a real legacy channel when indexed
+channels also exist); for REGULATOR, both ``OUT_*`` sides (so shared
+``PDN_IN_*`` / ``PDN_N_NET`` / one SERIES side can be templates). Parts
+with only ``PDNn_ROLE`` (no part-wide ``PDN_ROLE``) always treat the
+unindexed form as template-only when indexed channels exist.
 
 Example — dual SERIES paths sharing one resistance::
 
@@ -3261,6 +3264,8 @@ def _resolve_channel_roles(
     When indexed channels exist and the unindexed form lacks a *complete*
     terminal set for its role, ``None`` is omitted (template-only). A real
     unindexed channel alongside indexed ones (complete terminals) is kept.
+    Parts with only ``PDNn_ROLE`` (no part-wide ``PDN_ROLE``) always treat
+    the unindexed form as template-only when indexed channels exist.
 
     A channel that declares a role (or a cross-role value / terminal) but is
     missing the value parameter its role needs — even after template
@@ -3285,9 +3290,13 @@ def _resolve_channel_roles(
 
     has_indexed = any(idx is not None for idx in candidates)
     if has_indexed and None in candidates:
-        if part_role in VALID_ROLES and not _unindexed_has_defining_terminals(
-            params, part_role,
-        ):
+        # Drop legacy when it is only a value/meta template. Indexed-only
+        # parts (no part-wide PDN_ROLE) always treat unindexed params as
+        # templates — otherwise PDN_R / PDN_V would error as "missing
+        # PDN_ROLE" while still emitting the indexed directives.
+        if part_role not in VALID_ROLES:
+            candidates.discard(None)
+        elif not _unindexed_has_defining_terminals(params, part_role):
             candidates.discard(None)
 
     ordered = sorted(candidates, key=lambda x: (x is not None, x or 0))

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -77,11 +77,12 @@ Unindexed template inheritance
 ------------------------------
 Unindexed ``PDN_*`` parameters act as defaults for indexed channels: for
 channel *n*, ``PDNn_X`` wins when set, otherwise ``PDN_X`` is used. When at
-least one indexed channel exists and the unindexed form has **no**
-channel-defining terminals of its own, the legacy ``index=None`` channel is
-*not* emitted — unindexed values are template-only. Channel-defining
-terminals are the P/N (or single-net) nets/pins for SOURCE/SINK/SERIES, and
-**OUT_*** only for REGULATOR (so shared ``PDN_IN_*`` can be a template).
+least one indexed channel exists and the unindexed form does **not** carry a
+*complete* terminal set for its role, the legacy ``index=None`` channel is
+*not* emitted — unindexed values are template-only. A complete set means
+both sides of a two-terminal pair (or ``PDN_NET`` / ``PDN_PINS`` for
+single-net SOURCE/SINK); for REGULATOR, both ``OUT_*`` sides (so shared
+``PDN_IN_*`` / ``PDN_N_NET`` / one SERIES side can be templates).
 
 Example — dual SERIES paths sharing one resistance::
 
@@ -89,6 +90,14 @@ Example — dual SERIES paths sharing one resistance::
     PDN_R      = 0.05
     PDN1_P_NET = VIN_A     PDN1_N_NET = VOUT_A
     PDN2_P_NET = VIN_B     PDN2_N_NET = VOUT_B
+
+Example — dual SERIES with a shared P-side net::
+
+    PDN_ROLE   = SERIES
+    PDN_R      = 0.05
+    PDN_P_NET  = VIN
+    PDN1_N_NET = VOUT_A
+    PDN2_N_NET = VOUT_B
 
 Example — dual REGULATOR outputs sharing Vin / type / voltage::
 
@@ -100,8 +109,9 @@ Example — dual REGULATOR outputs sharing Vin / type / voltage::
     PDN2_OUT_P_NET     = GND       PDN2_OUT_N_NET = VOUT_N
 
 The classic pattern with a real unindexed channel *plus* indexed ones
-(``PDN_I`` + ``PDN_P_NET`` alongside ``PDN1_I`` + …) is unchanged: unindexed
-keeps its own terminals, so it remains a directive.
+(``PDN_I`` + ``PDN_P_NET`` + ``PDN_N_NET`` alongside ``PDN1_I`` + …) is
+unchanged: unindexed keeps a complete terminal pair, so it remains a
+directive.
 
 Values support SI prefixes and units (``500mA``, ``3V3``, ``1.5k``, ``0.1``).
 
@@ -220,18 +230,6 @@ _KNOWN_SUFFIXES_BY_ROLE: dict[str, frozenset[str]] = {
         "IN_P_NET", "IN_N_NET", "IN_P_PINS", "IN_N_PINS",
     }),
     "SERIES": frozenset({"R", "P_NET", "N_NET", "P_PINS", "N_PINS"}),
-}
-
-# Terminals that make the *unindexed* channel a real directive alongside
-# indexed ones (as opposed to template-only defaults). REGULATOR channels
-# are defined by their outputs — shared IN_* may stay on PDN_IN_*.
-_CHANNEL_DEFINING_SUFFIXES_BY_ROLE: dict[str, frozenset[str]] = {
-    "SOURCE": _COMMON_TERMINAL_SUFFIXES,
-    "SINK": _COMMON_TERMINAL_SUFFIXES,
-    "SERIES": frozenset({"P_NET", "N_NET", "P_PINS", "N_PINS"}),
-    "REGULATOR": frozenset({
-        "OUT_P_NET", "OUT_N_NET", "OUT_P_PINS", "OUT_N_PINS",
-    }),
 }
 
 _ALL_INHERITABLE_SUFFIXES: frozenset[str] = frozenset().union(
@@ -467,12 +465,73 @@ def _unindexed_has_defining_terminals(
     params: dict[str, str],
     role: str,
 ) -> bool:
-    """True when the legacy channel carries role-defining terminal params."""
-    suffixes = _CHANNEL_DEFINING_SUFFIXES_BY_ROLE.get(role, frozenset())
-    return any(
-        _ci_get(params, _channel_key(suffix, None)) is not None
-        for suffix in suffixes
-    )
+    """True when the legacy channel has a *complete* terminal set for ``role``.
+
+    A lone shared side (``PDN_N_NET``, ``PDN_P_NET``, ``PDN_IN_*``) is not
+    enough — those stay templates when indexed channels exist. SOURCE/SINK
+    may also be complete via single-net ``PDN_NET`` / ``PDN_PINS``.
+    """
+    if role in ("SOURCE", "SINK"):
+        if (
+            _ci_get(params, _channel_key("NET", None)) is not None
+            or _ci_get(params, _channel_key("PINS", None)) is not None
+        ):
+            return True
+        has_p = (
+            _ci_get(params, _channel_key("P_NET", None)) is not None
+            or _ci_get(params, _channel_key("P_PINS", None)) is not None
+        )
+        has_n = (
+            _ci_get(params, _channel_key("N_NET", None)) is not None
+            or _ci_get(params, _channel_key("N_PINS", None)) is not None
+        )
+        return has_p and has_n
+    if role == "SERIES":
+        has_p = (
+            _ci_get(params, _channel_key("P_NET", None)) is not None
+            or _ci_get(params, _channel_key("P_PINS", None)) is not None
+        )
+        has_n = (
+            _ci_get(params, _channel_key("N_NET", None)) is not None
+            or _ci_get(params, _channel_key("N_PINS", None)) is not None
+        )
+        return has_p and has_n
+    if role == "REGULATOR":
+        has_out_p = (
+            _ci_get(params, _channel_key("OUT_P_NET", None)) is not None
+            or _ci_get(params, _channel_key("OUT_P_PINS", None)) is not None
+        )
+        has_out_n = (
+            _ci_get(params, _channel_key("OUT_N_NET", None)) is not None
+            or _ci_get(params, _channel_key("OUT_N_PINS", None)) is not None
+        )
+        return has_out_p and has_out_n
+    return False
+
+
+def _active_roles_for_discovery(
+    params: dict[str, str],
+    part_role: str,
+) -> set[str]:
+    """Roles whose value/terminal suffixes may mark a channel present.
+
+    Uses the part-wide default plus every valid ``PDNn_ROLE`` override so
+    mixed-role parts still discover SOURCE and SINK channels, while a
+    leftover ``PDN1_R`` on a SINK-only part does not invent a phantom channel.
+    """
+    roles: set[str] = set()
+    if part_role in VALID_ROLES:
+        roles.add(part_role)
+    for idx in _discover_channel_indices(params, "ROLE"):
+        if idx is None:
+            continue
+        raw = _ci_get(params, _channel_key("ROLE", idx))
+        if raw is None:
+            continue
+        role = raw.strip().upper()
+        if role in VALID_ROLES:
+            roles.add(role)
+    return roles
 
 
 def _discover_channel_indices(params: dict[str, str],
@@ -1593,6 +1652,7 @@ def _series_channel_indices(
     scratch = AnnotationResult()
     grouped = _resolve_channel_roles(
         comp.parameters, part_role, comp.designator, scratch,
+        report_errors=False,
     )
     return list(grouped.get("SERIES", []))
 
@@ -2531,6 +2591,7 @@ def _collect_supply_voltages_by_net(
         scratch = AnnotationResult()
         grouped = _resolve_channel_roles(
             comp.parameters, part_role, comp.designator, scratch,
+            report_errors=False,
         )
         for role in ("SOURCE", "REGULATOR"):
             for idx in grouped.get(role, []):
@@ -3180,29 +3241,38 @@ def _resolve_channel_roles(
     part_role: str,
     designator: str,
     result: AnnotationResult,
+    *,
+    report_errors: bool = True,
 ) -> dict[str, list[int | None]]:
     """Group a part's present channels by effective role.
 
     Each channel's effective role is its ``PDN<n>_ROLE`` override (validated
     against :data:`VALID_ROLES`) or the part-wide ``part_role``. A channel is
-    *present* when it carries a value param, a channel-defining terminal
-    param, or an indexed ``PDNn_ROLE`` — the value may be inherited from the
-    unindexed template via :func:`_channel_get`. Returns ``{role: [index,
-    …]}`` in discovery order (unindexed first, then ascending index).
+    *present* when it carries a value param, a terminal param for an *active*
+    role on the part, or an indexed ``PDNn_ROLE`` — the value may be
+    inherited from the unindexed template via :func:`_channel_get`. Returns
+    ``{role: [index, …]}`` in discovery order (unindexed first, then
+    ascending index).
 
-    When indexed channels exist and the unindexed form has no
-    channel-defining terminals for its role, ``None`` is omitted (template-
-    only). A real unindexed channel alongside indexed ones (own terminals)
-    is kept.
+    Discovery is scoped to :func:`_active_roles_for_discovery` so a leftover
+    cross-role value (e.g. ``PDN1_R`` on a SINK-only part) does not invent a
+    phantom channel.
+
+    When indexed channels exist and the unindexed form lacks a *complete*
+    terminal set for its role, ``None`` is omitted (template-only). A real
+    unindexed channel alongside indexed ones (complete terminals) is kept.
 
     A channel that declares a role (or a cross-role value / terminal) but is
     missing the value parameter its role needs — even after template
-    inheritance — produces an error and is dropped.
+    inheritance — produces an error and is dropped when ``report_errors`` is
+    true; dry-run callers (bridge / supply maps) pass ``report_errors=False``
+    to omit invalid channels quietly.
     """
     candidates: set[int | None] = set()
-    marking_suffixes: set[str] = set(_VALUE_SUFFIX_BY_ROLE.values())
-    for role_suffixes in _KNOWN_SUFFIXES_BY_ROLE.values():
-        marking_suffixes |= set(role_suffixes)
+    marking_suffixes: set[str] = set()
+    for role in _active_roles_for_discovery(params, part_role):
+        marking_suffixes.add(_VALUE_SUFFIX_BY_ROLE[role])
+        marking_suffixes |= set(_KNOWN_SUFFIXES_BY_ROLE[role])
     for suffix in marking_suffixes:
         candidates.update(_discover_channel_indices(params, suffix))
     # An indexed PDN<n>_ROLE override also marks its channel present, so a
@@ -3228,33 +3298,37 @@ def _resolve_channel_roles(
         if override_raw is not None:
             eff = override_raw.strip().upper()
             if eff not in VALID_ROLES:
-                result.errors.append(
-                    f"{_channel_label(designator, idx)}: unknown "
-                    f"{_channel_key('ROLE', idx)}={override_raw!r} — must be "
-                    f"one of {sorted(VALID_ROLES)}"
-                )
+                if report_errors:
+                    result.errors.append(
+                        f"{_channel_label(designator, idx)}: unknown "
+                        f"{_channel_key('ROLE', idx)}={override_raw!r} — must be "
+                        f"one of {sorted(VALID_ROLES)}"
+                    )
                 continue
         else:
             if not part_role:
-                result.errors.append(
-                    f"{_channel_label(designator, idx)}: missing "
-                    f"{_channel_key('ROLE', idx)} (no part-wide PDN_ROLE)"
-                )
+                if report_errors:
+                    result.errors.append(
+                        f"{_channel_label(designator, idx)}: missing "
+                        f"{_channel_key('ROLE', idx)} (no part-wide PDN_ROLE)"
+                    )
                 continue
             eff = part_role
         value_suffix = _VALUE_SUFFIX_BY_ROLE[eff]
         if _channel_get(params, value_suffix, idx) is None:
-            value_key = _channel_key(value_suffix, idx)
-            if idx is not None:
-                result.errors.append(
-                    f"{eff} on {_channel_label(designator, idx)}: missing "
-                    f"{value_key} (or template {_channel_key(value_suffix, None)})"
-                )
-            else:
-                result.errors.append(
-                    f"{eff} on {_channel_label(designator, idx)}: missing "
-                    f"{value_key}"
-                )
+            if report_errors:
+                value_key = _channel_key(value_suffix, idx)
+                if idx is not None:
+                    result.errors.append(
+                        f"{eff} on {_channel_label(designator, idx)}: missing "
+                        f"{value_key} (or template "
+                        f"{_channel_key(value_suffix, None)})"
+                    )
+                else:
+                    result.errors.append(
+                        f"{eff} on {_channel_label(designator, idx)}: missing "
+                        f"{value_key}"
+                    )
             continue
         grouped.setdefault(eff, []).append(idx)
     return grouped

--- a/scripts/launch-combined-gui.ps1
+++ b/scripts/launch-combined-gui.ps1
@@ -1,0 +1,122 @@
+<#
+.SYNOPSIS
+    Check out origin/test/combined and launch the GUI (Altium bootstrap path).
+
+.DESCRIPTION
+    Used by Run_FYPA.ps1 after clone/uv sync. Fetches the shared combined branch,
+    hard-resets to the remote tip, and runs Launch_GUI.py (or FYPA.py gui).
+
+    Does not merge feature branches. Maintain the shared branch with:
+      pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+
+.PARAMETER PrjPcb
+    Path to the focused .PrjPcb.
+
+.PARAMETER LaunchGui
+    Absolute path to Launch_GUI.py (outside the disposable clone). Optional.
+
+.PARAMETER Remote
+    Remote name. Default: origin
+
+.PARAMETER TestBranch
+    Combined branch name. Default: test/combined
+
+.PARAMETER RepoRoot
+    FYPA repo root. Default: parent of scripts/.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $PrjPcb,
+
+    [string] $LaunchGui,
+
+    [string] $Remote = "origin",
+
+    [string] $TestBranch = "test/combined",
+
+    [string] $RepoRoot
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $RepoRoot) {
+    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+}
+else {
+    $RepoRoot = (Resolve-Path -LiteralPath $RepoRoot).Path
+}
+Set-Location $RepoRoot
+
+if (-not (Test-Path -LiteralPath (Join-Path $RepoRoot 'FYPA.py'))) {
+    throw "FYPA.py not found in $RepoRoot"
+}
+
+if (-not (Test-Path -LiteralPath $PrjPcb)) {
+    throw "PrjPcb not found: $PrjPcb"
+}
+$PrjPcbPath = (Resolve-Path -LiteralPath $PrjPcb).Path
+
+function Invoke-GitLogged {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs
+    )
+    Write-Host (">> git {0}" -f ($GitArgs -join ' ')) -ForegroundColor DarkGray
+    & git.exe @GitArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($GitArgs -join ' ') failed (exit $LASTEXITCODE)"
+    }
+}
+
+$RemoteRef = "$Remote/$TestBranch"
+Write-Host "==> Fetch $Remote $TestBranch"
+& git.exe fetch $Remote $TestBranch 2>&1 | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning "git fetch $Remote $TestBranch failed; trying existing $RemoteRef"
+}
+
+& git.exe rev-parse --verify "$RemoteRef^{commit}" 2>$null | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    throw @"
+$RemoteRef not found.
+Publish the shared branch first (on a maintainer machine or via the team/local Action):
+
+  pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+"@
+}
+
+$Tip = ([string](& git.exe rev-parse --verify "$RemoteRef^{commit}")).Trim()
+Write-Host "==> Checkout $TestBranch @ $Tip"
+Invoke-GitLogged @('checkout', '-B', $TestBranch, $RemoteRef)
+Invoke-GitLogged @('reset', '--hard', $RemoteRef)
+
+Write-Host "==> uv sync (on $TestBranch)"
+& uv sync
+if ($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+    $venvPython = Join-Path $RepoRoot '.venv\Scripts\python.exe'
+    if (Test-Path -LiteralPath $venvPython) {
+        Write-Warning "uv sync failed; reusing existing .venv"
+    }
+    else {
+        throw "uv sync failed (exit $LASTEXITCODE)"
+    }
+}
+
+Write-Host "==> Launch GUI"
+$env:PYTHONUNBUFFERED = '1'
+if ($LaunchGui -and (Test-Path -LiteralPath $LaunchGui)) {
+    Write-Host "    Using Launch_GUI.py (File > Import style, GUI first)"
+    & uv run --extra spacemouse python $LaunchGui $PrjPcbPath
+}
+else {
+    if ($LaunchGui) {
+        Write-Warning "Launch_GUI.py missing at $LaunchGui — falling back to FYPA.py gui"
+    }
+    & uv run --extra spacemouse FYPA.py gui $PrjPcbPath
+}
+
+if ($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}

--- a/scripts/maintain-test-combined.ps1
+++ b/scripts/maintain-test-combined.ps1
@@ -4,8 +4,13 @@
 
 .DESCRIPTION
     Reads team/test-combined.json (team/local by default), fetches base + extras
-    from origin, recreates the disposable test branch using remote tips only,
+    from origin, updates the disposable test branch using remote tips only,
     and optionally force-pushes with lease.
+
+    Default (no -Rebuild): if origin/test/combined exists, check it out and
+    merge only extras whose tips are not already ancestors of HEAD
+    (incremental — keeps prior conflict resolutions). Pass -Rebuild for a
+    clean recreate from baseBranch (expect conflicts again).
 
     Local unpushed commits are never merged — tips are always origin/<branch>.
     Missing remote extras abort the run.
@@ -26,20 +31,34 @@
     Remote name. Default: origin
 
 .PARAMETER Rebuild
-    Force recreate even when the stamp on the existing local test branch matches.
+    Delete/recreate from baseBranch even when a published tip exists.
+    Prefer incremental updates without this switch.
+
+.PARAMETER Abort
+    Abort a stuck merge: hard-reset local test/combined to origin/test/combined
+    (if present), clear merge/rebase state, and check out the starting branch.
+    Does not push.
 
 .PARAMETER Push
-    After a successful rebuild (or reuse), push --force-with-lease to Remote.
+    After a successful update (or reuse), push --force-with-lease to Remote.
 
 .PARAMETER BaseBranch / TestBranch / ExtraFeatureBranches / DeleteTestBranchFirst
     Override individual config fields.
 
 .EXAMPLE
-    pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+    pwsh scripts/maintain-test-combined.ps1 -Push
+
+    Incremental update from origin/test/combined, then publish.
 
 .EXAMPLE
-    pwsh scripts/maintain-test-combined.ps1
-    Build locally without pushing (e.g. to resolve merge conflicts).
+    pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+
+    Clean recreate from main (resolves conflicts from scratch).
+
+.EXAMPLE
+    pwsh scripts/maintain-test-combined.ps1 -Abort
+
+    Escape a mid-merge worktree and return to the previous branch.
 #>
 
 [CmdletBinding()]
@@ -48,6 +67,7 @@ param(
     [string] $TeamConfigRef = "team/local",
     [string] $Remote = "origin",
     [switch] $Rebuild,
+    [switch] $Abort,
     [switch] $Push,
     [string] $BaseBranch,
     [string] $TestBranch,
@@ -119,6 +139,15 @@ function Invoke-GitSoft {
 function Test-GitRef {
     param([string] $Ref)
     & git show-ref --verify --quiet $Ref
+    return $LASTEXITCODE -eq 0
+}
+
+function Test-GitAncestor {
+    param(
+        [string] $Ancestor,
+        [string] $Descendant
+    )
+    & git.exe merge-base --is-ancestor $Ancestor $Descendant 2>$null | Out-Null
     return $LASTEXITCODE -eq 0
 }
 
@@ -397,8 +426,76 @@ function Read-TestCombinedConfig {
     return $Config
 }
 
+function Clear-TestCombinedUpstream {
+    param([string] $Branch)
+    # Creating from origin/main sets upstream to main — confusing ("ahead of main").
+    & git.exe branch --unset-upstream $Branch 2>$null | Out-Null
+}
+
 if (-not (Test-Path "FYPA.py")) {
     throw "FYPA.py not found in $RepoRoot — run this script from the FYPA repo."
+}
+
+$ReturnBranch = Get-CurrentBranch
+if (-not $ReturnBranch) {
+    throw "Could not determine the current branch (detached HEAD?). Check out a branch first."
+}
+
+if ($Abort) {
+    $AbortTestBranch = if ($PSBoundParameters.ContainsKey("TestBranch") -and $TestBranch) {
+        $TestBranch
+    }
+    else {
+        "test/combined"
+    }
+    Write-Host "==> Abort: clear merge/rebase state and reset $AbortTestBranch"
+    $onAbortBranch = ((Get-CurrentBranch) -eq $AbortTestBranch)
+    if ($onAbortBranch) {
+        & git merge --abort 2>$null | Out-Null
+        & git rebase --abort 2>$null | Out-Null
+        & git reset --merge 2>$null | Out-Null
+    }
+    try {
+        Sync-RemoteBranches -RemoteName $Remote -Branches @($AbortTestBranch)
+    }
+    catch {
+        Write-Warning "Fetch $Remote/$AbortTestBranch failed — using existing refs if present."
+    }
+    $RemoteAbortRef = "$Remote/$AbortTestBranch"
+    if (Test-GitRef "refs/remotes/$Remote/$AbortTestBranch") {
+        if ($onAbortBranch) {
+            Invoke-Git @('reset', '--hard', $RemoteAbortRef)
+            Clear-TestCombinedUpstream -Branch $AbortTestBranch
+            Write-Host "==> $AbortTestBranch reset to $RemoteAbortRef"
+            if ($ReturnBranch -ne $AbortTestBranch) {
+                Write-Host "==> Return to $ReturnBranch"
+                Restore-DevBranch -Branch $ReturnBranch
+            }
+        }
+        else {
+            # Update the local branch tip without checking it out (worktree may be dirty).
+            if (Test-GitRef "refs/heads/$AbortTestBranch") {
+                Invoke-Git @('branch', '-f', $AbortTestBranch, $RemoteAbortRef)
+            }
+            else {
+                Invoke-Git @('branch', $AbortTestBranch, $RemoteAbortRef)
+            }
+            Clear-TestCombinedUpstream -Branch $AbortTestBranch
+            Write-Host "==> Local $AbortTestBranch forced to $RemoteAbortRef (no checkout)"
+        }
+    }
+    elseif ($onAbortBranch) {
+        Write-Host "==> No $RemoteAbortRef — checking out $ReturnBranch and deleting local tip"
+        Restore-DevBranch -Branch $ReturnBranch
+        if (Test-GitRef "refs/heads/$AbortTestBranch") {
+            Invoke-Git @('branch', '-D', $AbortTestBranch)
+        }
+    }
+    else {
+        Write-Host "==> No local/remote $AbortTestBranch to reset"
+    }
+    Write-Host "==> Abort done — on $(Get-CurrentBranch)"
+    exit 0
 }
 
 # Soft-fetch team config ref so git show origin/team/local:... works.
@@ -439,11 +536,6 @@ if (-not $TestBranch) { throw "testBranch is empty." }
 
 Write-Host "==> Branch source: $Remote tips only (no local-ahead merge)"
 
-$ReturnBranch = Get-CurrentBranch
-if (-not $ReturnBranch) {
-    throw "Could not determine the current branch (detached HEAD?). Check out a branch first."
-}
-
 Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
 # test/combined may not exist yet on first publish — soft-fetch only.
 try {
@@ -477,6 +569,7 @@ foreach ($ExtraBranch in $ExtraFeatureBranches) {
     $ResolvedExtras.Add(@{
         Branch   = $ExtraTarget.Branch
         MergeRef = $ExtraTarget.MergeRef
+        Sha      = $ExtraTarget.Sha
     })
 }
 
@@ -500,23 +593,34 @@ $DesiredStamp = ConvertTo-NormalizedStamp (Get-InputStamp `
     -BaseSha $BaseSha `
     -ExtraPairs @($ExtraStampPairs))
 
-$TestBranchExists = Test-GitRef "refs/heads/$TestBranch"
-$ExistingTip = if ($TestBranchExists) { Get-RefSha -Ref $TestBranch } else { $null }
-$ExistingStamp = ConvertTo-NormalizedStamp (Get-TestCombinedStamp -Commit $ExistingTip)
+$RemoteTestRef = "$Remote/$TestBranch"
+$HasRemoteTest = Test-GitRef "refs/remotes/$Remote/$TestBranch"
+$RemoteTestSha = if ($HasRemoteTest) { Get-RefSha -Ref $RemoteTestRef } else { $null }
+$RemoteStamp = ConvertTo-NormalizedStamp (Get-TestCombinedStamp -Commit $RemoteTestSha)
+
 $CanReuse = (
     -not $Rebuild -and
-    $TestBranchExists -and
-    $ExistingStamp -and
-    ($ExistingStamp -eq $DesiredStamp)
+    $RemoteStamp -and
+    ($RemoteStamp -eq $DesiredStamp)
 )
 
-if (-not $CanReuse -and $TestBranchExists -and -not $Rebuild) {
-    if (-not $ExistingStamp) {
-        Write-Host "==> No reuse stamp on $TestBranch — will rebuild"
-    }
-    else {
-        Write-Host "==> Stamp mismatch on $TestBranch — will rebuild"
-    }
+$UseIncremental = (
+    -not $Rebuild -and
+    -not $CanReuse -and
+    $HasRemoteTest
+)
+
+if ($CanReuse) {
+    Write-Host "==> Stamp matches $RemoteTestRef — reuse"
+}
+elseif ($UseIncremental) {
+    Write-Host "==> Incremental update from $RemoteTestRef (pass -Rebuild for clean recreate)"
+}
+elseif ($Rebuild) {
+    Write-Host "==> -Rebuild: clean recreate from $BaseRef"
+}
+else {
+    Write-Host "==> No $RemoteTestRef yet — first create from $BaseRef"
 }
 
 $IgnoredPaths = @('.gitignore', 'FYPA.code-workspace')
@@ -531,6 +635,7 @@ if ($BlockingStatus.Count -gt 0) {
     throw @"
 Uncommitted changes detected on '$ReturnBranch'.
 Commit or stash them before running maintain-test-combined.
+To escape a stuck merge: pwsh scripts/maintain-test-combined.ps1 -Abort
 "@
 }
 
@@ -538,22 +643,36 @@ $Returned = $false
 $LeaveOnConflict = $false
 try {
     if ($CanReuse) {
-        Write-Host "==> Reuse $TestBranch (inputs unchanged)"
-        if ((Get-CurrentBranch) -ne $TestBranch) {
-            Invoke-Git @('checkout', $TestBranch)
+        Write-Host "==> Checkout $TestBranch @ $RemoteTestRef"
+        Invoke-Git @('checkout', '-B', $TestBranch, $RemoteTestRef)
+        Invoke-Git @('reset', '--hard', $RemoteTestRef)
+        Clear-TestCombinedUpstream -Branch $TestBranch
+    }
+    elseif ($UseIncremental) {
+        Write-Host "==> Checkout $TestBranch @ $RemoteTestRef"
+        Invoke-Git @('checkout', '-B', $TestBranch, $RemoteTestRef)
+        Invoke-Git @('reset', '--hard', $RemoteTestRef)
+        Clear-TestCombinedUpstream -Branch $TestBranch
+
+        $HeadSha = Get-RefSha -Ref 'HEAD'
+        foreach ($Extra in $ResolvedExtras) {
+            if (Test-GitAncestor -Ancestor $Extra.Sha -Descendant $HeadSha) {
+                Write-Host "==> Skip $($Extra.Branch) (already in $TestBranch)"
+                continue
+            }
+            Write-Host "==> Merge $($Extra.MergeRef) into $TestBranch"
+            Merge-FeatureBranch -MergeRef $Extra.MergeRef -ExtraBranch $Extra.Branch -IgnoredPaths $IgnoredPaths
+            $HeadSha = Get-RefSha -Ref 'HEAD'
+        }
+
+        $NewTip = Get-RefSha -Ref 'HEAD'
+        if ($NewTip) {
+            Set-TestCombinedStamp -Commit $NewTip -Stamp $DesiredStamp
+            Write-Host "==> Stamp written for $TestBranch"
         }
     }
     else {
-        if ($Rebuild) {
-            Write-Host "==> Rebuild requested — recreating $TestBranch"
-        }
-        elseif (-not $TestBranchExists) {
-            Write-Host "==> $TestBranch missing — creating from $BaseRef"
-        }
-        else {
-            Write-Host "==> Inputs changed — recreating $TestBranch from $BaseRef"
-        }
-
+        # Full recreate from base (first publish or -Rebuild).
         if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
             Write-Host "==> Delete $TestBranch"
             if ((Get-CurrentBranch) -eq $TestBranch) {
@@ -571,6 +690,7 @@ try {
             Write-Host "==> Create $TestBranch from $BaseRef"
             Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
         }
+        Clear-TestCombinedUpstream -Branch $TestBranch
 
         foreach ($Extra in $ResolvedExtras) {
             Write-Host "==> Merge $($Extra.MergeRef) into $TestBranch"
@@ -598,17 +718,21 @@ try {
 }
 catch {
     $msg = "$_"
-    if ($msg -match 'Merge conflict' -and (Test-MergeInProgress)) {
+    if ($msg -match 'Merge conflict' -and (
+            (Test-MergeInProgress) -or ((Get-UnmergedPaths).Count -gt 0)
+        )) {
         $LeaveOnConflict = $true
         Write-Host @"
 
-==> Merge conflict — staying on $TestBranch with the conflict in place.
-Resolve, commit, then:
+==> Merge conflict — still on $TestBranch (do not git switch away).
 
-  git notes --ref=test-combined add -f -m '<stamp>' HEAD   # optional
-  git push --force-with-lease $Remote HEAD:refs/heads/$TestBranch
+Finish:
+  git add -u
+  git commit --no-edit
+  pwsh scripts/maintain-test-combined.ps1 -Push
 
-Or re-run: pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+Abort back to published tip + previous branch:
+  pwsh scripts/maintain-test-combined.ps1 -Abort
 "@
     }
     elseif ((Get-CurrentBranch) -ne $ReturnBranch) {

--- a/scripts/maintain-test-combined.ps1
+++ b/scripts/maintain-test-combined.ps1
@@ -444,7 +444,14 @@ if (-not $ReturnBranch) {
     throw "Could not determine the current branch (detached HEAD?). Check out a branch first."
 }
 
-Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches + @($TestBranch))
+Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
+# test/combined may not exist yet on first publish — soft-fetch only.
+try {
+    Sync-RemoteBranches -RemoteName $Remote -Branches @($TestBranch)
+}
+catch {
+    Write-Host "==> $Remote/$TestBranch not fetched yet (ok on first publish)"
+}
 
 $BaseTarget = Resolve-RemoteTip -Branch $BaseBranch -RemoteName $Remote
 if (-not $BaseTarget) {

--- a/scripts/maintain-test-combined.ps1
+++ b/scripts/maintain-test-combined.ps1
@@ -535,6 +535,7 @@ Commit or stash them before running maintain-test-combined.
 }
 
 $Returned = $false
+$LeaveOnConflict = $false
 try {
     if ($CanReuse) {
         Write-Host "==> Reuse $TestBranch (inputs unchanged)"
@@ -596,22 +597,40 @@ try {
     }
 }
 catch {
-    if ((Get-CurrentBranch) -ne $ReturnBranch) {
+    $msg = "$_"
+    if ($msg -match 'Merge conflict' -and (Test-MergeInProgress)) {
+        $LeaveOnConflict = $true
+        Write-Host @"
+
+==> Merge conflict — staying on $TestBranch with the conflict in place.
+Resolve, commit, then:
+
+  git notes --ref=test-combined add -f -m '<stamp>' HEAD   # optional
+  git push --force-with-lease $Remote HEAD:refs/heads/$TestBranch
+
+Or re-run: pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+"@
+    }
+    elseif ((Get-CurrentBranch) -ne $ReturnBranch) {
         & git merge --abort 2>$null | Out-Null
         & git rebase --abort 2>$null | Out-Null
     }
     throw
 }
 finally {
-    $Current = Get-CurrentBranch
-    if ($Current -ne $ReturnBranch) {
-        Write-Host "==> Return to $ReturnBranch"
-        Restore-DevBranch -Branch $ReturnBranch
-        $Returned = $true
+    if (-not $LeaveOnConflict) {
+        $Current = Get-CurrentBranch
+        if ($Current -ne $ReturnBranch) {
+            Write-Host "==> Return to $ReturnBranch"
+            Restore-DevBranch -Branch $ReturnBranch
+            $Returned = $true
+        }
     }
 }
 
-if (-not $Returned) {
-    Write-Host "==> Return to $ReturnBranch"
-    Restore-DevBranch -Branch $ReturnBranch
+if (-not $LeaveOnConflict) {
+    if (-not $Returned) {
+        Write-Host "==> Return to $ReturnBranch"
+        Restore-DevBranch -Branch $ReturnBranch
+    }
 }

--- a/scripts/maintain-test-combined.ps1
+++ b/scripts/maintain-test-combined.ps1
@@ -1,0 +1,610 @@
+<#
+.SYNOPSIS
+    Rebuild origin/test/combined from team/local config and optionally push.
+
+.DESCRIPTION
+    Reads team/test-combined.json (team/local by default), fetches base + extras
+    from origin, recreates the disposable test branch using remote tips only,
+    and optionally force-pushes with lease.
+
+    Local unpushed commits are never merged — tips are always origin/<branch>.
+    Missing remote extras abort the run.
+
+    Config resolution (first match wins):
+      scripts/test-combined.json          local override (gitignored)
+      team/test-combined.json             working tree
+      team/local:team/test-combined.json  from team/local via git show
+      scripts/test-combined.example.json  fallback
+
+.PARAMETER ConfigPath
+    Path or ref:path to a JSON config. Overrides the default search order.
+
+.PARAMETER TeamConfigRef
+    Git ref for team/test-combined.json via git show. Default: team/local
+
+.PARAMETER Remote
+    Remote name. Default: origin
+
+.PARAMETER Rebuild
+    Force recreate even when the stamp on the existing local test branch matches.
+
+.PARAMETER Push
+    After a successful rebuild (or reuse), push --force-with-lease to Remote.
+
+.PARAMETER BaseBranch / TestBranch / ExtraFeatureBranches / DeleteTestBranchFirst
+    Override individual config fields.
+
+.EXAMPLE
+    pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+
+.EXAMPLE
+    pwsh scripts/maintain-test-combined.ps1
+    Build locally without pushing (e.g. to resolve merge conflicts).
+#>
+
+[CmdletBinding()]
+param(
+    [string] $ConfigPath,
+    [string] $TeamConfigRef = "team/local",
+    [string] $Remote = "origin",
+    [switch] $Rebuild,
+    [switch] $Push,
+    [string] $BaseBranch,
+    [string] $TestBranch,
+    [string[]] $ExtraFeatureBranches,
+    [bool] $DeleteTestBranchFirst
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+Set-Location $RepoRoot
+
+function Invoke-GitCore {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs,
+        [switch] $Quiet
+    )
+    if ($GitArgs.Count -eq 0) {
+        throw "Invoke-GitCore: no arguments"
+    }
+
+    $Output = @(& git.exe @GitArgs 2>&1)
+    $ExitCode = $LASTEXITCODE
+
+    if (-not $Quiet) {
+        foreach ($Line in $Output) {
+            if ($Line -is [System.Management.Automation.ErrorRecord]) {
+                Write-Warning $Line.ToString()
+            }
+            else {
+                Write-Host $Line
+            }
+        }
+    }
+
+    $Stdout = @(
+        $Output |
+            Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] } |
+            ForEach-Object { [string] $_ }
+    )
+
+    return @{
+        ExitCode = $ExitCode
+        Output   = $Stdout
+    }
+}
+
+function Invoke-Git {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs
+    )
+    $Result = Invoke-GitCore @GitArgs
+    if ($Result.ExitCode -ne 0) {
+        throw "git $($GitArgs -join ' ') failed (exit $($Result.ExitCode))"
+    }
+    return $Result.Output
+}
+
+function Invoke-GitSoft {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs
+    )
+    return (Invoke-GitCore @GitArgs).ExitCode
+}
+
+function Test-GitRef {
+    param([string] $Ref)
+    & git show-ref --verify --quiet $Ref
+    return $LASTEXITCODE -eq 0
+}
+
+function Get-RefSha {
+    param([string] $Ref)
+    $Sha = ([string] (& git.exe rev-parse --verify "$Ref^{commit}" 2>$null)).Trim()
+    if ($LASTEXITCODE -ne 0 -or -not $Sha) {
+        return $null
+    }
+    return $Sha
+}
+
+function Sync-RemoteBranches {
+    param(
+        [string] $RemoteName,
+        [string[]] $Branches
+    )
+
+    $UniqueBranches = @($Branches | Where-Object { $_ } | Select-Object -Unique)
+    if ($UniqueBranches.Count -eq 0) {
+        return
+    }
+
+    Write-Host "==> Fetch $RemoteName $($UniqueBranches -join ', ')"
+    $Result = Invoke-GitCore -Quiet @(@('fetch', $RemoteName) + $UniqueBranches)
+    if ($Result.ExitCode -ne 0) {
+        $Detail = ($Result.Output -join "`n").Trim()
+        if ($Detail) {
+            throw "git fetch $RemoteName failed (exit $($Result.ExitCode)): $Detail"
+        }
+        throw "git fetch $RemoteName failed (exit $($Result.ExitCode))"
+    }
+}
+
+function Resolve-RemoteTip {
+    param(
+        [string] $Branch,
+        [string] $RemoteName
+    )
+
+    $RemoteRef = "$RemoteName/$Branch"
+    if (-not (Test-GitRef "refs/remotes/$RemoteName/$Branch")) {
+        return $null
+    }
+    $Sha = Get-RefSha -Ref $RemoteRef
+    if (-not $Sha) { return $null }
+    return @{
+        Branch   = $Branch
+        MergeRef = $RemoteRef
+        Sha      = $Sha
+        Source   = 'remote'
+    }
+}
+
+function Get-InputStamp {
+    param(
+        [string] $ConfigIdentity,
+        [string] $BaseName,
+        [string] $BaseSha,
+        [string[]] $ExtraPairs
+    )
+
+    $Parts = [System.Collections.Generic.List[string]]::new()
+    $Parts.Add("config=$ConfigIdentity")
+    $Parts.Add("base=$BaseName=$BaseSha")
+    foreach ($Pair in $ExtraPairs) {
+        if ($Pair) { $Parts.Add("extra=$Pair") }
+    }
+    return ($Parts -join '|')
+}
+
+function Get-TestCombinedStamp {
+    param([string] $Commit)
+    if (-not $Commit) { return $null }
+    $Lines = @(& git.exe notes --ref=test-combined show $Commit 2>$null)
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+    return (($Lines -join "`n").Trim())
+}
+
+function Set-TestCombinedStamp {
+    param(
+        [string] $Commit,
+        [string] $Stamp
+    )
+    $ExitCode = Invoke-GitSoft @(
+        'notes', '--ref=test-combined', 'add', '-f', '-m', $Stamp, $Commit
+    )
+    if ($ExitCode -ne 0) {
+        Write-Warning "Could not write test-combined stamp note on $Commit"
+    }
+}
+
+function ConvertTo-NormalizedStamp {
+    param([string] $Stamp)
+    if (-not $Stamp) { return $null }
+    $Normalized = $Stamp.Trim() -replace "`r`n", "`n" -replace "`r", "`n"
+    if ($Normalized.Contains("`n")) {
+        $Normalized = (($Normalized -split "`n") | ForEach-Object { $_.Trim() } | Where-Object { $_ }) -join '|'
+    }
+    return $Normalized
+}
+
+function Test-MergeInProgress {
+    $MergeHead = & git.exe rev-parse -q --verify MERGE_HEAD 2>$null
+    return [bool] $MergeHead
+}
+
+function Get-UnmergedPaths {
+    $Output = & git.exe diff --name-only --diff-filter=U 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        return @()
+    }
+    return @($Output | Where-Object { $_ })
+}
+
+function Resolve-IgnoredMergeConflicts {
+    param(
+        [string[]] $IgnoredPaths,
+        [ValidateSet('ours', 'theirs')]
+        [string] $Prefer = 'ours'
+    )
+
+    foreach ($Path in (Get-UnmergedPaths)) {
+        if ($Path -in $IgnoredPaths) {
+            Write-Host "==> Auto-resolve merge conflict in $Path ($Prefer)"
+            Invoke-Git @('checkout', "--$Prefer", '--', $Path)
+            Invoke-Git @('add', '--', $Path)
+        }
+    }
+
+    return @(Get-UnmergedPaths)
+}
+
+function Merge-FeatureBranch {
+    param(
+        [string] $MergeRef,
+        [string] $ExtraBranch,
+        [string[]] $IgnoredPaths
+    )
+
+    $MergeMessage = "test: merge $ExtraBranch for combined testing"
+    $ExitCode = Invoke-GitSoft @(
+        'merge', $MergeRef, '--no-edit', '-m', $MergeMessage
+    )
+    if ($ExitCode -eq 0) {
+        return
+    }
+
+    if (-not (Test-MergeInProgress)) {
+        throw "git merge $MergeRef failed (exit $ExitCode)"
+    }
+
+    $Remaining = Resolve-IgnoredMergeConflicts -IgnoredPaths $IgnoredPaths -Prefer 'ours'
+    if ($Remaining.Count -gt 0) {
+        throw "Merge conflict in: $($Remaining -join ', ')"
+    }
+
+    Invoke-Git @('commit', '--no-edit')
+}
+
+function Get-CurrentBranch {
+    return ([string] (Invoke-Git @('branch', '--show-current') | Select-Object -First 1)).Trim()
+}
+
+function Restore-DevBranch {
+    param([string] $Branch)
+    if ($Branch) {
+        Invoke-Git @('checkout', $Branch)
+    }
+}
+
+function Get-GitConfigJson {
+    param(
+        [string[]] $Refs,
+        [string] $RepoPath = "team/test-combined.json"
+    )
+
+    foreach ($Ref in $Refs) {
+        if (-not $Ref) { continue }
+        $Spec = "${Ref}:${RepoPath}"
+        $Json = & git show $Spec 2>$null
+        if ($LASTEXITCODE -eq 0 -and $Json) {
+            return @{ Source = $Spec; Json = [string] $Json }
+        }
+    }
+
+    return $null
+}
+
+function Resolve-ConfigSource {
+    param(
+        [string] $ExplicitPath,
+        [string] $TeamRef
+    )
+
+    if ($ExplicitPath) {
+        if (Test-Path $ExplicitPath) {
+            return @{
+                Source = (Resolve-Path $ExplicitPath).Path
+                Json   = $null
+            }
+        }
+        if ($ExplicitPath -match ':') {
+            $Json = & git show $ExplicitPath 2>$null
+            if ($LASTEXITCODE -eq 0 -and $Json) {
+                return @{ Source = $ExplicitPath; Json = [string] $Json }
+            }
+        }
+        throw "Config file not found: $ExplicitPath"
+    }
+
+    $LocalCandidates = @(
+        (Join-Path $RepoRoot "scripts/test-combined.json"),
+        (Join-Path $RepoRoot "team/test-combined.json")
+    )
+
+    foreach ($Candidate in $LocalCandidates) {
+        if (Test-Path $Candidate) {
+            return @{
+                Source = (Resolve-Path $Candidate).Path
+                Json   = $null
+            }
+        }
+    }
+
+    $GitRefs = @(
+        $TeamRef,
+        "origin/$TeamRef"
+    )
+    $FromGit = Get-GitConfigJson -Refs $GitRefs
+    if ($FromGit) {
+        return $FromGit
+    }
+
+    $Example = Join-Path $RepoRoot "scripts/test-combined.example.json"
+    if (Test-Path $Example) {
+        Write-Warning "Using example config ($Example). Copy to scripts/test-combined.json or update team/local."
+        return @{
+            Source = (Resolve-Path $Example).Path
+            Json   = $null
+        }
+    }
+
+    throw @"
+No test-combined config found.
+Fetch team/local (git fetch origin team/local) or create scripts/test-combined.json from scripts/test-combined.example.json.
+"@
+}
+
+function Read-TestCombinedConfig {
+    param(
+        [string] $Source,
+        [string] $Json
+    )
+
+    try {
+        if ($Json) {
+            $Config = $Json | ConvertFrom-Json
+        }
+        else {
+            $Config = Get-Content -Raw -Path $Source | ConvertFrom-Json
+        }
+    }
+    catch {
+        throw "Failed to parse config JSON at '$Source': $_"
+    }
+
+    foreach ($Required in @("baseBranch", "testBranch", "extraFeatureBranches")) {
+        if (-not ($Config.PSObject.Properties.Name -contains $Required)) {
+            throw "Config '$Source' is missing required field '$Required'."
+        }
+    }
+
+    return $Config
+}
+
+if (-not (Test-Path "FYPA.py")) {
+    throw "FYPA.py not found in $RepoRoot — run this script from the FYPA repo."
+}
+
+# Soft-fetch team config ref so git show origin/team/local:... works.
+if (-not $ConfigPath) {
+    try {
+        Sync-RemoteBranches -RemoteName $Remote -Branches @($TeamConfigRef)
+    }
+    catch {
+        Write-Warning "Fetch $Remote $TeamConfigRef failed; using existing refs if present."
+        Write-Warning "$_"
+    }
+}
+
+$ConfigSource = Resolve-ConfigSource -ExplicitPath $ConfigPath -TeamRef $TeamConfigRef
+Write-Host "==> Config: $($ConfigSource.Source)"
+$Config = Read-TestCombinedConfig -Source $ConfigSource.Source -Json $ConfigSource.Json
+
+$BaseBranch = if ($PSBoundParameters.ContainsKey("BaseBranch")) { $BaseBranch } else { [string] $Config.baseBranch }
+$TestBranch = if ($PSBoundParameters.ContainsKey("TestBranch")) { $TestBranch } else { [string] $Config.testBranch }
+$ExtraFeatureBranches = if ($PSBoundParameters.ContainsKey("ExtraFeatureBranches")) {
+    $ExtraFeatureBranches
+}
+else {
+    @($Config.extraFeatureBranches | ForEach-Object { [string] $_ })
+}
+$DeleteTestBranchFirst = if ($PSBoundParameters.ContainsKey("DeleteTestBranchFirst")) {
+    $DeleteTestBranchFirst
+}
+elseif ($Config.PSObject.Properties.Name -contains "deleteTestBranchFirst") {
+    [bool] $Config.deleteTestBranchFirst
+}
+else {
+    $false
+}
+
+if (-not $BaseBranch) { throw "baseBranch is empty." }
+if (-not $TestBranch) { throw "testBranch is empty." }
+
+Write-Host "==> Branch source: $Remote tips only (no local-ahead merge)"
+
+$ReturnBranch = Get-CurrentBranch
+if (-not $ReturnBranch) {
+    throw "Could not determine the current branch (detached HEAD?). Check out a branch first."
+}
+
+Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches + @($TestBranch))
+
+$BaseTarget = Resolve-RemoteTip -Branch $BaseBranch -RemoteName $Remote
+if (-not $BaseTarget) {
+    throw "Base branch '$BaseBranch' not found as $Remote/$BaseBranch. Push it first."
+}
+
+$BaseRef = $BaseTarget.MergeRef
+$BaseSha = $BaseTarget.Sha
+Write-Host "==> Base: $BaseRef"
+
+$ExtraStampPairs = [System.Collections.Generic.List[string]]::new()
+$ResolvedExtras = [System.Collections.Generic.List[hashtable]]::new()
+$MissingExtras = [System.Collections.Generic.List[string]]::new()
+foreach ($ExtraBranch in $ExtraFeatureBranches) {
+    if (-not $ExtraBranch) { continue }
+    $ExtraTarget = Resolve-RemoteTip -Branch $ExtraBranch -RemoteName $Remote
+    if (-not $ExtraTarget) {
+        $MissingExtras.Add($ExtraBranch)
+        continue
+    }
+    Write-Host "==> Extra: $($ExtraTarget.MergeRef)"
+    $ExtraStampPairs.Add("$ExtraBranch=$($ExtraTarget.Sha)")
+    $ResolvedExtras.Add(@{
+        Branch   = $ExtraTarget.Branch
+        MergeRef = $ExtraTarget.MergeRef
+    })
+}
+
+if ($MissingExtras.Count -gt 0) {
+    throw @"
+Missing on ${Remote}: $($MissingExtras -join ', ').
+Push each feature branch before maintaining $TestBranch.
+"@
+}
+
+$ConfigIdentity = @(
+    "base=$BaseBranch",
+    "test=$TestBranch",
+    "deleteFirst=$DeleteTestBranchFirst",
+    "extras=$($ExtraFeatureBranches -join ',')"
+) -join ';'
+
+$DesiredStamp = ConvertTo-NormalizedStamp (Get-InputStamp `
+    -ConfigIdentity $ConfigIdentity `
+    -BaseName $BaseBranch `
+    -BaseSha $BaseSha `
+    -ExtraPairs @($ExtraStampPairs))
+
+$TestBranchExists = Test-GitRef "refs/heads/$TestBranch"
+$ExistingTip = if ($TestBranchExists) { Get-RefSha -Ref $TestBranch } else { $null }
+$ExistingStamp = ConvertTo-NormalizedStamp (Get-TestCombinedStamp -Commit $ExistingTip)
+$CanReuse = (
+    -not $Rebuild -and
+    $TestBranchExists -and
+    $ExistingStamp -and
+    ($ExistingStamp -eq $DesiredStamp)
+)
+
+if (-not $CanReuse -and $TestBranchExists -and -not $Rebuild) {
+    if (-not $ExistingStamp) {
+        Write-Host "==> No reuse stamp on $TestBranch — will rebuild"
+    }
+    else {
+        Write-Host "==> Stamp mismatch on $TestBranch — will rebuild"
+    }
+}
+
+$IgnoredPaths = @('.gitignore', 'FYPA.code-workspace')
+$Status = @(Invoke-Git @('status', '--porcelain'))
+$BlockingStatus = @($Status | Where-Object {
+    $path = $_.Substring(3).Trim()
+    if ($path -match ' -> ') { $path = ($path -split ' -> ', 2)[-1].Trim() }
+    elseif ($path -match "`t") { $path = ($path -split "`t", 2)[-1].Trim() }
+    $path -notin $IgnoredPaths
+})
+if ($BlockingStatus.Count -gt 0) {
+    throw @"
+Uncommitted changes detected on '$ReturnBranch'.
+Commit or stash them before running maintain-test-combined.
+"@
+}
+
+$Returned = $false
+try {
+    if ($CanReuse) {
+        Write-Host "==> Reuse $TestBranch (inputs unchanged)"
+        if ((Get-CurrentBranch) -ne $TestBranch) {
+            Invoke-Git @('checkout', $TestBranch)
+        }
+    }
+    else {
+        if ($Rebuild) {
+            Write-Host "==> Rebuild requested — recreating $TestBranch"
+        }
+        elseif (-not $TestBranchExists) {
+            Write-Host "==> $TestBranch missing — creating from $BaseRef"
+        }
+        else {
+            Write-Host "==> Inputs changed — recreating $TestBranch from $BaseRef"
+        }
+
+        if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
+            Write-Host "==> Delete $TestBranch"
+            if ((Get-CurrentBranch) -eq $TestBranch) {
+                Invoke-Git @('checkout', $ReturnBranch)
+            }
+            Invoke-Git @('branch', '-D', $TestBranch)
+        }
+
+        if (Test-GitRef "refs/heads/$TestBranch") {
+            Write-Host "==> Recreate $TestBranch from $BaseRef"
+            Invoke-Git @('branch', '-f', $TestBranch, $BaseRef)
+            Invoke-Git @('checkout', $TestBranch)
+        }
+        else {
+            Write-Host "==> Create $TestBranch from $BaseRef"
+            Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
+        }
+
+        foreach ($Extra in $ResolvedExtras) {
+            Write-Host "==> Merge $($Extra.MergeRef) into $TestBranch"
+            Merge-FeatureBranch -MergeRef $Extra.MergeRef -ExtraBranch $Extra.Branch -IgnoredPaths $IgnoredPaths
+        }
+
+        $NewTip = Get-RefSha -Ref 'HEAD'
+        if ($NewTip) {
+            Set-TestCombinedStamp -Commit $NewTip -Stamp $DesiredStamp
+            Write-Host "==> Stamp written for $TestBranch"
+        }
+    }
+
+    $Tip = Get-RefSha -Ref 'HEAD'
+    Write-Host "==> $TestBranch tip: $Tip"
+
+    if ($Push) {
+        Write-Host "==> Push --force-with-lease $Remote $TestBranch"
+        Invoke-Git @('push', '--force-with-lease', $Remote, "HEAD:refs/heads/$TestBranch")
+        Write-Host "==> Pushed $Remote/$TestBranch"
+    }
+    else {
+        Write-Host "==> Local only (pass -Push to update $Remote/$TestBranch)"
+    }
+}
+catch {
+    if ((Get-CurrentBranch) -ne $ReturnBranch) {
+        & git merge --abort 2>$null | Out-Null
+        & git rebase --abort 2>$null | Out-Null
+    }
+    throw
+}
+finally {
+    $Current = Get-CurrentBranch
+    if ($Current -ne $ReturnBranch) {
+        Write-Host "==> Return to $ReturnBranch"
+        Restore-DevBranch -Branch $ReturnBranch
+        $Returned = $true
+    }
+}
+
+if (-not $Returned) {
+    Write-Host "==> Return to $ReturnBranch"
+    Restore-DevBranch -Branch $ReturnBranch
+}

--- a/scripts/test-combined.example.json
+++ b/scripts/test-combined.example.json
@@ -1,0 +1,9 @@
+{
+  "baseBranch": "main",
+  "testBranch": "test/combined",
+  "deleteTestBranchFirst": true,
+  "extraFeatureBranches": [
+    "feature/example-a",
+    "fix/example-b"
+  ]
+}

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -10,6 +10,7 @@
 #   pwsh scripts/test-combined.ps1
 #   pwsh scripts/test-combined.ps1 --local-only
 #   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
+#   pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
 #
 # By default baseBranch and extraFeatureBranches are fetched from origin and merged
 # via origin/<branch>. Pass --local-only to use local branches only.
@@ -30,7 +31,8 @@ param(
     [string] $BaseBranch,
     [string] $TestBranch,
     [string[]] $ExtraFeatureBranches,
-    [bool] $DeleteTestBranchFirst
+    [bool] $DeleteTestBranchFirst,
+    [string] $PrjPcb
 )
 
 $ErrorActionPreference = "Stop"
@@ -341,6 +343,14 @@ else {
     $false
 }
 
+$PrjPcbPath = $null
+if ($PrjPcb) {
+    if (-not (Test-Path -LiteralPath $PrjPcb)) {
+        throw "PrjPcb not found: $PrjPcb"
+    }
+    $PrjPcbPath = (Resolve-Path -LiteralPath $PrjPcb).Path
+}
+
 if (-not $BaseBranch) { throw "baseBranch is empty." }
 if (-not $TestBranch) { throw "testBranch is empty." }
 
@@ -434,7 +444,13 @@ try {
     }
 
     Write-Host "==> uv run FYPA.py"
-    & uv run --extra spacemouse FYPA.py
+    if ($PrjPcbPath) {
+        Write-Host "    Project: $PrjPcbPath"
+        & uv run --extra spacemouse FYPA.py gui $PrjPcbPath
+    }
+    else {
+        & uv run --extra spacemouse FYPA.py
+    }
     $FypaExit = $LASTEXITCODE
 }
 catch {

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -1,0 +1,463 @@
+# Build a local combined test branch from a base branch + feature branches, run tests/FYPA, then switch back.
+#
+# Config (first match wins):
+#   scripts/test-combined.json          local override (gitignored)
+#   team/test-combined.json             working tree
+#   team/local:team/test-combined.json  from team/local branch via git show (no checkout)
+#   scripts/test-combined.example.json  fallback
+#
+# Usage (from repo root, any branch):
+#   pwsh scripts/test-combined.ps1
+#   pwsh scripts/test-combined.ps1 --local-only
+#   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
+#
+# By default baseBranch and extraFeatureBranches are fetched from origin and merged
+# via origin/<branch>. Pass --local-only to use local branches only.
+#
+# Workflow:
+#   1. Remember current branch
+#   2. Optionally delete the test branch, then recreate it from the base branch
+#   3. Merge every extra feature branch (.gitignore conflicts auto-resolved with --ours)
+#   4. Run pytest topology suite, then uv run FYPA.py
+#   5. Return to the branch you started on (even if a step exits with an error)
+
+[CmdletBinding()]
+param(
+    [string] $ConfigPath,
+    [string] $TeamConfigRef = "team/local",
+    [string] $Remote = "origin",
+    [switch] $LocalOnly,
+    [string] $BaseBranch,
+    [string] $TestBranch,
+    [string[]] $ExtraFeatureBranches,
+    [bool] $DeleteTestBranchFirst
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+Set-Location $RepoRoot
+
+function Invoke-GitCore {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs,
+        [switch] $Quiet
+    )
+    if ($GitArgs.Count -eq 0) {
+        throw "Invoke-GitCore: no arguments"
+    }
+
+    $Output = @(& git.exe @GitArgs 2>&1)
+    $ExitCode = $LASTEXITCODE
+
+    if (-not $Quiet) {
+        foreach ($Line in $Output) {
+            if ($Line -is [System.Management.Automation.ErrorRecord]) {
+                Write-Warning $Line.ToString()
+            }
+            else {
+                Write-Host $Line
+            }
+        }
+    }
+
+    $Stdout = @(
+        $Output |
+            Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] } |
+            ForEach-Object { [string] $_ }
+    )
+
+    return @{
+        ExitCode = $ExitCode
+        Output   = $Stdout
+    }
+}
+
+function Invoke-Git {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs
+    )
+    $Result = Invoke-GitCore @GitArgs
+    if ($Result.ExitCode -ne 0) {
+        throw "git $($GitArgs -join ' ') failed (exit $($Result.ExitCode))"
+    }
+    return $Result.Output
+}
+
+function Invoke-GitSoft {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs
+    )
+    return (Invoke-GitCore @GitArgs).ExitCode
+}
+
+function Test-GitRef {
+    param([string] $Ref)
+    & git show-ref --verify --quiet $Ref
+    return $LASTEXITCODE -eq 0
+}
+
+function Get-BranchMergeRef {
+    param(
+        [string] $Branch,
+        [string] $RemoteName,
+        [bool] $UseLocalOnly
+    )
+
+    if ($UseLocalOnly) {
+        return $Branch
+    }
+    return "$RemoteName/$Branch"
+}
+
+function Test-BranchAvailable {
+    param(
+        [string] $Branch,
+        [string] $RemoteName,
+        [bool] $UseLocalOnly
+    )
+
+    if ($UseLocalOnly) {
+        return Test-GitRef "refs/heads/$Branch"
+    }
+    return Test-GitRef "refs/remotes/$RemoteName/$Branch"
+}
+
+function Sync-RemoteBranches {
+    param(
+        [string] $RemoteName,
+        [string[]] $Branches
+    )
+
+    $UniqueBranches = @($Branches | Where-Object { $_ } | Select-Object -Unique)
+    if ($UniqueBranches.Count -eq 0) {
+        return
+    }
+
+    Write-Host "==> Fetch $RemoteName $($UniqueBranches -join ', ')"
+    Invoke-Git @(@('fetch', $RemoteName) + $UniqueBranches)
+}
+
+function Test-MergeInProgress {
+    $MergeHead = & git.exe rev-parse -q --verify MERGE_HEAD 2>$null
+    return [bool] $MergeHead
+}
+
+function Get-UnmergedPaths {
+    $Output = & git.exe diff --name-only --diff-filter=U 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        return @()
+    }
+    return @($Output | Where-Object { $_ })
+}
+
+function Resolve-IgnoredMergeConflicts {
+    param(
+        [string[]] $IgnoredPaths,
+        [ValidateSet('ours', 'theirs')]
+        [string] $Prefer = 'ours'
+    )
+
+    foreach ($Path in (Get-UnmergedPaths)) {
+        if ($Path -in $IgnoredPaths) {
+            Write-Host "==> Auto-resolve merge conflict in $Path ($Prefer)"
+            Invoke-Git @('checkout', "--$Prefer", '--', $Path)
+            Invoke-Git @('add', '--', $Path)
+        }
+    }
+
+    return @(Get-UnmergedPaths)
+}
+
+function Merge-FeatureBranch {
+    param(
+        [string] $MergeRef,
+        [string] $ExtraBranch,
+        [string[]] $IgnoredPaths
+    )
+
+    $MergeMessage = "test: merge $ExtraBranch for local testing"
+    $ExitCode = Invoke-GitSoft @(
+        'merge', $MergeRef, '--no-edit', '-m', $MergeMessage
+    )
+    if ($ExitCode -eq 0) {
+        return
+    }
+
+    if (-not (Test-MergeInProgress)) {
+        throw "git merge $MergeRef failed (exit $ExitCode)"
+    }
+
+    $Remaining = Resolve-IgnoredMergeConflicts -IgnoredPaths $IgnoredPaths -Prefer 'ours'
+    if ($Remaining.Count -gt 0) {
+        throw "Merge conflict in: $($Remaining -join ', ')"
+    }
+
+    Invoke-Git @('commit', '--no-edit')
+}
+
+function Get-CurrentBranch {
+    return ([string] (Invoke-Git @('branch', '--show-current') | Select-Object -First 1)).Trim()
+}
+
+function Restore-DevBranch {
+    param([string] $Branch)
+    if ($Branch) {
+        Invoke-Git @('checkout', $Branch)
+    }
+}
+
+function Get-GitConfigJson {
+    param(
+        [string[]] $Refs,
+        [string] $RepoPath = "team/test-combined.json"
+    )
+
+    foreach ($Ref in $Refs) {
+        if (-not $Ref) { continue }
+        $Spec = "${Ref}:${RepoPath}"
+        $Json = & git show $Spec 2>$null
+        if ($LASTEXITCODE -eq 0 -and $Json) {
+            return @{ Source = $Spec; Json = [string] $Json }
+        }
+    }
+
+    return $null
+}
+
+function Resolve-ConfigSource {
+    param(
+        [string] $ExplicitPath,
+        [string] $TeamRef
+    )
+
+    if ($ExplicitPath) {
+        if (Test-Path $ExplicitPath) {
+            return @{
+                Source = (Resolve-Path $ExplicitPath).Path
+                Json   = $null
+            }
+        }
+        if ($ExplicitPath -match ':') {
+            $Json = & git show $ExplicitPath 2>$null
+            if ($LASTEXITCODE -eq 0 -and $Json) {
+                return @{ Source = $ExplicitPath; Json = [string] $Json }
+            }
+        }
+        throw "Config file not found: $ExplicitPath"
+    }
+
+    $LocalCandidates = @(
+        (Join-Path $RepoRoot "scripts/test-combined.json"),
+        (Join-Path $RepoRoot "team/test-combined.json")
+    )
+
+    foreach ($Candidate in $LocalCandidates) {
+        if (Test-Path $Candidate) {
+            return @{
+                Source = (Resolve-Path $Candidate).Path
+                Json   = $null
+            }
+        }
+    }
+
+    $GitRefs = @(
+        $TeamRef,
+        "origin/$TeamRef"
+    )
+    $FromGit = Get-GitConfigJson -Refs $GitRefs
+    if ($FromGit) {
+        return $FromGit
+    }
+
+    $Example = Join-Path $RepoRoot "scripts/test-combined.example.json"
+    if (Test-Path $Example) {
+        Write-Warning "Using example config ($Example). Copy to scripts/test-combined.json or update team/local."
+        return @{
+            Source = (Resolve-Path $Example).Path
+            Json   = $null
+        }
+    }
+
+    throw @"
+No test-combined config found.
+Fetch team/local (git fetch origin team/local) or create scripts/test-combined.json from scripts/test-combined.example.json.
+"@
+}
+
+function Read-TestCombinedConfig {
+    param(
+        [string] $Source,
+        [string] $Json
+    )
+
+    try {
+        if ($Json) {
+            $Config = $Json | ConvertFrom-Json
+        }
+        else {
+            $Config = Get-Content -Raw -Path $Source | ConvertFrom-Json
+        }
+    }
+    catch {
+        throw "Failed to parse config JSON at '$Source': $_"
+    }
+
+    foreach ($Required in @("baseBranch", "testBranch", "extraFeatureBranches")) {
+        if (-not ($Config.PSObject.Properties.Name -contains $Required)) {
+            throw "Config '$Source' is missing required field '$Required'."
+        }
+    }
+
+    return $Config
+}
+
+if (-not (Test-Path "FYPA.py")) {
+    throw "FYPA.py not found in $RepoRoot — run this script from the FYPA repo."
+}
+
+$ConfigSource = Resolve-ConfigSource -ExplicitPath $ConfigPath -TeamRef $TeamConfigRef
+Write-Host "==> Config: $($ConfigSource.Source)"
+$Config = Read-TestCombinedConfig -Source $ConfigSource.Source -Json $ConfigSource.Json
+
+$BaseBranch = if ($PSBoundParameters.ContainsKey("BaseBranch")) { $BaseBranch } else { [string] $Config.baseBranch }
+$TestBranch = if ($PSBoundParameters.ContainsKey("TestBranch")) { $TestBranch } else { [string] $Config.testBranch }
+$ExtraFeatureBranches = if ($PSBoundParameters.ContainsKey("ExtraFeatureBranches")) {
+    $ExtraFeatureBranches
+}
+else {
+    @($Config.extraFeatureBranches | ForEach-Object { [string] $_ })
+}
+$DeleteTestBranchFirst = if ($PSBoundParameters.ContainsKey("DeleteTestBranchFirst")) {
+    $DeleteTestBranchFirst
+}
+elseif ($Config.PSObject.Properties.Name -contains "deleteTestBranchFirst") {
+    [bool] $Config.deleteTestBranchFirst
+}
+else {
+    $false
+}
+
+if (-not $BaseBranch) { throw "baseBranch is empty." }
+if (-not $TestBranch) { throw "testBranch is empty." }
+
+$UseLocalOnly = [bool] $LocalOnly
+if ($UseLocalOnly) {
+    Write-Host "==> Branch source: local only"
+}
+else {
+    Write-Host "==> Branch source: $Remote (fetch + merge remote-tracking refs)"
+}
+
+$ReturnBranch = Get-CurrentBranch
+if (-not $ReturnBranch) {
+    throw "Could not determine the current branch."
+}
+
+if ($UseLocalOnly) {
+    if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $true)) {
+        throw "Base branch '$BaseBranch' not found locally."
+    }
+}
+else {
+    Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
+    if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $false)) {
+        throw "Remote branch '$Remote/$BaseBranch' not found after fetch."
+    }
+}
+
+$BaseRef = Get-BranchMergeRef -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+
+$IgnoredPaths = @('.gitignore', 'FYPA.code-workspace')
+$Status = @(Invoke-Git @('status', '--porcelain'))
+$BlockingStatus = @($Status | Where-Object {
+    $path = $_.Substring(3).Trim()
+    if ($path -match ' -> ') { $path = ($path -split ' -> ', 2)[-1].Trim() }
+    elseif ($path -match "`t") { $path = ($path -split "`t", 2)[-1].Trim() }
+    $path -notin $IgnoredPaths
+})
+if ($BlockingStatus.Count -gt 0) {
+    throw @"
+Uncommitted changes detected on '$ReturnBranch'.
+Commit or stash them before running the test script.
+"@
+}
+
+$Returned = $false
+$FypaExit = 0
+try {
+    if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
+        Write-Host "==> Delete $TestBranch"
+        if (Get-CurrentBranch -eq $TestBranch) {
+            Invoke-Git @('checkout', $ReturnBranch)
+        }
+        Invoke-Git @('branch', '-D', $TestBranch)
+    }
+
+    if (Test-GitRef "refs/heads/$TestBranch") {
+        Write-Host "==> Recreate $TestBranch from $BaseRef"
+        Invoke-Git @('branch', '-f', $TestBranch, $BaseRef)
+        Invoke-Git @('checkout', $TestBranch)
+    }
+    else {
+        Write-Host "==> Create $TestBranch from $BaseRef"
+        Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
+    }
+
+    foreach ($ExtraBranch in $ExtraFeatureBranches) {
+        if (-not $ExtraBranch) { continue }
+
+        $MergeRef = Get-BranchMergeRef -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+        if (Test-BranchAvailable -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly) {
+            Write-Host "==> Merge $MergeRef into $TestBranch"
+            Merge-FeatureBranch -MergeRef $MergeRef -ExtraBranch $ExtraBranch -IgnoredPaths $IgnoredPaths
+        }
+        else {
+            $Label = if ($UseLocalOnly) { "local branch" } else { "remote branch" }
+            Write-Warning "Extra feature $Label '$ExtraBranch' not found — continuing without it."
+        }
+    }
+
+    Write-Host "==> pytest topology tests"
+    & uv run python -m pytest `
+        tests/test_topology_invariants.py `
+        tests/test_topology_regressions.py `
+        tests/test_topology_layout.py `
+        tests/test_topology_geometry.py `
+        tests/test_topology_labels.py `
+        tests/test_pdn_topology.py -q
+    if ($LASTEXITCODE -ne 0) {
+        throw "pytest failed (exit $LASTEXITCODE)"
+    }
+
+    Write-Host "==> uv run FYPA.py"
+    & uv run --extra spacemouse FYPA.py
+    $FypaExit = $LASTEXITCODE
+}
+catch {
+    if (Get-CurrentBranch -ne $ReturnBranch) {
+        & git merge --abort 2>$null | Out-Null
+        & git rebase --abort 2>$null | Out-Null
+    }
+    throw
+}
+finally {
+    $Current = Get-CurrentBranch
+    if ($Current -ne $ReturnBranch) {
+        Write-Host "==> Return to $ReturnBranch"
+        Restore-DevBranch -Branch $ReturnBranch
+        $Returned = $true
+    }
+}
+
+if (-not $Returned) {
+    Write-Host "==> Return to $ReturnBranch"
+    Restore-DevBranch -Branch $ReturnBranch
+}
+
+if ($FypaExit -and $FypaExit -ne 0) {
+    exit $FypaExit
+}

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -1,36 +1,112 @@
-# Build a local combined test branch from a base branch + feature branches, run tests/FYPA, then switch back.
-#
-# Config (first match wins):
-#   scripts/test-combined.json          local override (gitignored)
-#   team/test-combined.json             working tree
-#   team/local:team/test-combined.json  from team/local branch via git show (no checkout)
-#   scripts/test-combined.example.json  fallback
-#
-# Usage (from repo root, any branch):
-#   pwsh scripts/test-combined.ps1
-#   pwsh scripts/test-combined.ps1 -LocalOnly
-#   pwsh scripts/test-combined.ps1 -Rebuild
-#   pwsh scripts/test-combined.ps1 -SkipTests
-#   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
-#   pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
-#
-# By default baseBranch and extraFeatureBranches are soft-fetched from origin.
-# Each input is resolved to the tip that includes local work: if the local branch
-# is ahead of (or diverged from) origin/<branch>, the local tip is merged; if
-# local is behind, origin/<branch> is used; local-only or remote-only branches
-# are accepted either way. If fetch fails (offline), existing refs are resolved
-# the same way. When input SHAs match the stamp on an existing test branch, that
-# branch is reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
-# Pass -LocalOnly to skip fetch and use local branches only.
-#
-# Workflow:
-#   1. Remember current branch
-#   2. Soft-fetch inputs (or local-only); resolve tips (prefer local when ahead);
-#      reuse test branch if stamp matches
-#   3. Otherwise optionally delete, recreate from base, merge feature branches
-#      (.gitignore conflicts auto-resolved with --ours); write stamp note
-#   4. Optionally run pytest topology suite (-SkipTests to skip), then uv run FYPA.py
-#   5. Return to the branch you started on (even if a step exits with an error)
+<#
+.SYNOPSIS
+    Build a local combined test branch, run tests/FYPA, then switch back.
+
+.DESCRIPTION
+    Merges a base branch plus feature branches into a disposable test branch,
+    optionally runs the pytest topology suite and FYPA.py, then returns to the
+    branch you started on (even if a step exits with an error).
+
+    Config resolution (first match wins):
+      scripts/test-combined.json          local override (gitignored)
+      team/test-combined.json             working tree
+      team/local:team/test-combined.json  from team/local via git show (no checkout)
+      scripts/test-combined.example.json  fallback
+
+    By default baseBranch and extraFeatureBranches are soft-fetched from origin.
+    Each input is resolved to the tip that includes local work: if the local
+    branch is ahead of (or diverged from) origin/<branch>, the local tip is
+    merged; if local is behind, origin/<branch> is used; local-only or
+    remote-only branches are accepted either way. If fetch fails (offline),
+    existing refs are resolved the same way.
+
+    When input SHAs match the stamp on an existing test branch, that branch is
+    reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
+    Pass -LocalOnly to skip fetch and use local branches only.
+
+    Workflow:
+      1. Remember current branch
+      2. Soft-fetch inputs (or local-only); resolve tips (prefer local when ahead);
+         reuse test branch if stamp matches
+      3. Otherwise optionally delete, recreate from base, merge feature branches
+         (.gitignore conflicts auto-resolved with --ours); write stamp note
+      4. Optionally run pytest topology suite (-SkipTests to skip), then uv run FYPA.py
+      5. Return to the starting branch
+
+.PARAMETER ConfigPath
+    Path to a JSON config file. Overrides the default config search order.
+
+.PARAMETER TeamConfigRef
+    Git ref used when reading team/test-combined.json via git show.
+    Default: team/local
+
+.PARAMETER Remote
+    Remote name used for soft-fetch and tip resolution. Default: origin
+
+.PARAMETER LocalOnly
+    Skip fetch; resolve and merge local branches only.
+
+.PARAMETER Rebuild
+    Force delete/recreate of the test branch even when the stamp matches.
+
+.PARAMETER SkipTests
+    Skip the pytest topology suite; still runs FYPA.py unless the script exits earlier.
+
+.PARAMETER BaseBranch
+    Override config baseBranch (branch the test branch is created from).
+
+.PARAMETER TestBranch
+    Override config testBranch (name of the disposable combined branch).
+
+.PARAMETER ExtraFeatureBranches
+    Override config extraFeatureBranches (branches merged onto the base).
+
+.PARAMETER DeleteTestBranchFirst
+    Override config deleteTestBranchFirst. When true, delete the existing test
+    branch before recreating it.
+
+.PARAMETER PrjPcb
+    Path to a .PrjPcb passed through to FYPA.py.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1
+
+    Use default config resolution, soft-fetch, reuse or rebuild the test branch,
+    run tests and FYPA, then switch back.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1 -LocalOnly
+
+    Skip remote fetch; use local branch tips only.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1 -Rebuild
+
+    Force a clean recreate of the test branch.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1 -SkipTests
+
+    Build/reuse the test branch and run FYPA without pytest.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
+
+    Use an explicit local config file.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
+
+    Pass a project file through to FYPA.py.
+
+.EXAMPLE
+    Get-Help .\scripts\test-combined.ps1 -Full
+
+    Show this help. Equivalent: pwsh scripts/test-combined.ps1 -?
+
+.NOTES
+    Run from the repo root (or any branch); the script cds to the repo root itself.
+#>
 
 [CmdletBinding()]
 param(

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -9,17 +9,23 @@
 # Usage (from repo root, any branch):
 #   pwsh scripts/test-combined.ps1
 #   pwsh scripts/test-combined.ps1 --local-only
+#   pwsh scripts/test-combined.ps1 -Rebuild
+#   pwsh scripts/test-combined.ps1 -SkipTests
 #   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
 #   pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
 #
-# By default baseBranch and extraFeatureBranches are fetched from origin and merged
-# via origin/<branch>. Pass --local-only to use local branches only.
+# By default baseBranch and extraFeatureBranches are soft-fetched from origin and
+# merged via origin/<branch>. If fetch fails (offline), local refs are used.
+# When input SHAs match the stamp on an existing test branch, that branch is
+# reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
+# Pass --local-only to skip fetch and use local branches only.
 #
 # Workflow:
 #   1. Remember current branch
-#   2. Optionally delete the test branch, then recreate it from the base branch
-#   3. Merge every extra feature branch (.gitignore conflicts auto-resolved with --ours)
-#   4. Run pytest topology suite, then uv run FYPA.py
+#   2. Soft-fetch inputs (or local-only); reuse test branch if stamp matches
+#   3. Otherwise optionally delete, recreate from base, merge feature branches
+#      (.gitignore conflicts auto-resolved with --ours); write stamp note
+#   4. Optionally run pytest topology suite (-SkipTests to skip), then uv run FYPA.py
 #   5. Return to the branch you started on (even if a step exits with an error)
 
 [CmdletBinding()]
@@ -28,6 +34,8 @@ param(
     [string] $TeamConfigRef = "team/local",
     [string] $Remote = "origin",
     [switch] $LocalOnly,
+    [switch] $Rebuild,
+    [switch] $SkipTests,
     [string] $BaseBranch,
     [string] $TestBranch,
     [string[]] $ExtraFeatureBranches,
@@ -140,7 +148,78 @@ function Sync-RemoteBranches {
     }
 
     Write-Host "==> Fetch $RemoteName $($UniqueBranches -join ', ')"
-    Invoke-Git @(@('fetch', $RemoteName) + $UniqueBranches)
+    # git writes progress to stderr; don't surface it as PowerShell warnings.
+    $Result = Invoke-GitCore -Quiet @(@('fetch', $RemoteName) + $UniqueBranches)
+    if ($Result.ExitCode -ne 0) {
+        $Detail = ($Result.Output -join "`n").Trim()
+        if ($Detail) {
+            throw "git fetch $RemoteName failed (exit $($Result.ExitCode)): $Detail"
+        }
+        throw "git fetch $RemoteName failed (exit $($Result.ExitCode))"
+    }
+}
+
+function Get-RefSha {
+    param([string] $Ref)
+    $Sha = ([string] (& git.exe rev-parse --verify "$Ref^{commit}" 2>$null)).Trim()
+    if ($LASTEXITCODE -ne 0 -or -not $Sha) {
+        return $null
+    }
+    return $Sha
+}
+
+function Get-InputStamp {
+    param(
+        [string] $ConfigIdentity,
+        [string] $BaseName,
+        [string] $BaseSha,
+        [string[]] $ExtraPairs
+    )
+
+    # Single-line stamp: PowerShell [string] casts of multi-line git output join
+    # with spaces and would break equality checks if we used newlines.
+    $Parts = [System.Collections.Generic.List[string]]::new()
+    $Parts.Add("config=$ConfigIdentity")
+    $Parts.Add("base=$BaseName=$BaseSha")
+    foreach ($Pair in $ExtraPairs) {
+        if ($Pair) { $Parts.Add("extra=$Pair") }
+    }
+    return ($Parts -join '|')
+}
+
+function Get-TestCombinedStamp {
+    param([string] $Commit)
+    if (-not $Commit) { return $null }
+    $Lines = @(& git.exe notes --ref=test-combined show $Commit 2>$null)
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+    # Join exactly as written; Trim only outer whitespace.
+    return (($Lines -join "`n").Trim())
+}
+
+function Set-TestCombinedStamp {
+    param(
+        [string] $Commit,
+        [string] $Stamp
+    )
+    $ExitCode = Invoke-GitSoft @(
+        'notes', '--ref=test-combined', 'add', '-f', '-m', $Stamp, $Commit
+    )
+    if ($ExitCode -ne 0) {
+        Write-Warning "Could not write test-combined stamp note on $Commit"
+    }
+}
+
+function ConvertTo-NormalizedStamp {
+    param([string] $Stamp)
+    if (-not $Stamp) { return $null }
+    # Accept legacy multiline notes (joined with `n) and new single-line (`|`) form.
+    $Normalized = $Stamp.Trim() -replace "`r`n", "`n" -replace "`r", "`n"
+    if ($Normalized.Contains("`n")) {
+        $Normalized = (($Normalized -split "`n") | ForEach-Object { $_.Trim() } | Where-Object { $_ }) -join '|'
+    }
+    return $Normalized
 }
 
 function Test-MergeInProgress {
@@ -359,7 +438,7 @@ if ($UseLocalOnly) {
     Write-Host "==> Branch source: local only"
 }
 else {
-    Write-Host "==> Branch source: $Remote (fetch + merge remote-tracking refs)"
+    Write-Host "==> Branch source: $Remote (soft-fetch + merge remote-tracking refs)"
 }
 
 $ReturnBranch = Get-CurrentBranch
@@ -373,13 +452,87 @@ if ($UseLocalOnly) {
     }
 }
 else {
-    Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
-    if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $false)) {
-        throw "Remote branch '$Remote/$BaseBranch' not found after fetch."
+    try {
+        Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
+        if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $false)) {
+            throw "Remote branch '$Remote/$BaseBranch' not found after fetch."
+        }
+    }
+    catch {
+        Write-Warning "Fetch from $Remote failed or remote base missing; falling back to local refs."
+        Write-Warning "$_"
+        $UseLocalOnly = $true
+        if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $true)) {
+            throw "Base branch '$BaseBranch' not found locally after soft-fetch fallback."
+        }
+        Write-Host "==> Branch source: local only (fallback)"
     }
 }
 
 $BaseRef = Get-BranchMergeRef -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+$BaseSha = Get-RefSha -Ref $BaseRef
+if (-not $BaseSha) {
+    throw "Could not resolve SHA for base ref '$BaseRef'."
+}
+
+$ExtraStampPairs = [System.Collections.Generic.List[string]]::new()
+$ResolvedExtras = [System.Collections.Generic.List[hashtable]]::new()
+foreach ($ExtraBranch in $ExtraFeatureBranches) {
+    if (-not $ExtraBranch) { continue }
+    $MergeRef = Get-BranchMergeRef -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+    if (Test-BranchAvailable -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly) {
+        $ExtraSha = Get-RefSha -Ref $MergeRef
+        if (-not $ExtraSha) {
+            Write-Warning "Could not resolve SHA for '$MergeRef' — continuing without it."
+            continue
+        }
+        $ExtraStampPairs.Add("$ExtraBranch=$ExtraSha")
+        $ResolvedExtras.Add(@{
+            Branch   = $ExtraBranch
+            MergeRef = $MergeRef
+        })
+    }
+    else {
+        $Label = if ($UseLocalOnly) { "local branch" } else { "remote branch" }
+        Write-Warning "Extra feature $Label '$ExtraBranch' not found — continuing without it."
+    }
+}
+
+$ConfigIdentity = @(
+    "base=$BaseBranch",
+    "test=$TestBranch",
+    "deleteFirst=$DeleteTestBranchFirst",
+    "extras=$($ExtraFeatureBranches -join ',')"
+) -join ';'
+
+$DesiredStamp = ConvertTo-NormalizedStamp (Get-InputStamp `
+    -ConfigIdentity $ConfigIdentity `
+    -BaseName $BaseBranch `
+    -BaseSha $BaseSha `
+    -ExtraPairs @($ExtraStampPairs))
+
+$TestBranchExists = Test-GitRef "refs/heads/$TestBranch"
+$ExistingTip = if ($TestBranchExists) { Get-RefSha -Ref $TestBranch } else { $null }
+$ExistingStampRaw = $null
+if ($ExistingTip) {
+    $ExistingStampRaw = Get-TestCombinedStamp -Commit $ExistingTip
+}
+$ExistingStamp = ConvertTo-NormalizedStamp $ExistingStampRaw
+$CanReuse = (
+    -not $Rebuild -and
+    $TestBranchExists -and
+    $ExistingStamp -and
+    ($ExistingStamp -eq $DesiredStamp)
+)
+
+if (-not $CanReuse -and $TestBranchExists -and -not $Rebuild) {
+    if (-not $ExistingStamp) {
+        Write-Host "==> No reuse stamp on $TestBranch — will rebuild"
+    }
+    else {
+        Write-Host "==> Stamp mismatch on $TestBranch — will rebuild"
+    }
+}
 
 $IgnoredPaths = @('.gitignore', 'FYPA.code-workspace')
 $Status = @(Invoke-Git @('status', '--porcelain'))
@@ -399,48 +552,68 @@ Commit or stash them before running the test script.
 $Returned = $false
 $FypaExit = 0
 try {
-    if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
-        Write-Host "==> Delete $TestBranch"
-        if (Get-CurrentBranch -eq $TestBranch) {
-            Invoke-Git @('checkout', $ReturnBranch)
+    if ($CanReuse) {
+        Write-Host "==> Reuse $TestBranch (inputs unchanged)"
+        if ((Get-CurrentBranch) -ne $TestBranch) {
+            Invoke-Git @('checkout', $TestBranch)
         }
-        Invoke-Git @('branch', '-D', $TestBranch)
-    }
-
-    if (Test-GitRef "refs/heads/$TestBranch") {
-        Write-Host "==> Recreate $TestBranch from $BaseRef"
-        Invoke-Git @('branch', '-f', $TestBranch, $BaseRef)
-        Invoke-Git @('checkout', $TestBranch)
     }
     else {
-        Write-Host "==> Create $TestBranch from $BaseRef"
-        Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
-    }
-
-    foreach ($ExtraBranch in $ExtraFeatureBranches) {
-        if (-not $ExtraBranch) { continue }
-
-        $MergeRef = Get-BranchMergeRef -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
-        if (Test-BranchAvailable -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly) {
-            Write-Host "==> Merge $MergeRef into $TestBranch"
-            Merge-FeatureBranch -MergeRef $MergeRef -ExtraBranch $ExtraBranch -IgnoredPaths $IgnoredPaths
+        if ($Rebuild) {
+            Write-Host "==> Rebuild requested — recreating $TestBranch"
+        }
+        elseif (-not $TestBranchExists) {
+            Write-Host "==> $TestBranch missing — creating from $BaseRef"
         }
         else {
-            $Label = if ($UseLocalOnly) { "local branch" } else { "remote branch" }
-            Write-Warning "Extra feature $Label '$ExtraBranch' not found — continuing without it."
+            Write-Host "==> Inputs changed — recreating $TestBranch from $BaseRef"
+        }
+
+        if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
+            Write-Host "==> Delete $TestBranch"
+            if ((Get-CurrentBranch) -eq $TestBranch) {
+                Invoke-Git @('checkout', $ReturnBranch)
+            }
+            Invoke-Git @('branch', '-D', $TestBranch)
+        }
+
+        if (Test-GitRef "refs/heads/$TestBranch") {
+            Write-Host "==> Recreate $TestBranch from $BaseRef"
+            Invoke-Git @('branch', '-f', $TestBranch, $BaseRef)
+            Invoke-Git @('checkout', $TestBranch)
+        }
+        else {
+            Write-Host "==> Create $TestBranch from $BaseRef"
+            Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
+        }
+
+        foreach ($Extra in $ResolvedExtras) {
+            Write-Host "==> Merge $($Extra.MergeRef) into $TestBranch"
+            Merge-FeatureBranch -MergeRef $Extra.MergeRef -ExtraBranch $Extra.Branch -IgnoredPaths $IgnoredPaths
+        }
+
+        $NewTip = Get-RefSha -Ref 'HEAD'
+        if ($NewTip) {
+            Set-TestCombinedStamp -Commit $NewTip -Stamp $DesiredStamp
+            Write-Host "==> Stamp written for $TestBranch"
         }
     }
 
-    Write-Host "==> pytest topology tests"
-    & uv run python -m pytest `
-        tests/test_topology_invariants.py `
-        tests/test_topology_regressions.py `
-        tests/test_topology_layout.py `
-        tests/test_topology_geometry.py `
-        tests/test_topology_labels.py `
-        tests/test_pdn_topology.py -q
-    if ($LASTEXITCODE -ne 0) {
-        throw "pytest failed (exit $LASTEXITCODE)"
+    if ($SkipTests) {
+        Write-Host "==> Skip pytest (-SkipTests)"
+    }
+    else {
+        Write-Host "==> pytest topology tests"
+        & uv run python -m pytest `
+            tests/test_topology_invariants.py `
+            tests/test_topology_regressions.py `
+            tests/test_topology_layout.py `
+            tests/test_topology_geometry.py `
+            tests/test_topology_labels.py `
+            tests/test_pdn_topology.py -q
+        if ($LASTEXITCODE -ne 0) {
+            throw "pytest failed (exit $LASTEXITCODE)"
+        }
     }
 
     Write-Host "==> uv run FYPA.py"

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -8,7 +8,7 @@
 #
 # Usage (from repo root, any branch):
 #   pwsh scripts/test-combined.ps1
-#   pwsh scripts/test-combined.ps1 --local-only
+#   pwsh scripts/test-combined.ps1 -LocalOnly
 #   pwsh scripts/test-combined.ps1 -Rebuild
 #   pwsh scripts/test-combined.ps1 -SkipTests
 #   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
@@ -21,7 +21,7 @@
 # are accepted either way. If fetch fails (offline), existing refs are resolved
 # the same way. When input SHAs match the stamp on an existing test branch, that
 # branch is reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
-# Pass --local-only to skip fetch and use local branches only.
+# Pass -LocalOnly to skip fetch and use local branches only.
 #
 # Workflow:
 #   1. Remember current branch

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -14,15 +14,19 @@
 #   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
 #   pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
 #
-# By default baseBranch and extraFeatureBranches are soft-fetched from origin and
-# merged via origin/<branch>. If fetch fails (offline), local refs are used.
-# When input SHAs match the stamp on an existing test branch, that branch is
-# reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
+# By default baseBranch and extraFeatureBranches are soft-fetched from origin.
+# Each input is resolved to the tip that includes local work: if the local branch
+# is ahead of (or diverged from) origin/<branch>, the local tip is merged; if
+# local is behind, origin/<branch> is used; local-only or remote-only branches
+# are accepted either way. If fetch fails (offline), existing refs are resolved
+# the same way. When input SHAs match the stamp on an existing test branch, that
+# branch is reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
 # Pass --local-only to skip fetch and use local branches only.
 #
 # Workflow:
 #   1. Remember current branch
-#   2. Soft-fetch inputs (or local-only); reuse test branch if stamp matches
+#   2. Soft-fetch inputs (or local-only); resolve tips (prefer local when ahead);
+#      reuse test branch if stamp matches
 #   3. Otherwise optionally delete, recreate from base, merge feature branches
 #      (.gitignore conflicts auto-resolved with --ours); write stamp note
 #   4. Optionally run pytest topology suite (-SkipTests to skip), then uv run FYPA.py
@@ -110,30 +114,120 @@ function Test-GitRef {
     return $LASTEXITCODE -eq 0
 }
 
-function Get-BranchMergeRef {
+function Test-GitAncestor {
     param(
-        [string] $Branch,
-        [string] $RemoteName,
-        [bool] $UseLocalOnly
+        [string] $Ancestor,
+        [string] $Descendant
     )
-
-    if ($UseLocalOnly) {
-        return $Branch
-    }
-    return "$RemoteName/$Branch"
+    & git.exe merge-base --is-ancestor $Ancestor $Descendant 2>$null | Out-Null
+    return $LASTEXITCODE -eq 0
 }
 
-function Test-BranchAvailable {
+function Resolve-BranchMergeTarget {
     param(
         [string] $Branch,
         [string] $RemoteName,
         [bool] $UseLocalOnly
     )
 
+    $LocalRef = $Branch
+    $RemoteRef = "$RemoteName/$Branch"
+    $HasLocal = Test-GitRef "refs/heads/$Branch"
+    $HasRemote = Test-GitRef "refs/remotes/$RemoteName/$Branch"
+
     if ($UseLocalOnly) {
-        return Test-GitRef "refs/heads/$Branch"
+        if (-not $HasLocal) { return $null }
+        $Sha = Get-RefSha -Ref $LocalRef
+        if (-not $Sha) { return $null }
+        return @{
+            Branch   = $Branch
+            MergeRef = $LocalRef
+            Sha      = $Sha
+            Source   = 'local'
+        }
     }
-    return Test-GitRef "refs/remotes/$RemoteName/$Branch"
+
+    if ($HasLocal -and $HasRemote) {
+        $LocalSha = Get-RefSha -Ref $LocalRef
+        $RemoteSha = Get-RefSha -Ref $RemoteRef
+        if (-not $LocalSha -and -not $RemoteSha) { return $null }
+        if (-not $LocalSha) {
+            return @{
+                Branch   = $Branch
+                MergeRef = $RemoteRef
+                Sha      = $RemoteSha
+                Source   = 'remote'
+            }
+        }
+        if (-not $RemoteSha) {
+            return @{
+                Branch   = $Branch
+                MergeRef = $LocalRef
+                Sha      = $LocalSha
+                Source   = 'local'
+            }
+        }
+        if ($LocalSha -eq $RemoteSha) {
+            return @{
+                Branch   = $Branch
+                MergeRef = $LocalRef
+                Sha      = $LocalSha
+                Source   = 'local'
+            }
+        }
+        # Local contains remote → unpushed local commits; keep them.
+        if (Test-GitAncestor -Ancestor $RemoteSha -Descendant $LocalSha) {
+            Write-Host "==> ${Branch}: using local (ahead of $RemoteRef)"
+            return @{
+                Branch   = $Branch
+                MergeRef = $LocalRef
+                Sha      = $LocalSha
+                Source   = 'local'
+            }
+        }
+        # Remote contains local → local checkout is stale; take remote.
+        if (Test-GitAncestor -Ancestor $LocalSha -Descendant $RemoteSha) {
+            return @{
+                Branch   = $Branch
+                MergeRef = $RemoteRef
+                Sha      = $RemoteSha
+                Source   = 'remote'
+            }
+        }
+        # Diverged: never drop local work.
+        Write-Warning "${Branch}: local and $RemoteRef have diverged — using local tip"
+        return @{
+            Branch   = $Branch
+            MergeRef = $LocalRef
+            Sha      = $LocalSha
+            Source   = 'local'
+        }
+    }
+
+    if ($HasLocal) {
+        $Sha = Get-RefSha -Ref $LocalRef
+        if (-not $Sha) { return $null }
+        Write-Host "==> ${Branch}: no $RemoteRef — using local"
+        return @{
+            Branch   = $Branch
+            MergeRef = $LocalRef
+            Sha      = $Sha
+            Source   = 'local'
+        }
+    }
+
+    if ($HasRemote) {
+        $Sha = Get-RefSha -Ref $RemoteRef
+        if (-not $Sha) { return $null }
+        return @{
+            Branch   = $Branch
+            MergeRef = $RemoteRef
+            Sha      = $Sha
+            Source   = 'remote'
+        }
+    }
+
+    return $null
 }
 
 function Sync-RemoteBranches {
@@ -438,7 +532,7 @@ if ($UseLocalOnly) {
     Write-Host "==> Branch source: local only"
 }
 else {
-    Write-Host "==> Branch source: $Remote (soft-fetch + merge remote-tracking refs)"
+    Write-Host "==> Branch source: $Remote (soft-fetch; prefer local when ahead/diverged)"
 }
 
 $ReturnBranch = Get-CurrentBranch
@@ -446,56 +540,42 @@ if (-not $ReturnBranch) {
     throw "Could not determine the current branch."
 }
 
-if ($UseLocalOnly) {
-    if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $true)) {
-        throw "Base branch '$BaseBranch' not found locally."
-    }
-}
-else {
+if (-not $UseLocalOnly) {
     try {
         Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
-        if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $false)) {
-            throw "Remote branch '$Remote/$BaseBranch' not found after fetch."
-        }
     }
     catch {
-        Write-Warning "Fetch from $Remote failed or remote base missing; falling back to local refs."
+        Write-Warning "Fetch from $Remote failed; resolving from existing local/remote-tracking refs."
         Write-Warning "$_"
-        $UseLocalOnly = $true
-        if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $true)) {
-            throw "Base branch '$BaseBranch' not found locally after soft-fetch fallback."
-        }
-        Write-Host "==> Branch source: local only (fallback)"
     }
 }
 
-$BaseRef = Get-BranchMergeRef -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
-$BaseSha = Get-RefSha -Ref $BaseRef
-if (-not $BaseSha) {
-    throw "Could not resolve SHA for base ref '$BaseRef'."
+$BaseTarget = Resolve-BranchMergeTarget -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+if (-not $BaseTarget) {
+    $Where = if ($UseLocalOnly) { "locally" } else { "locally or as $Remote/$BaseBranch" }
+    throw "Base branch '$BaseBranch' not found $Where."
 }
+
+$BaseRef = $BaseTarget.MergeRef
+$BaseSha = $BaseTarget.Sha
+Write-Host "==> Base: $BaseRef ($($BaseTarget.Source))"
 
 $ExtraStampPairs = [System.Collections.Generic.List[string]]::new()
 $ResolvedExtras = [System.Collections.Generic.List[hashtable]]::new()
 foreach ($ExtraBranch in $ExtraFeatureBranches) {
     if (-not $ExtraBranch) { continue }
-    $MergeRef = Get-BranchMergeRef -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
-    if (Test-BranchAvailable -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly) {
-        $ExtraSha = Get-RefSha -Ref $MergeRef
-        if (-not $ExtraSha) {
-            Write-Warning "Could not resolve SHA for '$MergeRef' — continuing without it."
-            continue
-        }
-        $ExtraStampPairs.Add("$ExtraBranch=$ExtraSha")
-        $ResolvedExtras.Add(@{
-            Branch   = $ExtraBranch
-            MergeRef = $MergeRef
-        })
+    $ExtraTarget = Resolve-BranchMergeTarget -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+    if (-not $ExtraTarget) {
+        $Where = if ($UseLocalOnly) { "locally" } else { "locally or on $Remote" }
+        Write-Warning "Extra feature branch '$ExtraBranch' not found $Where — continuing without it."
+        continue
     }
-    else {
-        $Label = if ($UseLocalOnly) { "local branch" } else { "remote branch" }
-        Write-Warning "Extra feature $Label '$ExtraBranch' not found — continuing without it."
-    }
+    Write-Host "==> Extra: $($ExtraTarget.MergeRef) ($($ExtraTarget.Source))"
+    $ExtraStampPairs.Add("$ExtraBranch=$($ExtraTarget.Sha)")
+    $ResolvedExtras.Add(@{
+        Branch   = $ExtraTarget.Branch
+        MergeRef = $ExtraTarget.MergeRef
+    })
 }
 
 $ConfigIdentity = @(

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -1,69 +1,26 @@
 <#
 .SYNOPSIS
-    Build a local combined test branch, run tests/FYPA, then switch back.
+    Check out origin/test/combined, optionally run tests/FYPA, then switch back.
 
 .DESCRIPTION
-    Merges a base branch plus feature branches into a disposable test branch,
-    optionally runs the pytest topology suite and FYPA.py, then returns to the
-    branch you started on (even if a step exits with an error).
+    The combined branch is maintained centrally (see scripts/maintain-test-combined.ps1).
+    This script only fetches and checks out the remote tip — it does not merge
+    feature branches.
 
-    Config resolution (first match wins):
-      scripts/test-combined.json          local override (gitignored)
-      team/test-combined.json             working tree
-      team/local:team/test-combined.json  from team/local via git show (no checkout)
-      scripts/test-combined.example.json  fallback
-
-    By default baseBranch and extraFeatureBranches are soft-fetched from origin.
-    Each input is resolved to the tip that includes local work: if the local
-    branch is ahead of (or diverged from) origin/<branch>, the local tip is
-    merged; if local is behind, origin/<branch> is used; local-only or
-    remote-only branches are accepted either way. If fetch fails (offline),
-    existing refs are resolved the same way.
-
-    When input SHAs match the stamp on an existing test branch, that branch is
-    reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
-    Pass -LocalOnly to skip fetch and use local branches only.
-
-    Workflow:
-      1. Remember current branch
-      2. Soft-fetch inputs (or local-only); resolve tips (prefer local when ahead);
-         reuse test branch if stamp matches
-      3. Otherwise optionally delete, recreate from base, merge feature branches
-         (.gitignore conflicts auto-resolved with --ours); write stamp note
-      4. Optionally run pytest topology suite (-SkipTests to skip), then uv run FYPA.py
-      5. Return to the starting branch
-
-.PARAMETER ConfigPath
-    Path to a JSON config file. Overrides the default config search order.
-
-.PARAMETER TeamConfigRef
-    Git ref used when reading team/test-combined.json via git show.
-    Default: team/local
+    To rebuild and push test/combined:
+      pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
 
 .PARAMETER Remote
-    Remote name used for soft-fetch and tip resolution. Default: origin
+    Remote name. Default: origin
 
-.PARAMETER LocalOnly
-    Skip fetch; resolve and merge local branches only.
+.PARAMETER TestBranch
+    Combined branch name. Default: test/combined
 
 .PARAMETER Rebuild
-    Force delete/recreate of the test branch even when the stamp matches.
+    Not supported here — prints how to run maintain-test-combined.ps1 and exits 1.
 
 .PARAMETER SkipTests
     Skip the pytest topology suite; still runs FYPA.py unless the script exits earlier.
-
-.PARAMETER BaseBranch
-    Override config baseBranch (branch the test branch is created from).
-
-.PARAMETER TestBranch
-    Override config testBranch (name of the disposable combined branch).
-
-.PARAMETER ExtraFeatureBranches
-    Override config extraFeatureBranches (branches merged onto the base).
-
-.PARAMETER DeleteTestBranchFirst
-    Override config deleteTestBranchFirst. When true, delete the existing test
-    branch before recreating it.
 
 .PARAMETER PrjPcb
     Path to a .PrjPcb passed through to FYPA.py.
@@ -71,55 +28,16 @@
 .EXAMPLE
     pwsh scripts/test-combined.ps1
 
-    Use default config resolution, soft-fetch, reuse or rebuild the test branch,
-    run tests and FYPA, then switch back.
-
 .EXAMPLE
-    pwsh scripts/test-combined.ps1 -LocalOnly
-
-    Skip remote fetch; use local branch tips only.
-
-.EXAMPLE
-    pwsh scripts/test-combined.ps1 -Rebuild
-
-    Force a clean recreate of the test branch.
-
-.EXAMPLE
-    pwsh scripts/test-combined.ps1 -SkipTests
-
-    Build/reuse the test branch and run FYPA without pytest.
-
-.EXAMPLE
-    pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
-
-    Use an explicit local config file.
-
-.EXAMPLE
-    pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
-
-    Pass a project file through to FYPA.py.
-
-.EXAMPLE
-    Get-Help .\scripts\test-combined.ps1 -Full
-
-    Show this help. Equivalent: pwsh scripts/test-combined.ps1 -?
-
-.NOTES
-    Run from the repo root (or any branch); the script cds to the repo root itself.
+    pwsh scripts/test-combined.ps1 -SkipTests -PrjPcb path\to\Board.PrjPcb
 #>
 
 [CmdletBinding()]
 param(
-    [string] $ConfigPath,
-    [string] $TeamConfigRef = "team/local",
     [string] $Remote = "origin",
-    [switch] $LocalOnly,
+    [string] $TestBranch = "test/combined",
     [switch] $Rebuild,
     [switch] $SkipTests,
-    [string] $BaseBranch,
-    [string] $TestBranch,
-    [string[]] $ExtraFeatureBranches,
-    [bool] $DeleteTestBranchFirst,
     [string] $PrjPcb
 )
 
@@ -127,6 +45,18 @@ $ErrorActionPreference = "Stop"
 
 $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
 Set-Location $RepoRoot
+
+if ($Rebuild) {
+    Write-Error @"
+-Rebuild is no longer supported by test-combined.ps1.
+Rebuild and publish the shared branch with:
+
+  pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+
+Then re-run this script to check out $Remote/$TestBranch.
+"@
+    exit 1
+}
 
 function Invoke-GitCore {
     param(
@@ -176,12 +106,8 @@ function Invoke-Git {
     return $Result.Output
 }
 
-function Invoke-GitSoft {
-    param(
-        [Parameter(Mandatory, ValueFromRemainingArguments)]
-        [string[]] $GitArgs
-    )
-    return (Invoke-GitCore @GitArgs).ExitCode
+function Get-CurrentBranch {
+    return ([string] (Invoke-Git @('branch', '--show-current') | Select-Object -First 1)).Trim()
 }
 
 function Test-GitRef {
@@ -190,406 +116,8 @@ function Test-GitRef {
     return $LASTEXITCODE -eq 0
 }
 
-function Test-GitAncestor {
-    param(
-        [string] $Ancestor,
-        [string] $Descendant
-    )
-    & git.exe merge-base --is-ancestor $Ancestor $Descendant 2>$null | Out-Null
-    return $LASTEXITCODE -eq 0
-}
-
-function Resolve-BranchMergeTarget {
-    param(
-        [string] $Branch,
-        [string] $RemoteName,
-        [bool] $UseLocalOnly
-    )
-
-    $LocalRef = $Branch
-    $RemoteRef = "$RemoteName/$Branch"
-    $HasLocal = Test-GitRef "refs/heads/$Branch"
-    $HasRemote = Test-GitRef "refs/remotes/$RemoteName/$Branch"
-
-    if ($UseLocalOnly) {
-        if (-not $HasLocal) { return $null }
-        $Sha = Get-RefSha -Ref $LocalRef
-        if (-not $Sha) { return $null }
-        return @{
-            Branch   = $Branch
-            MergeRef = $LocalRef
-            Sha      = $Sha
-            Source   = 'local'
-        }
-    }
-
-    if ($HasLocal -and $HasRemote) {
-        $LocalSha = Get-RefSha -Ref $LocalRef
-        $RemoteSha = Get-RefSha -Ref $RemoteRef
-        if (-not $LocalSha -and -not $RemoteSha) { return $null }
-        if (-not $LocalSha) {
-            return @{
-                Branch   = $Branch
-                MergeRef = $RemoteRef
-                Sha      = $RemoteSha
-                Source   = 'remote'
-            }
-        }
-        if (-not $RemoteSha) {
-            return @{
-                Branch   = $Branch
-                MergeRef = $LocalRef
-                Sha      = $LocalSha
-                Source   = 'local'
-            }
-        }
-        if ($LocalSha -eq $RemoteSha) {
-            return @{
-                Branch   = $Branch
-                MergeRef = $LocalRef
-                Sha      = $LocalSha
-                Source   = 'local'
-            }
-        }
-        # Local contains remote → unpushed local commits; keep them.
-        if (Test-GitAncestor -Ancestor $RemoteSha -Descendant $LocalSha) {
-            Write-Host "==> ${Branch}: using local (ahead of $RemoteRef)"
-            return @{
-                Branch   = $Branch
-                MergeRef = $LocalRef
-                Sha      = $LocalSha
-                Source   = 'local'
-            }
-        }
-        # Remote contains local → local checkout is stale; take remote.
-        if (Test-GitAncestor -Ancestor $LocalSha -Descendant $RemoteSha) {
-            return @{
-                Branch   = $Branch
-                MergeRef = $RemoteRef
-                Sha      = $RemoteSha
-                Source   = 'remote'
-            }
-        }
-        # Diverged: never drop local work.
-        Write-Warning "${Branch}: local and $RemoteRef have diverged — using local tip"
-        return @{
-            Branch   = $Branch
-            MergeRef = $LocalRef
-            Sha      = $LocalSha
-            Source   = 'local'
-        }
-    }
-
-    if ($HasLocal) {
-        $Sha = Get-RefSha -Ref $LocalRef
-        if (-not $Sha) { return $null }
-        Write-Host "==> ${Branch}: no $RemoteRef — using local"
-        return @{
-            Branch   = $Branch
-            MergeRef = $LocalRef
-            Sha      = $Sha
-            Source   = 'local'
-        }
-    }
-
-    if ($HasRemote) {
-        $Sha = Get-RefSha -Ref $RemoteRef
-        if (-not $Sha) { return $null }
-        return @{
-            Branch   = $Branch
-            MergeRef = $RemoteRef
-            Sha      = $Sha
-            Source   = 'remote'
-        }
-    }
-
-    return $null
-}
-
-function Sync-RemoteBranches {
-    param(
-        [string] $RemoteName,
-        [string[]] $Branches
-    )
-
-    $UniqueBranches = @($Branches | Where-Object { $_ } | Select-Object -Unique)
-    if ($UniqueBranches.Count -eq 0) {
-        return
-    }
-
-    Write-Host "==> Fetch $RemoteName $($UniqueBranches -join ', ')"
-    # git writes progress to stderr; don't surface it as PowerShell warnings.
-    $Result = Invoke-GitCore -Quiet @(@('fetch', $RemoteName) + $UniqueBranches)
-    if ($Result.ExitCode -ne 0) {
-        $Detail = ($Result.Output -join "`n").Trim()
-        if ($Detail) {
-            throw "git fetch $RemoteName failed (exit $($Result.ExitCode)): $Detail"
-        }
-        throw "git fetch $RemoteName failed (exit $($Result.ExitCode))"
-    }
-}
-
-function Get-RefSha {
-    param([string] $Ref)
-    $Sha = ([string] (& git.exe rev-parse --verify "$Ref^{commit}" 2>$null)).Trim()
-    if ($LASTEXITCODE -ne 0 -or -not $Sha) {
-        return $null
-    }
-    return $Sha
-}
-
-function Get-InputStamp {
-    param(
-        [string] $ConfigIdentity,
-        [string] $BaseName,
-        [string] $BaseSha,
-        [string[]] $ExtraPairs
-    )
-
-    # Single-line stamp: PowerShell [string] casts of multi-line git output join
-    # with spaces and would break equality checks if we used newlines.
-    $Parts = [System.Collections.Generic.List[string]]::new()
-    $Parts.Add("config=$ConfigIdentity")
-    $Parts.Add("base=$BaseName=$BaseSha")
-    foreach ($Pair in $ExtraPairs) {
-        if ($Pair) { $Parts.Add("extra=$Pair") }
-    }
-    return ($Parts -join '|')
-}
-
-function Get-TestCombinedStamp {
-    param([string] $Commit)
-    if (-not $Commit) { return $null }
-    $Lines = @(& git.exe notes --ref=test-combined show $Commit 2>$null)
-    if ($LASTEXITCODE -ne 0) {
-        return $null
-    }
-    # Join exactly as written; Trim only outer whitespace.
-    return (($Lines -join "`n").Trim())
-}
-
-function Set-TestCombinedStamp {
-    param(
-        [string] $Commit,
-        [string] $Stamp
-    )
-    $ExitCode = Invoke-GitSoft @(
-        'notes', '--ref=test-combined', 'add', '-f', '-m', $Stamp, $Commit
-    )
-    if ($ExitCode -ne 0) {
-        Write-Warning "Could not write test-combined stamp note on $Commit"
-    }
-}
-
-function ConvertTo-NormalizedStamp {
-    param([string] $Stamp)
-    if (-not $Stamp) { return $null }
-    # Accept legacy multiline notes (joined with `n) and new single-line (`|`) form.
-    $Normalized = $Stamp.Trim() -replace "`r`n", "`n" -replace "`r", "`n"
-    if ($Normalized.Contains("`n")) {
-        $Normalized = (($Normalized -split "`n") | ForEach-Object { $_.Trim() } | Where-Object { $_ }) -join '|'
-    }
-    return $Normalized
-}
-
-function Test-MergeInProgress {
-    $MergeHead = & git.exe rev-parse -q --verify MERGE_HEAD 2>$null
-    return [bool] $MergeHead
-}
-
-function Get-UnmergedPaths {
-    $Output = & git.exe diff --name-only --diff-filter=U 2>$null
-    if ($LASTEXITCODE -ne 0) {
-        return @()
-    }
-    return @($Output | Where-Object { $_ })
-}
-
-function Resolve-IgnoredMergeConflicts {
-    param(
-        [string[]] $IgnoredPaths,
-        [ValidateSet('ours', 'theirs')]
-        [string] $Prefer = 'ours'
-    )
-
-    foreach ($Path in (Get-UnmergedPaths)) {
-        if ($Path -in $IgnoredPaths) {
-            Write-Host "==> Auto-resolve merge conflict in $Path ($Prefer)"
-            Invoke-Git @('checkout', "--$Prefer", '--', $Path)
-            Invoke-Git @('add', '--', $Path)
-        }
-    }
-
-    return @(Get-UnmergedPaths)
-}
-
-function Merge-FeatureBranch {
-    param(
-        [string] $MergeRef,
-        [string] $ExtraBranch,
-        [string[]] $IgnoredPaths
-    )
-
-    $MergeMessage = "test: merge $ExtraBranch for local testing"
-    $ExitCode = Invoke-GitSoft @(
-        'merge', $MergeRef, '--no-edit', '-m', $MergeMessage
-    )
-    if ($ExitCode -eq 0) {
-        return
-    }
-
-    if (-not (Test-MergeInProgress)) {
-        throw "git merge $MergeRef failed (exit $ExitCode)"
-    }
-
-    $Remaining = Resolve-IgnoredMergeConflicts -IgnoredPaths $IgnoredPaths -Prefer 'ours'
-    if ($Remaining.Count -gt 0) {
-        throw "Merge conflict in: $($Remaining -join ', ')"
-    }
-
-    Invoke-Git @('commit', '--no-edit')
-}
-
-function Get-CurrentBranch {
-    return ([string] (Invoke-Git @('branch', '--show-current') | Select-Object -First 1)).Trim()
-}
-
-function Restore-DevBranch {
-    param([string] $Branch)
-    if ($Branch) {
-        Invoke-Git @('checkout', $Branch)
-    }
-}
-
-function Get-GitConfigJson {
-    param(
-        [string[]] $Refs,
-        [string] $RepoPath = "team/test-combined.json"
-    )
-
-    foreach ($Ref in $Refs) {
-        if (-not $Ref) { continue }
-        $Spec = "${Ref}:${RepoPath}"
-        $Json = & git show $Spec 2>$null
-        if ($LASTEXITCODE -eq 0 -and $Json) {
-            return @{ Source = $Spec; Json = [string] $Json }
-        }
-    }
-
-    return $null
-}
-
-function Resolve-ConfigSource {
-    param(
-        [string] $ExplicitPath,
-        [string] $TeamRef
-    )
-
-    if ($ExplicitPath) {
-        if (Test-Path $ExplicitPath) {
-            return @{
-                Source = (Resolve-Path $ExplicitPath).Path
-                Json   = $null
-            }
-        }
-        if ($ExplicitPath -match ':') {
-            $Json = & git show $ExplicitPath 2>$null
-            if ($LASTEXITCODE -eq 0 -and $Json) {
-                return @{ Source = $ExplicitPath; Json = [string] $Json }
-            }
-        }
-        throw "Config file not found: $ExplicitPath"
-    }
-
-    $LocalCandidates = @(
-        (Join-Path $RepoRoot "scripts/test-combined.json"),
-        (Join-Path $RepoRoot "team/test-combined.json")
-    )
-
-    foreach ($Candidate in $LocalCandidates) {
-        if (Test-Path $Candidate) {
-            return @{
-                Source = (Resolve-Path $Candidate).Path
-                Json   = $null
-            }
-        }
-    }
-
-    $GitRefs = @(
-        $TeamRef,
-        "origin/$TeamRef"
-    )
-    $FromGit = Get-GitConfigJson -Refs $GitRefs
-    if ($FromGit) {
-        return $FromGit
-    }
-
-    $Example = Join-Path $RepoRoot "scripts/test-combined.example.json"
-    if (Test-Path $Example) {
-        Write-Warning "Using example config ($Example). Copy to scripts/test-combined.json or update team/local."
-        return @{
-            Source = (Resolve-Path $Example).Path
-            Json   = $null
-        }
-    }
-
-    throw @"
-No test-combined config found.
-Fetch team/local (git fetch origin team/local) or create scripts/test-combined.json from scripts/test-combined.example.json.
-"@
-}
-
-function Read-TestCombinedConfig {
-    param(
-        [string] $Source,
-        [string] $Json
-    )
-
-    try {
-        if ($Json) {
-            $Config = $Json | ConvertFrom-Json
-        }
-        else {
-            $Config = Get-Content -Raw -Path $Source | ConvertFrom-Json
-        }
-    }
-    catch {
-        throw "Failed to parse config JSON at '$Source': $_"
-    }
-
-    foreach ($Required in @("baseBranch", "testBranch", "extraFeatureBranches")) {
-        if (-not ($Config.PSObject.Properties.Name -contains $Required)) {
-            throw "Config '$Source' is missing required field '$Required'."
-        }
-    }
-
-    return $Config
-}
-
 if (-not (Test-Path "FYPA.py")) {
     throw "FYPA.py not found in $RepoRoot — run this script from the FYPA repo."
-}
-
-$ConfigSource = Resolve-ConfigSource -ExplicitPath $ConfigPath -TeamRef $TeamConfigRef
-Write-Host "==> Config: $($ConfigSource.Source)"
-$Config = Read-TestCombinedConfig -Source $ConfigSource.Source -Json $ConfigSource.Json
-
-$BaseBranch = if ($PSBoundParameters.ContainsKey("BaseBranch")) { $BaseBranch } else { [string] $Config.baseBranch }
-$TestBranch = if ($PSBoundParameters.ContainsKey("TestBranch")) { $TestBranch } else { [string] $Config.testBranch }
-$ExtraFeatureBranches = if ($PSBoundParameters.ContainsKey("ExtraFeatureBranches")) {
-    $ExtraFeatureBranches
-}
-else {
-    @($Config.extraFeatureBranches | ForEach-Object { [string] $_ })
-}
-$DeleteTestBranchFirst = if ($PSBoundParameters.ContainsKey("DeleteTestBranchFirst")) {
-    $DeleteTestBranchFirst
-}
-elseif ($Config.PSObject.Properties.Name -contains "deleteTestBranchFirst") {
-    [bool] $Config.deleteTestBranchFirst
-}
-else {
-    $false
 }
 
 $PrjPcbPath = $null
@@ -600,94 +128,9 @@ if ($PrjPcb) {
     $PrjPcbPath = (Resolve-Path -LiteralPath $PrjPcb).Path
 }
 
-if (-not $BaseBranch) { throw "baseBranch is empty." }
-if (-not $TestBranch) { throw "testBranch is empty." }
-
-$UseLocalOnly = [bool] $LocalOnly
-if ($UseLocalOnly) {
-    Write-Host "==> Branch source: local only"
-}
-else {
-    Write-Host "==> Branch source: $Remote (soft-fetch; prefer local when ahead/diverged)"
-}
-
 $ReturnBranch = Get-CurrentBranch
 if (-not $ReturnBranch) {
     throw "Could not determine the current branch."
-}
-
-if (-not $UseLocalOnly) {
-    try {
-        Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
-    }
-    catch {
-        Write-Warning "Fetch from $Remote failed; resolving from existing local/remote-tracking refs."
-        Write-Warning "$_"
-    }
-}
-
-$BaseTarget = Resolve-BranchMergeTarget -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
-if (-not $BaseTarget) {
-    $Where = if ($UseLocalOnly) { "locally" } else { "locally or as $Remote/$BaseBranch" }
-    throw "Base branch '$BaseBranch' not found $Where."
-}
-
-$BaseRef = $BaseTarget.MergeRef
-$BaseSha = $BaseTarget.Sha
-Write-Host "==> Base: $BaseRef ($($BaseTarget.Source))"
-
-$ExtraStampPairs = [System.Collections.Generic.List[string]]::new()
-$ResolvedExtras = [System.Collections.Generic.List[hashtable]]::new()
-foreach ($ExtraBranch in $ExtraFeatureBranches) {
-    if (-not $ExtraBranch) { continue }
-    $ExtraTarget = Resolve-BranchMergeTarget -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
-    if (-not $ExtraTarget) {
-        $Where = if ($UseLocalOnly) { "locally" } else { "locally or on $Remote" }
-        Write-Warning "Extra feature branch '$ExtraBranch' not found $Where — continuing without it."
-        continue
-    }
-    Write-Host "==> Extra: $($ExtraTarget.MergeRef) ($($ExtraTarget.Source))"
-    $ExtraStampPairs.Add("$ExtraBranch=$($ExtraTarget.Sha)")
-    $ResolvedExtras.Add(@{
-        Branch   = $ExtraTarget.Branch
-        MergeRef = $ExtraTarget.MergeRef
-    })
-}
-
-$ConfigIdentity = @(
-    "base=$BaseBranch",
-    "test=$TestBranch",
-    "deleteFirst=$DeleteTestBranchFirst",
-    "extras=$($ExtraFeatureBranches -join ',')"
-) -join ';'
-
-$DesiredStamp = ConvertTo-NormalizedStamp (Get-InputStamp `
-    -ConfigIdentity $ConfigIdentity `
-    -BaseName $BaseBranch `
-    -BaseSha $BaseSha `
-    -ExtraPairs @($ExtraStampPairs))
-
-$TestBranchExists = Test-GitRef "refs/heads/$TestBranch"
-$ExistingTip = if ($TestBranchExists) { Get-RefSha -Ref $TestBranch } else { $null }
-$ExistingStampRaw = $null
-if ($ExistingTip) {
-    $ExistingStampRaw = Get-TestCombinedStamp -Commit $ExistingTip
-}
-$ExistingStamp = ConvertTo-NormalizedStamp $ExistingStampRaw
-$CanReuse = (
-    -not $Rebuild -and
-    $TestBranchExists -and
-    $ExistingStamp -and
-    ($ExistingStamp -eq $DesiredStamp)
-)
-
-if (-not $CanReuse -and $TestBranchExists -and -not $Rebuild) {
-    if (-not $ExistingStamp) {
-        Write-Host "==> No reuse stamp on $TestBranch — will rebuild"
-    }
-    else {
-        Write-Host "==> Stamp mismatch on $TestBranch — will rebuild"
-    }
 }
 
 $IgnoredPaths = @('.gitignore', 'FYPA.code-workspace')
@@ -705,55 +148,27 @@ Commit or stash them before running the test script.
 "@
 }
 
+$RemoteRef = "$Remote/$TestBranch"
+Write-Host "==> Fetch $Remote $TestBranch"
+$FetchResult = Invoke-GitCore -Quiet @('fetch', $Remote, $TestBranch)
+if ($FetchResult.ExitCode -ne 0) {
+    Write-Warning "Fetch failed; using existing $RemoteRef if present."
+}
+
+if (-not (Test-GitRef "refs/remotes/$Remote/$TestBranch")) {
+    throw @"
+$RemoteRef not found.
+Publish the shared branch first:
+  pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+"@
+}
+
 $Returned = $false
 $FypaExit = 0
 try {
-    if ($CanReuse) {
-        Write-Host "==> Reuse $TestBranch (inputs unchanged)"
-        if ((Get-CurrentBranch) -ne $TestBranch) {
-            Invoke-Git @('checkout', $TestBranch)
-        }
-    }
-    else {
-        if ($Rebuild) {
-            Write-Host "==> Rebuild requested — recreating $TestBranch"
-        }
-        elseif (-not $TestBranchExists) {
-            Write-Host "==> $TestBranch missing — creating from $BaseRef"
-        }
-        else {
-            Write-Host "==> Inputs changed — recreating $TestBranch from $BaseRef"
-        }
-
-        if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
-            Write-Host "==> Delete $TestBranch"
-            if ((Get-CurrentBranch) -eq $TestBranch) {
-                Invoke-Git @('checkout', $ReturnBranch)
-            }
-            Invoke-Git @('branch', '-D', $TestBranch)
-        }
-
-        if (Test-GitRef "refs/heads/$TestBranch") {
-            Write-Host "==> Recreate $TestBranch from $BaseRef"
-            Invoke-Git @('branch', '-f', $TestBranch, $BaseRef)
-            Invoke-Git @('checkout', $TestBranch)
-        }
-        else {
-            Write-Host "==> Create $TestBranch from $BaseRef"
-            Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
-        }
-
-        foreach ($Extra in $ResolvedExtras) {
-            Write-Host "==> Merge $($Extra.MergeRef) into $TestBranch"
-            Merge-FeatureBranch -MergeRef $Extra.MergeRef -ExtraBranch $Extra.Branch -IgnoredPaths $IgnoredPaths
-        }
-
-        $NewTip = Get-RefSha -Ref 'HEAD'
-        if ($NewTip) {
-            Set-TestCombinedStamp -Commit $NewTip -Stamp $DesiredStamp
-            Write-Host "==> Stamp written for $TestBranch"
-        }
-    }
+    Write-Host "==> Checkout $TestBranch from $RemoteRef"
+    Invoke-Git @('checkout', '-B', $TestBranch, $RemoteRef)
+    Invoke-Git @('reset', '--hard', $RemoteRef)
 
     if ($SkipTests) {
         Write-Host "==> Skip pytest (-SkipTests)"
@@ -783,24 +198,20 @@ try {
     $FypaExit = $LASTEXITCODE
 }
 catch {
-    if (Get-CurrentBranch -ne $ReturnBranch) {
-        & git merge --abort 2>$null | Out-Null
-        & git rebase --abort 2>$null | Out-Null
-    }
     throw
 }
 finally {
     $Current = Get-CurrentBranch
     if ($Current -ne $ReturnBranch) {
         Write-Host "==> Return to $ReturnBranch"
-        Restore-DevBranch -Branch $ReturnBranch
+        Invoke-Git @('checkout', $ReturnBranch)
         $Returned = $true
     }
 }
 
 if (-not $Returned) {
     Write-Host "==> Return to $ReturnBranch"
-    Restore-DevBranch -Branch $ReturnBranch
+    Invoke-Git @('checkout', $ReturnBranch)
 }
 
 if ($FypaExit -and $FypaExit -ne 0) {

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -798,6 +798,189 @@ def test_series_auto_infer_single_channel_only():
     assert any("multi-channel SERIES requires explicit" in e for e in bad.errors)
 
 
+def test_series_template_r_with_indexed_nets_multi_pin():
+    """Unindexed PDN_R is a template; indexed nets alone define two channels.
+
+    Multi-pin footprints must still resolve pads from the named nets (no
+    2-pin auto-infer, no legacy '10 pads' error).
+    """
+    # Nets: 0=VIN_A 1=VOUT_A 2=VIN_B 3=VOUT_B 4=CTRL
+    proj = _minimal_proj(
+        nets=(
+            RawNet("VIN_A"), RawNet("VOUT_A"),
+            RawNet("VIN_B"), RawNet("VOUT_B"), RawNet("CTRL"),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="SW1", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN_R": "0.05",
+                    "PDN1_P_NET": "VIN_A",
+                    "PDN1_N_NET": "VOUT_A",
+                    "PDN2_P_NET": "VIN_B",
+                    "PDN2_N_NET": "VOUT_B",
+                },
+                pin_designators=("1", "2", "3", "4", "5"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="SW1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="RELAY", source_designator="SW1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 0),   # VIN_A
+            _pad(0, "2", 1, 1),  # VOUT_A
+            _pad(0, "3", 2, 2),  # VIN_B
+            _pad(0, "4", 3, 3),  # VOUT_B
+            _pad(0, "5", 4, 4),  # CTRL (ignored)
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    series = [d for d in result.directives if isinstance(d, ResistorSpec)]
+    assert len(series) == 2
+    by_ch = {d.channel_index: d for d in series}
+    assert None not in by_ch
+    assert by_ch[1].resistance == 0.05
+    assert by_ch[2].resistance == 0.05
+    assert {p.pad_designator for p in by_ch[1].p.pins} == {"1"}
+    assert {p.pad_designator for p in by_ch[1].n.pins} == {"2"}
+    assert {p.pad_designator for p in by_ch[2].p.pins} == {"3"}
+    assert {p.pad_designator for p in by_ch[2].n.pins} == {"4"}
+
+
+def test_series_template_r_override_on_one_channel():
+    proj = _minimal_proj(
+        nets=(RawNet("A"), RawNet("B"), RawNet("C"), RawNet("D")),
+        sch_components=(
+            RawSchComponent(
+                designator="FB1", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN_R": "0.1",
+                    "PDN1_P_NET": "A", "PDN1_N_NET": "B",
+                    "PDN2_R": "0.2",
+                    "PDN2_P_NET": "C", "PDN2_N_NET": "D",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="FB1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="1206-4", source_designator="FB1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 0), _pad(0, "2", 1, 1),
+            _pad(0, "3", 2, 2), _pad(0, "4", 3, 3),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    by_ch = {
+        d.channel_index: d
+        for d in result.directives if isinstance(d, ResistorSpec)
+    }
+    assert by_ch[1].resistance == 0.1
+    assert by_ch[2].resistance == 0.2
+
+
+def test_regulator_template_shared_in_and_voltage():
+    """Shared PDN_V / IN_* / TYPE with per-channel OUT_* only — no legacy channel."""
+    # Nets: 0=GND 1=VIN 2=VOUT_P 3=VOUT_N
+    proj = _minimal_proj(
+        nets=(
+            RawNet("GND"), RawNet("VIN"), RawNet("VOUT_P"), RawNet("VOUT_N"),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="U2", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_V": "3.3",
+                    "PDN_REGULATOR_TYPE": "LDO",
+                    "PDN_QUIESCENT": "390uA",
+                    "PDN_IN_P_NET": "VIN",
+                    "PDN_IN_N_NET": "GND",
+                    "PDN1_OUT_P_NET": "VOUT_P",
+                    "PDN1_OUT_N_NET": "GND",
+                    "PDN2_OUT_P_NET": "GND",
+                    "PDN2_OUT_N_NET": "VOUT_N",
+                },
+                pin_designators=("1", "2", "3", "4", "5"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U2", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="DFN", source_designator="U2",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1),   # VIN
+            _pad(0, "2", 0, 1),  # GND
+            _pad(0, "3", 2, 2),  # VOUT_P
+            _pad(0, "4", 3, 3),  # VOUT_N
+            _pad(0, "5", 0, 4),  # GND again
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    regs = [d for d in result.directives if isinstance(d, RegulatorSpec)]
+    assert len(regs) == 2
+    by_ch = {d.channel_index: d for d in regs}
+    assert None not in by_ch
+    assert by_ch[1].voltage == 3.3
+    assert by_ch[2].voltage == 3.3
+    assert by_ch[1].regulator_type == "LDO"
+    assert by_ch[2].quiescent_current == pytest.approx(390e-6)
+    assert by_ch[1].in_p.requested_net == "VIN"
+    assert by_ch[2].in_p.requested_net == "VIN"
+    assert by_ch[1].out_p.requested_net == "VOUT_P"
+    assert by_ch[2].out_n.requested_net == "VOUT_N"
+
+
+def test_sink_unindexed_plus_indexed_both_real_channels():
+    """Legacy SINK with its own terminals stays a real channel beside PDN1_*."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+3V3"), RawNet("+1V8")),
+        sch_components=(
+            RawSchComponent(
+                designator="U7", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "500mA",
+                    "PDN_P_NET": "+3V3",
+                    "PDN_N_NET": "GND",
+                    "PDN1_I": "250mA",
+                    "PDN1_P_NET": "+1V8",
+                    "PDN1_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U7", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U7",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1),
+            _pad(0, "2", 2, 1),
+            _pad(0, "3", 0, 2),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert {d.channel_index for d in sinks} == {None, 1}
+
+
 def test_series_nested_pcb_placement_and_indexed_channels():
     proj = _minimal_proj(
         nets=(RawNet("A"), RawNet("B"), RawNet("C"), RawNet("D")),

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -981,6 +981,126 @@ def test_sink_unindexed_plus_indexed_both_real_channels():
     assert {d.channel_index for d in sinks} == {None, 1}
 
 
+def test_sink_template_shared_n_net():
+    """Shared PDN_N_NET alone is template-only; each channel needs its P net."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+3V3"), RawNet("+1V8")),
+        sch_components=(
+            RawSchComponent(
+                designator="U7", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_N_NET": "GND",
+                    "PDN1_P_NET": "+3V3",
+                    "PDN2_I": "50mA",
+                    "PDN2_P_NET": "+1V8",
+                },
+                pin_designators=("1", "2", "3"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U7", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U7",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1),
+            _pad(0, "2", 2, 1),
+            _pad(0, "3", 0, 2),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    by_ch = {d.channel_index: d for d in sinks}
+    assert None not in by_ch
+    assert by_ch[1].current == pytest.approx(0.1)
+    assert by_ch[2].current == pytest.approx(0.05)
+    assert by_ch[1].n.requested_net == "GND"
+    assert by_ch[2].n.requested_net == "GND"
+
+
+def test_series_template_shared_p_net():
+    """Shared PDN_P_NET alone is template-only with per-channel N nets."""
+    proj = _minimal_proj(
+        nets=(RawNet("VIN"), RawNet("VOUT_A"), RawNet("VOUT_B")),
+        sch_components=(
+            RawSchComponent(
+                designator="SW1", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SERIES",
+                    "PDN_R": "0.05",
+                    "PDN_P_NET": "VIN",
+                    "PDN1_N_NET": "VOUT_A",
+                    "PDN2_N_NET": "VOUT_B",
+                },
+                pin_designators=("1", "2", "3"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="SW1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="RELAY", source_designator="SW1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 0),
+            _pad(0, "2", 1, 1),
+            _pad(0, "3", 2, 2),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    by_ch = {
+        d.channel_index: d
+        for d in result.directives if isinstance(d, ResistorSpec)
+    }
+    assert None not in by_ch
+    assert by_ch[1].p.requested_net == "VIN"
+    assert by_ch[2].p.requested_net == "VIN"
+    assert by_ch[1].n.requested_net == "VOUT_A"
+    assert by_ch[2].n.requested_net == "VOUT_B"
+
+
+def test_cross_role_value_suffix_does_not_create_phantom_channel():
+    """Leftover PDN1_R alone on a SINK-only part must not invent a channel."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("+3V3")),
+        sch_components=(
+            RawSchComponent(
+                designator="U7", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN_I": "100mA",
+                    "PDN_P_NET": "+3V3",
+                    "PDN_N_NET": "GND",
+                    "PDN1_R": "0.1",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="U7", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="QFN", source_designator="U7",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 1),
+            _pad(0, "2", 0, 1),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    sinks = [d for d in result.directives if isinstance(d, SinkSpec)]
+    assert len(sinks) == 1
+    assert sinks[0].channel_index is None
+    assert not any(isinstance(d, ResistorSpec) for d in result.directives)
+    assert any("PDN1_R" in w for w in result.warnings)
+
+
 def test_series_nested_pcb_placement_and_indexed_channels():
     proj = _minimal_proj(
         nets=(RawNet("A"), RawNet("B"), RawNet("C"), RawNet("D")),

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1101,6 +1101,38 @@ def test_cross_role_value_suffix_does_not_create_phantom_channel():
     assert any("PDN1_R" in w for w in result.warnings)
 
 
+def test_indexed_only_role_with_unindexed_value_template():
+    """PDNn_ROLE without part-wide PDN_ROLE may still inherit PDN_R / PDN_V."""
+    proj = _minimal_proj(
+        nets=(RawNet("A"), RawNet("B")),
+        sch_components=(
+            RawSchComponent(
+                designator="R1", schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN1_ROLE": "SERIES",
+                    "PDN_R": "0.05",
+                    "PDN1_P_NET": "A",
+                    "PDN1_N_NET": "B",
+                },
+                pin_designators=("1", "2"),
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="R1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="0402", source_designator="R1",
+            ),
+        ),
+        pads=(_pad(0, "1", 0), _pad(0, "2", 1, 1)),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    series = [d for d in result.directives if isinstance(d, ResistorSpec)]
+    assert len(series) == 1
+    assert series[0].channel_index == 1
+    assert series[0].resistance == 0.05
+
+
 def test_series_nested_pcb_placement_and_indexed_channels():
     proj = _minimal_proj(
         nets=(RawNet("A"), RawNet("B"), RawNet("C"), RawNet("D")),


### PR DESCRIPTION
## Motivation

Multi-path SERIES and multi-output REGULATOR parts often share one value or one side of the terminals (`PDN_R`, `PDN_IN_*`, a common return net) while each path has its own indexed nets. Today FYPA only auto-fills that pattern for a single unindexed 2-pad SERIES, so designers either duplicate every parameter per channel or get a misleading “N pads, not 2” / missing-channel failure when only the shared `PDN_*` form is present.

This change treats unset `PDNn_*` fields as inheriting from the unindexed `PDN_*` template, and only emits a legacy unindexed directive when that form still has a complete terminal set — so shared templates stay declarative and indexed channels resolve correctly.

## Summary

- Inherit unset indexed params from unindexed `PDN_*` templates via channel materialization
- Omit template-only unindexed channels when indexed channels exist (complete terminal set required to keep a real legacy channel)
- Scope channel discovery to active roles (no cross-role phantom channels)
- Indexed-only parts (`PDNn_ROLE` without `PDN_ROLE`): unindexed params stay templates
- Quiet dry-run role resolution for bridge / supply maps (`report_errors=False`)
- Docs + regression tests for shared nets, SERIES, REGULATOR, and edge cases

## Test plan

- [ ] `uv run pytest tests/test_annotations.py`
- [ ] Dual-path SERIES with shared `PDN_R` / return and per-channel nets → two SERIES directives
- [ ] Dual REGULATOR with shared IN / `PDN_V` and per-channel OUTs → two regulators
- [ ] Indexed-only `PDNn_ROLE` does not emit “missing PDN_ROLE” for template `PDN_R`/`PDN_V`
- [ ] Leftover cross-role `PDN1_*` on another role does not invent a phantom channel
