### PR TITLE
Auto-bridge Altium Net Ties without PDN SERIES directives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,8 @@ ExampleDesigns/Sandbox/*
 # would re-leak exactly what it removes. Run it before each commit.
 sanitize_sandbox.ps1
 wiring.json
-scripts/test-*.ps1
+# Local override for test-combined (team config is on team/local branch)
+scripts/test-combined.json
+# Fork-local team config (team/test-combined.json is tracked on team/local only)
+team/*
+!team/test-combined.json

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ sanitize_sandbox.ps1
 wiring.json
 # Local override for test-combined (team config is on team/local branch)
 scripts/test-combined.json
+scripts/py314.local.json
 # Fork-local team config (team/test-combined.json is tracked on team/local only)
 team/*
 !team/test-combined.json

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -1,0 +1,50 @@
+# Fork workflow (team/local)
+
+This fork keeps upstream-ready work separate from local team tooling.
+
+## Branches
+
+| Branch | Purpose |
+|--------|---------|
+| `main` | Tracks upstream; use as the base for upstream pull requests |
+| `team/local` | Shared fork config (combined-test branch list, etc.) |
+
+Daily development can use `team/local` or feature branches. **Do not merge `team/local` into branches you open upstream.**
+
+## Combined local test
+
+`scripts/test-combined.ps1` builds a throwaway branch, merges configured feature branches, runs topology tests and FYPA, then returns to your previous branch. Run it from **any** branch — config is read from `team/local` via `git show` when the file is not in your working tree.
+
+Config lives in `team/test-combined.json` on the `team/local` branch:
+
+```json
+{
+  "baseBranch": "main",
+  "testBranch": "test/combined",
+  "deleteTestBranchFirst": true,
+  "extraFeatureBranches": ["feature/example-a", "fix/example-b"]
+}
+```
+
+- `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate).
+- By default, `baseBranch` and `extraFeatureBranches` are **fetched from `origin`** and merged via `origin/<branch>`. Use `--local-only` to use local branches only.
+- Override any field on the command line, e.g. `-DeleteTestBranchFirst:$false`.
+
+```powershell
+pwsh scripts/test-combined.ps1
+pwsh scripts/test-combined.ps1 --local-only
+```
+
+Resolution order: `scripts/test-combined.json` (local override) → `team/test-combined.json` → `team/local:team/test-combined.json` → example file.
+
+For a one-off local config, copy `scripts/test-combined.example.json` to `scripts/test-combined.json` (gitignored).
+
+## Upstream pull requests
+
+Create the PR branch from upstream, not from `team/local`:
+
+```powershell
+git fetch upstream
+git checkout -b feature/my-fix upstream/main
+git cherry-pick <commit>   # feature commits only
+```

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -14,7 +14,7 @@ Daily development can use `team/local` or feature branches. **Do not merge `team
 
 ## Combined test (`test/combined`)
 
-Feature branches listed in `team/test-combined.json` on `team/local` are merged **once** into the shared `test/combined` branch and pushed to GitHub. Machines only fetch and check out that tip — they do not merge at Altium/FYPA start.
+Feature branches listed in `team/test-combined.json` on `team/local` are merged into the shared `test/combined` branch and pushed to GitHub. Machines only fetch and check out that tip — they do not merge at Altium/FYPA start.
 
 Config on `team/local`:
 
@@ -27,53 +27,54 @@ Config on `team/local`:
 }
 ```
 
-### Maintain (rebuild + publish)
+### Maintain (update + publish)
 
-Uses **origin tips only** (unpushed local commits are ignored). Missing remotes abort.
+Uses **origin tips only**. Prefer **incremental** updates (default): check out `origin/test/combined` and merge only extras not already in that tip. That keeps prior conflict resolutions.
 
 ```powershell
-pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+pwsh scripts/maintain-test-combined.ps1 -Push          # incremental
+pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push # clean recreate from main
+pwsh scripts/maintain-test-combined.ps1 -Abort         # escape stuck merge
 ```
 
-Omit `-Push` to rebuild locally while resolving merge conflicts, then push when clean.
+Omit `-Push` while resolving conflicts locally, then `-Push` when clean.
 
-On conflict, only `.gitignore` and `FYPA.code-workspace` auto-resolve with `--ours`; other conflicts stop the script.
+**Conflicts:** only `.gitignore` / `FYPA.code-workspace` auto-resolve. On a real conflict the script stays on `test/combined` — do not `git switch` away. Either finish (`git add` + `git commit`, then `-Push`) or run `-Abort` to hard-reset to `origin/test/combined` and return to your previous branch.
 
-Config resolution for maintain: `scripts/test-combined.json` (gitignored override) → `team/test-combined.json` → `team/local:team/test-combined.json` → example file.
+Use `-Rebuild` only when `main` moved a lot, extras were removed/reordered, or the tip is broken. Expect to resolve the same conflicts again.
+
+Config resolution: `scripts/test-combined.json` (gitignored) → `team/test-combined.json` → `team/local:team/test-combined.json` → example file.
 
 ### GitHub Action (fork only)
 
-`.github/workflows/maintain-test-combined.yml` lives **only on `team/local`** — never commit it to `main` or to branches destined for an upstream PR.
+`.github/workflows/maintain-test-combined.yml` lives **only on `team/local`** — never commit it to `main` or upstream PR branches.
 
-Triggers: `workflow_dispatch` (use `--ref team/local`) and pushes to `team/local` that touch `team/test-combined.json`. The job runs maintain with `-Rebuild -Push`.
+Triggers: `workflow_dispatch` (`--ref team/local`) and pushes to `team/local` that touch `team/test-combined.json`.
 
 ### Launch (no merge)
 
 ```powershell
 pwsh scripts/test-combined.ps1
-pwsh scripts/test-combined.ps1 -SkipTests
 pwsh scripts/test-combined.ps1 -SkipTests -PrjPcb path\to\Board.PrjPcb
 ```
 
-Checks out `origin/test/combined`, optionally runs topology pytest, then FYPA. `-Rebuild` is not supported here — use maintain.
+Checks out `origin/test/combined` only. `-Rebuild` is not supported — use maintain.
 
-Altium bootstrap (`Run_FYPA.ps1`) calls `scripts/launch-combined-gui.ps1` after clone/`uv sync`: fetch + hard-reset to `origin/test/combined`, then `Launch_GUI.py`.
+Altium (`Run_FYPA.ps1`) calls `scripts/launch-combined-gui.ps1`.
 
 ### Typical flow
 
 1. Push the feature branch to `origin`.
 2. Add it to `team/test-combined.json` on `team/local` and push `team/local`.
-3. Run maintain (or let the Action rebuild) so `origin/test/combined` updates.
-4. On any machine: Altium → Run FYPA → fetch + checkout — done.
+3. `pwsh scripts/maintain-test-combined.ps1 -Push` (incremental).
+4. On any machine: Altium / `test-combined.ps1` → `origin/test/combined`.
 
 Prefer clean feature branches in the JSON (not pre-merged `*-combined` stacks).
 
 ## Upstream pull requests
 
-Create the PR branch from upstream, not from `team/local`:
-
 ```powershell
 git fetch upstream
 git checkout -b feature/my-fix upstream/main
-git cherry-pick <commit>   # feature commits only
+git cherry-pick <commit>
 ```

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -7,15 +7,16 @@ This fork keeps upstream-ready work separate from local team tooling.
 | Branch | Purpose |
 |--------|---------|
 | `main` | Tracks upstream; use as the base for upstream pull requests |
-| `team/local` | Shared fork config (combined-test branch list, etc.) |
+| `team/local` | Shared fork config (combined-test branch list, GH Action for maintain) |
+| `test/combined` | Published integration tip built from the JSON list (force-pushed) |
 
 Daily development can use `team/local` or feature branches. **Do not merge `team/local` into branches you open upstream.**
 
-## Combined local test
+## Combined test (`test/combined`)
 
-`scripts/test-combined.ps1` builds a throwaway branch, merges configured feature branches, optionally runs topology tests and FYPA, then returns to your previous branch. Run it from **any** branch — config is read from `team/local` via `git show` when the file is not in your working tree.
+Feature branches listed in `team/test-combined.json` on `team/local` are merged **once** into the shared `test/combined` branch and pushed to GitHub. Machines only fetch and check out that tip — they do not merge at Altium/FYPA start.
 
-Config lives in `team/test-combined.json` on the `team/local` branch:
+Config on `team/local`:
 
 ```json
 {
@@ -26,22 +27,46 @@ Config lives in `team/test-combined.json` on the `team/local` branch:
 }
 ```
 
-- `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate). Only applies when the branch is rebuilt, not when it is reused.
-- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`**. Each input tip is resolved so **local work is never dropped**: if the local branch is ahead of or diverged from `origin/<branch>`, the local tip is used; if local is behind, `origin/<branch>` is used; branches that exist only locally or only on the remote are accepted either way. If fetch fails (offline), the same resolution runs against existing refs. Use `-LocalOnly` to skip fetch and use local branches only.
-- When the existing `testBranch` tip has a matching stamp (input SHAs + config identity stored as a git note), the branch is **reused** instead of rebuilt. Pass `-Rebuild` to force a clean recreate.
-- Topology pytest runs by default. Pass `-SkipTests` to skip them (the Altium launcher always passes `-SkipTests`).
-- Override any field on the command line, e.g. `-DeleteTestBranchFirst:$false`.
+### Maintain (rebuild + publish)
+
+Uses **origin tips only** (unpushed local commits are ignored). Missing remotes abort.
+
+```powershell
+pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+```
+
+Omit `-Push` to rebuild locally while resolving merge conflicts, then push when clean.
+
+On conflict, only `.gitignore` and `FYPA.code-workspace` auto-resolve with `--ours`; other conflicts stop the script.
+
+Config resolution for maintain: `scripts/test-combined.json` (gitignored override) → `team/test-combined.json` → `team/local:team/test-combined.json` → example file.
+
+### GitHub Action (fork only)
+
+`.github/workflows/maintain-test-combined.yml` lives **only on `team/local`** — never commit it to `main` or to branches destined for an upstream PR.
+
+Triggers: `workflow_dispatch` (use `--ref team/local`) and pushes to `team/local` that touch `team/test-combined.json`. The job runs maintain with `-Rebuild -Push`.
+
+### Launch (no merge)
 
 ```powershell
 pwsh scripts/test-combined.ps1
-pwsh scripts/test-combined.ps1 -LocalOnly
-pwsh scripts/test-combined.ps1 -Rebuild
 pwsh scripts/test-combined.ps1 -SkipTests
+pwsh scripts/test-combined.ps1 -SkipTests -PrjPcb path\to\Board.PrjPcb
 ```
 
-Resolution order: `scripts/test-combined.json` (local override) → `team/test-combined.json` → `team/local:team/test-combined.json` → example file.
+Checks out `origin/test/combined`, optionally runs topology pytest, then FYPA. `-Rebuild` is not supported here — use maintain.
 
-For a one-off local config, copy `scripts/test-combined.example.json` to `scripts/test-combined.json` (gitignored).
+Altium bootstrap (`Run_FYPA.ps1`) calls `scripts/launch-combined-gui.ps1` after clone/`uv sync`: fetch + hard-reset to `origin/test/combined`, then `Launch_GUI.py`.
+
+### Typical flow
+
+1. Push the feature branch to `origin`.
+2. Add it to `team/test-combined.json` on `team/local` and push `team/local`.
+3. Run maintain (or let the Action rebuild) so `origin/test/combined` updates.
+4. On any machine: Altium → Run FYPA → fetch + checkout — done.
+
+Prefer clean feature branches in the JSON (not pre-merged `*-combined` stacks).
 
 ## Upstream pull requests
 

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -27,7 +27,7 @@ Config lives in `team/test-combined.json` on the `team/local` branch:
 ```
 
 - `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate). Only applies when the branch is rebuilt, not when it is reused.
-- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`** and merged via `origin/<branch>`. If fetch fails (offline), local refs are used instead. Use `--local-only` to skip fetch entirely.
+- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`**. Each input tip is resolved so **local work is never dropped**: if the local branch is ahead of or diverged from `origin/<branch>`, the local tip is used; if local is behind, `origin/<branch>` is used; branches that exist only locally or only on the remote are accepted either way. If fetch fails (offline), the same resolution runs against existing refs. Use `--local-only` to skip fetch and use local branches only.
 - When the existing `testBranch` tip has a matching stamp (input SHAs + config identity stored as a git note), the branch is **reused** instead of rebuilt. Pass `-Rebuild` to force a clean recreate.
 - Topology pytest runs by default. Pass `-SkipTests` to skip them (the Altium launcher always passes `-SkipTests`).
 - Override any field on the command line, e.g. `-DeleteTestBranchFirst:$false`.

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -27,14 +27,14 @@ Config lives in `team/test-combined.json` on the `team/local` branch:
 ```
 
 - `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate). Only applies when the branch is rebuilt, not when it is reused.
-- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`**. Each input tip is resolved so **local work is never dropped**: if the local branch is ahead of or diverged from `origin/<branch>`, the local tip is used; if local is behind, `origin/<branch>` is used; branches that exist only locally or only on the remote are accepted either way. If fetch fails (offline), the same resolution runs against existing refs. Use `--local-only` to skip fetch and use local branches only.
+- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`**. Each input tip is resolved so **local work is never dropped**: if the local branch is ahead of or diverged from `origin/<branch>`, the local tip is used; if local is behind, `origin/<branch>` is used; branches that exist only locally or only on the remote are accepted either way. If fetch fails (offline), the same resolution runs against existing refs. Use `-LocalOnly` to skip fetch and use local branches only.
 - When the existing `testBranch` tip has a matching stamp (input SHAs + config identity stored as a git note), the branch is **reused** instead of rebuilt. Pass `-Rebuild` to force a clean recreate.
 - Topology pytest runs by default. Pass `-SkipTests` to skip them (the Altium launcher always passes `-SkipTests`).
 - Override any field on the command line, e.g. `-DeleteTestBranchFirst:$false`.
 
 ```powershell
 pwsh scripts/test-combined.ps1
-pwsh scripts/test-combined.ps1 --local-only
+pwsh scripts/test-combined.ps1 -LocalOnly
 pwsh scripts/test-combined.ps1 -Rebuild
 pwsh scripts/test-combined.ps1 -SkipTests
 ```

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -13,7 +13,7 @@ Daily development can use `team/local` or feature branches. **Do not merge `team
 
 ## Combined local test
 
-`scripts/test-combined.ps1` builds a throwaway branch, merges configured feature branches, runs topology tests and FYPA, then returns to your previous branch. Run it from **any** branch — config is read from `team/local` via `git show` when the file is not in your working tree.
+`scripts/test-combined.ps1` builds a throwaway branch, merges configured feature branches, optionally runs topology tests and FYPA, then returns to your previous branch. Run it from **any** branch — config is read from `team/local` via `git show` when the file is not in your working tree.
 
 Config lives in `team/test-combined.json` on the `team/local` branch:
 
@@ -26,13 +26,17 @@ Config lives in `team/test-combined.json` on the `team/local` branch:
 }
 ```
 
-- `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate).
-- By default, `baseBranch` and `extraFeatureBranches` are **fetched from `origin`** and merged via `origin/<branch>`. Use `--local-only` to use local branches only.
+- `deleteTestBranchFirst`: when `true`, delete `testBranch` before recreating it (clean slate). Only applies when the branch is rebuilt, not when it is reused.
+- By default, `baseBranch` and `extraFeatureBranches` are **soft-fetched from `origin`** and merged via `origin/<branch>`. If fetch fails (offline), local refs are used instead. Use `--local-only` to skip fetch entirely.
+- When the existing `testBranch` tip has a matching stamp (input SHAs + config identity stored as a git note), the branch is **reused** instead of rebuilt. Pass `-Rebuild` to force a clean recreate.
+- Topology pytest runs by default. Pass `-SkipTests` to skip them (the Altium launcher always passes `-SkipTests`).
 - Override any field on the command line, e.g. `-DeleteTestBranchFirst:$false`.
 
 ```powershell
 pwsh scripts/test-combined.ps1
 pwsh scripts/test-combined.ps1 --local-only
+pwsh scripts/test-combined.ps1 -Rebuild
+pwsh scripts/test-combined.ps1 -SkipTests
 ```
 
 Resolution order: `scripts/test-combined.json` (local override) → `team/test-combined.json` → `team/local:team/test-combined.json` → example file.

--- a/docs/user-guide/03-series-elements.md
+++ b/docs/user-guide/03-series-elements.md
@@ -15,6 +15,20 @@ solver cannot push current between them. With a `SERIES` directive, the
 two nets are bridged by a lumped resistance, current flows, and the
 voltage drop across the part shows up in the solve.
 
+## 3.0 Altium Net Ties (automatic)
+
+Altium **Net Tie** / **Net Tie (No BOM)** symbols (`Component Kind` on the
+schematic part) deliberately short two or more nets. FYPA detects that
+kind and auto-bridges the nets with a low-Ω short so they merge in the
+FEM — you do **not** need `PDN_ROLE=SERIES` on every Net Tie.
+
+- Override: if the Net Tie already carries any `PDN_*` parameter (for
+  example an explicit `SERIES` with a measured resistance, or incomplete
+  PDN fields), the auto-bridge is skipped and your annotation wins.
+- Jumpers and bare `0R` resistors that are still `Component Kind =
+  Standard` are **not** auto-detected; annotate those as `SERIES` as
+  usual.
+
 > Read [Section 1](01-sources-and-sinks.md) first if you have not — the
 > parameter mechanics (where to add them, hiding them, library-symbol
 > defaults) are the same.

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -176,6 +176,18 @@ _RESISTOR_LIKE_ROLES: frozenset[str] = frozenset({"SERIES"})
 
 VALID_ROLES: frozenset[str] = frozenset({"SOURCE", "SINK", "REGULATOR"}) | _RESISTOR_LIKE_ROLES
 
+# Altium ``ComponentKind`` values that are Net Ties (altium_monkey.ComponentKind).
+COMPONENT_KIND_NET_TIE_BOM: int = 3
+COMPONENT_KIND_NET_TIE_NO_BOM: int = 4
+NET_TIE_COMPONENT_KINDS: frozenset[int] = frozenset({
+    COMPONENT_KIND_NET_TIE_BOM,
+    COMPONENT_KIND_NET_TIE_NO_BOM,
+})
+# Synthetic SERIES resistance for auto-detected Net Ties. Must stay below
+# ``fypa.altium.loader.NET_MERGE_RESISTANCE_THRESHOLD_OHM`` (0.9 mΩ) so the
+# loader merges the two nets instead of inserting a fragile lumped short.
+NET_TIE_BRIDGE_RESISTANCE_OHM: float = 0.5e-3
+
 _COMMON_TERMINAL_SUFFIXES: frozenset[str] = frozenset({
     "NET", "PINS", "P_NET", "N_NET", "P_PINS", "N_PINS",
 })
@@ -445,6 +457,11 @@ def _is_pdn_annotated(params: dict[str, str]) -> bool:
     if _ci_get(params, ROLE_KEY) is not None:
         return True
     return _has_indexed_role_params(params)
+
+
+def _has_any_pdn_params(params: dict[str, str]) -> bool:
+    """True when any ``PDN_*`` / ``PDN<n>_*`` parameter key is present."""
+    return any(_INDEXED_KEY_RE.match(k.strip()) for k in params)
 
 
 def _part_role_default(params: dict[str, str]) -> str:
@@ -3129,6 +3146,128 @@ def _resolve_channel_roles(
     return grouped
 
 
+def _is_nettie_component_kind(kind: int) -> bool:
+    return int(kind) in NET_TIE_COMPONENT_KINDS
+
+
+def _nettie_net_names(proj: ExtractedProject, pcb_index: int) -> list[str]:
+    """Distinct connected net names on a PCB placement, pad order preserved."""
+    pads = _pads_by_component_all(proj).get(pcb_index, [])
+    names: list[str] = []
+    seen: set[int] = set()
+    for pad in pads:
+        ni = pad.net_index
+        if ni == NO_NET or ni in seen:
+            continue
+        if not (0 <= ni < len(proj.nets)):
+            continue
+        seen.add(ni)
+        names.append(proj.nets[ni].name)
+    return names
+
+
+def _synth_nettie_bridge_for_instance(
+    proj: ExtractedProject,
+    pcb_index: int,
+    schdoc_name: str,
+    enabled_layers: list[int],
+    result: AnnotationResult,
+    net_remap: dict[int, int] | None,
+) -> list[ResistorSpec]:
+    """Build low-Ω SERIES specs that short every distinct NetTie net together."""
+    pcb_des = proj.pcb_components[pcb_index].designator
+    role_diag = f"NetTie on {pcb_des}"
+    net_names = _nettie_net_names(proj, pcb_index)
+    if len(net_names) < 2:
+        reason = _autoinfer_failure_reason(proj, pcb_index)
+        result.warnings.append(
+            f"{role_diag} ({schdoc_name}): skipped auto-bridge — {reason}"
+        )
+        return []
+
+    specs: list[ResistorSpec] = []
+    # Chain consecutive nets so N nets become N-1 shorts (union-find merge
+    # collapses the whole set). Two-pin NetTies take the single pair path.
+    for p_net, n_net in zip(net_names, net_names[1:]):
+        params = {"PDN_P_NET": p_net, "PDN_N_NET": n_net}
+        pair = _resolve_two_terminal(
+            proj, pcb_index, params,
+            "PDN_P_NET", "PDN_N_NET", "PDN_P_PINS", "PDN_N_PINS",
+            enabled_layers, role_diag, result,
+            net_remap=net_remap,
+            schdoc_name=schdoc_name,
+        )
+        if pair is None:
+            continue
+        specs.append(ResistorSpec(
+            designator=pcb_des,
+            schdoc_name=schdoc_name,
+            resistance=NET_TIE_BRIDGE_RESISTANCE_OHM,
+            p=pair[0],
+            n=pair[1],
+            channel_index=None,
+        ))
+    if specs:
+        result.warnings.append(
+            f"{role_diag} ({schdoc_name}): auto-bridged "
+            f"{' ↔ '.join(net_names)} as low-Ω NetTie short "
+            f"({NET_TIE_BRIDGE_RESISTANCE_OHM * 1e3:.2g} mΩ)"
+        )
+    return specs
+
+
+def _synth_nettie_directives(
+    proj: ExtractedProject,
+    enabled_layers: list[int],
+    result: AnnotationResult,
+    skip_set: set[str],
+    net_remap: dict[int, int] | None = None,
+) -> list[ResistorSpec]:
+    """Emit synthetic SERIES bridges for Altium Net Tie schematic components.
+
+    Components with ``ComponentKind`` Net Tie / Net Tie (No BOM) short their
+    pads by design. Without PDN annotations FYPA would leave those nets
+    disconnected; this pass synthesises a low-Ω SERIES directive per PCB
+    placement so the loader's net-merge path collapses them.
+
+    An explicit ``PDN_ROLE`` on the same part wins — auto-bridge is skipped.
+    """
+    specs: list[ResistorSpec] = []
+    seen_pcb: set[int] = set()
+    for sch in proj.sch_components:
+        if not _is_nettie_component_kind(sch.component_kind):
+            continue
+        # Any schematic PDN_* (even incomplete) opts out of auto-bridge so a
+        # half-finished annotation is not silently replaced by a merge short.
+        if _has_any_pdn_params(sch.parameters):
+            continue
+        if sch.designator.upper() in skip_set:
+            continue
+        pcb_indices = _find_pcb_instances(proj, sch.designator)
+        if not pcb_indices:
+            result.warnings.append(
+                f"NetTie {sch.designator} ({sch.schdoc_name}): no PCB "
+                f"placement found — cannot auto-bridge"
+            )
+            continue
+        for pcb_idx in pcb_indices:
+            if pcb_idx in seen_pcb:
+                continue
+            seen_pcb.add(pcb_idx)
+            pcb = proj.pcb_components[pcb_idx]
+            # PCB Blanket/ECO PDN_* on the placement overrides auto-bridge,
+            # same as schematic PDN_* on the symbol.
+            if _has_any_pdn_params(pcb.parameters):
+                continue
+            if pcb.designator.upper() in skip_set:
+                continue
+            specs.extend(_synth_nettie_bridge_for_instance(
+                proj, pcb_idx, sch.schdoc_name, enabled_layers,
+                result, net_remap,
+            ))
+    return specs
+
+
 # --- public entry -------------------------------------------------------------
 
 def parse_annotations(proj: ExtractedProject,
@@ -3255,6 +3394,13 @@ def parse_annotations(proj: ExtractedProject,
                 # Every parser returns a list — empty if the directive failed
                 # to resolve, one element per resolved channel otherwise.
                 result.directives.extend(specs)
+
+    # Altium Net Ties short their pads by ComponentKind — synthesise low-Ω
+    # SERIES bridges so the loader merge path connects those nets without
+    # requiring a PDN_ROLE=SERIES on every NetTie symbol.
+    result.directives.extend(_synth_nettie_directives(
+        proj, enabled_layers, result, skip_set, net_remap=net_remap,
+    ))
 
     # Cross-directive checks (mode consistency, open-loop) + return grouping.
     _validate_directive_groups(result, proj, parameter_sources)

--- a/fypa/altium/extract.py
+++ b/fypa/altium/extract.py
@@ -401,6 +401,17 @@ class RawSchComponent:
     schdoc_name: str          # filename only, e.g. 'Power.SchDoc'
     parameters: dict[str, str]  # name -> text (case-preserved keys)
     pin_designators: tuple[str, ...]
+    # Altium schematic ComponentKind (see altium_monkey.ComponentKind).
+    # 3 = Net Tie (BOM), 4 = Net Tie (No BOM); 0 = Standard.
+    component_kind: int = 0
+
+
+def _sch_component_kind_value(comp) -> int:
+    """Return Altium ``ComponentKind`` as an int (0 = Standard)."""
+    kind = getattr(comp, "component_kind", None)
+    if kind is None:
+        return 0
+    return int(getattr(kind, "value", kind) or 0)
 
 
 @dataclass(frozen=True, slots=True)
@@ -1339,6 +1350,7 @@ def _extract_sch_component(comp, schdoc_name: str) -> RawSchComponent | None:
         schdoc_name=schdoc_name,
         parameters=parameters,
         pin_designators=tuple(pins),
+        component_kind=_sch_component_kind_value(comp),
     )
 
 

--- a/scripts/launch-combined-gui.ps1
+++ b/scripts/launch-combined-gui.ps1
@@ -1,0 +1,122 @@
+<#
+.SYNOPSIS
+    Check out origin/test/combined and launch the GUI (Altium bootstrap path).
+
+.DESCRIPTION
+    Used by Run_FYPA.ps1 after clone/uv sync. Fetches the shared combined branch,
+    hard-resets to the remote tip, and runs Launch_GUI.py (or FYPA.py gui).
+
+    Does not merge feature branches. Maintain the shared branch with:
+      pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+
+.PARAMETER PrjPcb
+    Path to the focused .PrjPcb.
+
+.PARAMETER LaunchGui
+    Absolute path to Launch_GUI.py (outside the disposable clone). Optional.
+
+.PARAMETER Remote
+    Remote name. Default: origin
+
+.PARAMETER TestBranch
+    Combined branch name. Default: test/combined
+
+.PARAMETER RepoRoot
+    FYPA repo root. Default: parent of scripts/.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $PrjPcb,
+
+    [string] $LaunchGui,
+
+    [string] $Remote = "origin",
+
+    [string] $TestBranch = "test/combined",
+
+    [string] $RepoRoot
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $RepoRoot) {
+    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+}
+else {
+    $RepoRoot = (Resolve-Path -LiteralPath $RepoRoot).Path
+}
+Set-Location $RepoRoot
+
+if (-not (Test-Path -LiteralPath (Join-Path $RepoRoot 'FYPA.py'))) {
+    throw "FYPA.py not found in $RepoRoot"
+}
+
+if (-not (Test-Path -LiteralPath $PrjPcb)) {
+    throw "PrjPcb not found: $PrjPcb"
+}
+$PrjPcbPath = (Resolve-Path -LiteralPath $PrjPcb).Path
+
+function Invoke-GitLogged {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs
+    )
+    Write-Host (">> git {0}" -f ($GitArgs -join ' ')) -ForegroundColor DarkGray
+    & git.exe @GitArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($GitArgs -join ' ') failed (exit $LASTEXITCODE)"
+    }
+}
+
+$RemoteRef = "$Remote/$TestBranch"
+Write-Host "==> Fetch $Remote $TestBranch"
+& git.exe fetch $Remote $TestBranch 2>&1 | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning "git fetch $Remote $TestBranch failed; trying existing $RemoteRef"
+}
+
+& git.exe rev-parse --verify "$RemoteRef^{commit}" 2>$null | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    throw @"
+$RemoteRef not found.
+Publish the shared branch first (on a maintainer machine or via the team/local Action):
+
+  pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+"@
+}
+
+$Tip = ([string](& git.exe rev-parse --verify "$RemoteRef^{commit}")).Trim()
+Write-Host "==> Checkout $TestBranch @ $Tip"
+Invoke-GitLogged @('checkout', '-B', $TestBranch, $RemoteRef)
+Invoke-GitLogged @('reset', '--hard', $RemoteRef)
+
+Write-Host "==> uv sync (on $TestBranch)"
+& uv sync
+if ($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+    $venvPython = Join-Path $RepoRoot '.venv\Scripts\python.exe'
+    if (Test-Path -LiteralPath $venvPython) {
+        Write-Warning "uv sync failed; reusing existing .venv"
+    }
+    else {
+        throw "uv sync failed (exit $LASTEXITCODE)"
+    }
+}
+
+Write-Host "==> Launch GUI"
+$env:PYTHONUNBUFFERED = '1'
+if ($LaunchGui -and (Test-Path -LiteralPath $LaunchGui)) {
+    Write-Host "    Using Launch_GUI.py (File > Import style, GUI first)"
+    & uv run --extra spacemouse python $LaunchGui $PrjPcbPath
+}
+else {
+    if ($LaunchGui) {
+        Write-Warning "Launch_GUI.py missing at $LaunchGui — falling back to FYPA.py gui"
+    }
+    & uv run --extra spacemouse FYPA.py gui $PrjPcbPath
+}
+
+if ($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}

--- a/scripts/maintain-test-combined.ps1
+++ b/scripts/maintain-test-combined.ps1
@@ -4,8 +4,13 @@
 
 .DESCRIPTION
     Reads team/test-combined.json (team/local by default), fetches base + extras
-    from origin, recreates the disposable test branch using remote tips only,
+    from origin, updates the disposable test branch using remote tips only,
     and optionally force-pushes with lease.
+
+    Default (no -Rebuild): if origin/test/combined exists, check it out and
+    merge only extras whose tips are not already ancestors of HEAD
+    (incremental — keeps prior conflict resolutions). Pass -Rebuild for a
+    clean recreate from baseBranch (expect conflicts again).
 
     Local unpushed commits are never merged — tips are always origin/<branch>.
     Missing remote extras abort the run.
@@ -26,20 +31,34 @@
     Remote name. Default: origin
 
 .PARAMETER Rebuild
-    Force recreate even when the stamp on the existing local test branch matches.
+    Delete/recreate from baseBranch even when a published tip exists.
+    Prefer incremental updates without this switch.
+
+.PARAMETER Abort
+    Abort a stuck merge: hard-reset local test/combined to origin/test/combined
+    (if present), clear merge/rebase state, and check out the starting branch.
+    Does not push.
 
 .PARAMETER Push
-    After a successful rebuild (or reuse), push --force-with-lease to Remote.
+    After a successful update (or reuse), push --force-with-lease to Remote.
 
 .PARAMETER BaseBranch / TestBranch / ExtraFeatureBranches / DeleteTestBranchFirst
     Override individual config fields.
 
 .EXAMPLE
-    pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+    pwsh scripts/maintain-test-combined.ps1 -Push
+
+    Incremental update from origin/test/combined, then publish.
 
 .EXAMPLE
-    pwsh scripts/maintain-test-combined.ps1
-    Build locally without pushing (e.g. to resolve merge conflicts).
+    pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+
+    Clean recreate from main (resolves conflicts from scratch).
+
+.EXAMPLE
+    pwsh scripts/maintain-test-combined.ps1 -Abort
+
+    Escape a mid-merge worktree and return to the previous branch.
 #>
 
 [CmdletBinding()]
@@ -48,6 +67,7 @@ param(
     [string] $TeamConfigRef = "team/local",
     [string] $Remote = "origin",
     [switch] $Rebuild,
+    [switch] $Abort,
     [switch] $Push,
     [string] $BaseBranch,
     [string] $TestBranch,
@@ -119,6 +139,15 @@ function Invoke-GitSoft {
 function Test-GitRef {
     param([string] $Ref)
     & git show-ref --verify --quiet $Ref
+    return $LASTEXITCODE -eq 0
+}
+
+function Test-GitAncestor {
+    param(
+        [string] $Ancestor,
+        [string] $Descendant
+    )
+    & git.exe merge-base --is-ancestor $Ancestor $Descendant 2>$null | Out-Null
     return $LASTEXITCODE -eq 0
 }
 
@@ -397,8 +426,76 @@ function Read-TestCombinedConfig {
     return $Config
 }
 
+function Clear-TestCombinedUpstream {
+    param([string] $Branch)
+    # Creating from origin/main sets upstream to main — confusing ("ahead of main").
+    & git.exe branch --unset-upstream $Branch 2>$null | Out-Null
+}
+
 if (-not (Test-Path "FYPA.py")) {
     throw "FYPA.py not found in $RepoRoot — run this script from the FYPA repo."
+}
+
+$ReturnBranch = Get-CurrentBranch
+if (-not $ReturnBranch) {
+    throw "Could not determine the current branch (detached HEAD?). Check out a branch first."
+}
+
+if ($Abort) {
+    $AbortTestBranch = if ($PSBoundParameters.ContainsKey("TestBranch") -and $TestBranch) {
+        $TestBranch
+    }
+    else {
+        "test/combined"
+    }
+    Write-Host "==> Abort: clear merge/rebase state and reset $AbortTestBranch"
+    $onAbortBranch = ((Get-CurrentBranch) -eq $AbortTestBranch)
+    if ($onAbortBranch) {
+        & git merge --abort 2>$null | Out-Null
+        & git rebase --abort 2>$null | Out-Null
+        & git reset --merge 2>$null | Out-Null
+    }
+    try {
+        Sync-RemoteBranches -RemoteName $Remote -Branches @($AbortTestBranch)
+    }
+    catch {
+        Write-Warning "Fetch $Remote/$AbortTestBranch failed — using existing refs if present."
+    }
+    $RemoteAbortRef = "$Remote/$AbortTestBranch"
+    if (Test-GitRef "refs/remotes/$Remote/$AbortTestBranch") {
+        if ($onAbortBranch) {
+            Invoke-Git @('reset', '--hard', $RemoteAbortRef)
+            Clear-TestCombinedUpstream -Branch $AbortTestBranch
+            Write-Host "==> $AbortTestBranch reset to $RemoteAbortRef"
+            if ($ReturnBranch -ne $AbortTestBranch) {
+                Write-Host "==> Return to $ReturnBranch"
+                Restore-DevBranch -Branch $ReturnBranch
+            }
+        }
+        else {
+            # Update the local branch tip without checking it out (worktree may be dirty).
+            if (Test-GitRef "refs/heads/$AbortTestBranch") {
+                Invoke-Git @('branch', '-f', $AbortTestBranch, $RemoteAbortRef)
+            }
+            else {
+                Invoke-Git @('branch', $AbortTestBranch, $RemoteAbortRef)
+            }
+            Clear-TestCombinedUpstream -Branch $AbortTestBranch
+            Write-Host "==> Local $AbortTestBranch forced to $RemoteAbortRef (no checkout)"
+        }
+    }
+    elseif ($onAbortBranch) {
+        Write-Host "==> No $RemoteAbortRef — checking out $ReturnBranch and deleting local tip"
+        Restore-DevBranch -Branch $ReturnBranch
+        if (Test-GitRef "refs/heads/$AbortTestBranch") {
+            Invoke-Git @('branch', '-D', $AbortTestBranch)
+        }
+    }
+    else {
+        Write-Host "==> No local/remote $AbortTestBranch to reset"
+    }
+    Write-Host "==> Abort done — on $(Get-CurrentBranch)"
+    exit 0
 }
 
 # Soft-fetch team config ref so git show origin/team/local:... works.
@@ -439,11 +536,6 @@ if (-not $TestBranch) { throw "testBranch is empty." }
 
 Write-Host "==> Branch source: $Remote tips only (no local-ahead merge)"
 
-$ReturnBranch = Get-CurrentBranch
-if (-not $ReturnBranch) {
-    throw "Could not determine the current branch (detached HEAD?). Check out a branch first."
-}
-
 Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
 # test/combined may not exist yet on first publish — soft-fetch only.
 try {
@@ -477,6 +569,7 @@ foreach ($ExtraBranch in $ExtraFeatureBranches) {
     $ResolvedExtras.Add(@{
         Branch   = $ExtraTarget.Branch
         MergeRef = $ExtraTarget.MergeRef
+        Sha      = $ExtraTarget.Sha
     })
 }
 
@@ -500,23 +593,34 @@ $DesiredStamp = ConvertTo-NormalizedStamp (Get-InputStamp `
     -BaseSha $BaseSha `
     -ExtraPairs @($ExtraStampPairs))
 
-$TestBranchExists = Test-GitRef "refs/heads/$TestBranch"
-$ExistingTip = if ($TestBranchExists) { Get-RefSha -Ref $TestBranch } else { $null }
-$ExistingStamp = ConvertTo-NormalizedStamp (Get-TestCombinedStamp -Commit $ExistingTip)
+$RemoteTestRef = "$Remote/$TestBranch"
+$HasRemoteTest = Test-GitRef "refs/remotes/$Remote/$TestBranch"
+$RemoteTestSha = if ($HasRemoteTest) { Get-RefSha -Ref $RemoteTestRef } else { $null }
+$RemoteStamp = ConvertTo-NormalizedStamp (Get-TestCombinedStamp -Commit $RemoteTestSha)
+
 $CanReuse = (
     -not $Rebuild -and
-    $TestBranchExists -and
-    $ExistingStamp -and
-    ($ExistingStamp -eq $DesiredStamp)
+    $RemoteStamp -and
+    ($RemoteStamp -eq $DesiredStamp)
 )
 
-if (-not $CanReuse -and $TestBranchExists -and -not $Rebuild) {
-    if (-not $ExistingStamp) {
-        Write-Host "==> No reuse stamp on $TestBranch — will rebuild"
-    }
-    else {
-        Write-Host "==> Stamp mismatch on $TestBranch — will rebuild"
-    }
+$UseIncremental = (
+    -not $Rebuild -and
+    -not $CanReuse -and
+    $HasRemoteTest
+)
+
+if ($CanReuse) {
+    Write-Host "==> Stamp matches $RemoteTestRef — reuse"
+}
+elseif ($UseIncremental) {
+    Write-Host "==> Incremental update from $RemoteTestRef (pass -Rebuild for clean recreate)"
+}
+elseif ($Rebuild) {
+    Write-Host "==> -Rebuild: clean recreate from $BaseRef"
+}
+else {
+    Write-Host "==> No $RemoteTestRef yet — first create from $BaseRef"
 }
 
 $IgnoredPaths = @('.gitignore', 'FYPA.code-workspace')
@@ -531,6 +635,7 @@ if ($BlockingStatus.Count -gt 0) {
     throw @"
 Uncommitted changes detected on '$ReturnBranch'.
 Commit or stash them before running maintain-test-combined.
+To escape a stuck merge: pwsh scripts/maintain-test-combined.ps1 -Abort
 "@
 }
 
@@ -538,22 +643,36 @@ $Returned = $false
 $LeaveOnConflict = $false
 try {
     if ($CanReuse) {
-        Write-Host "==> Reuse $TestBranch (inputs unchanged)"
-        if ((Get-CurrentBranch) -ne $TestBranch) {
-            Invoke-Git @('checkout', $TestBranch)
+        Write-Host "==> Checkout $TestBranch @ $RemoteTestRef"
+        Invoke-Git @('checkout', '-B', $TestBranch, $RemoteTestRef)
+        Invoke-Git @('reset', '--hard', $RemoteTestRef)
+        Clear-TestCombinedUpstream -Branch $TestBranch
+    }
+    elseif ($UseIncremental) {
+        Write-Host "==> Checkout $TestBranch @ $RemoteTestRef"
+        Invoke-Git @('checkout', '-B', $TestBranch, $RemoteTestRef)
+        Invoke-Git @('reset', '--hard', $RemoteTestRef)
+        Clear-TestCombinedUpstream -Branch $TestBranch
+
+        $HeadSha = Get-RefSha -Ref 'HEAD'
+        foreach ($Extra in $ResolvedExtras) {
+            if (Test-GitAncestor -Ancestor $Extra.Sha -Descendant $HeadSha) {
+                Write-Host "==> Skip $($Extra.Branch) (already in $TestBranch)"
+                continue
+            }
+            Write-Host "==> Merge $($Extra.MergeRef) into $TestBranch"
+            Merge-FeatureBranch -MergeRef $Extra.MergeRef -ExtraBranch $Extra.Branch -IgnoredPaths $IgnoredPaths
+            $HeadSha = Get-RefSha -Ref 'HEAD'
+        }
+
+        $NewTip = Get-RefSha -Ref 'HEAD'
+        if ($NewTip) {
+            Set-TestCombinedStamp -Commit $NewTip -Stamp $DesiredStamp
+            Write-Host "==> Stamp written for $TestBranch"
         }
     }
     else {
-        if ($Rebuild) {
-            Write-Host "==> Rebuild requested — recreating $TestBranch"
-        }
-        elseif (-not $TestBranchExists) {
-            Write-Host "==> $TestBranch missing — creating from $BaseRef"
-        }
-        else {
-            Write-Host "==> Inputs changed — recreating $TestBranch from $BaseRef"
-        }
-
+        # Full recreate from base (first publish or -Rebuild).
         if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
             Write-Host "==> Delete $TestBranch"
             if ((Get-CurrentBranch) -eq $TestBranch) {
@@ -571,6 +690,7 @@ try {
             Write-Host "==> Create $TestBranch from $BaseRef"
             Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
         }
+        Clear-TestCombinedUpstream -Branch $TestBranch
 
         foreach ($Extra in $ResolvedExtras) {
             Write-Host "==> Merge $($Extra.MergeRef) into $TestBranch"
@@ -598,17 +718,21 @@ try {
 }
 catch {
     $msg = "$_"
-    if ($msg -match 'Merge conflict' -and (Test-MergeInProgress)) {
+    if ($msg -match 'Merge conflict' -and (
+            (Test-MergeInProgress) -or ((Get-UnmergedPaths).Count -gt 0)
+        )) {
         $LeaveOnConflict = $true
         Write-Host @"
 
-==> Merge conflict — staying on $TestBranch with the conflict in place.
-Resolve, commit, then:
+==> Merge conflict — still on $TestBranch (do not git switch away).
 
-  git notes --ref=test-combined add -f -m '<stamp>' HEAD   # optional
-  git push --force-with-lease $Remote HEAD:refs/heads/$TestBranch
+Finish:
+  git add -u
+  git commit --no-edit
+  pwsh scripts/maintain-test-combined.ps1 -Push
 
-Or re-run: pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+Abort back to published tip + previous branch:
+  pwsh scripts/maintain-test-combined.ps1 -Abort
 "@
     }
     elseif ((Get-CurrentBranch) -ne $ReturnBranch) {

--- a/scripts/maintain-test-combined.ps1
+++ b/scripts/maintain-test-combined.ps1
@@ -444,7 +444,14 @@ if (-not $ReturnBranch) {
     throw "Could not determine the current branch (detached HEAD?). Check out a branch first."
 }
 
-Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches + @($TestBranch))
+Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
+# test/combined may not exist yet on first publish — soft-fetch only.
+try {
+    Sync-RemoteBranches -RemoteName $Remote -Branches @($TestBranch)
+}
+catch {
+    Write-Host "==> $Remote/$TestBranch not fetched yet (ok on first publish)"
+}
 
 $BaseTarget = Resolve-RemoteTip -Branch $BaseBranch -RemoteName $Remote
 if (-not $BaseTarget) {

--- a/scripts/maintain-test-combined.ps1
+++ b/scripts/maintain-test-combined.ps1
@@ -535,6 +535,7 @@ Commit or stash them before running maintain-test-combined.
 }
 
 $Returned = $false
+$LeaveOnConflict = $false
 try {
     if ($CanReuse) {
         Write-Host "==> Reuse $TestBranch (inputs unchanged)"
@@ -596,22 +597,40 @@ try {
     }
 }
 catch {
-    if ((Get-CurrentBranch) -ne $ReturnBranch) {
+    $msg = "$_"
+    if ($msg -match 'Merge conflict' -and (Test-MergeInProgress)) {
+        $LeaveOnConflict = $true
+        Write-Host @"
+
+==> Merge conflict — staying on $TestBranch with the conflict in place.
+Resolve, commit, then:
+
+  git notes --ref=test-combined add -f -m '<stamp>' HEAD   # optional
+  git push --force-with-lease $Remote HEAD:refs/heads/$TestBranch
+
+Or re-run: pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+"@
+    }
+    elseif ((Get-CurrentBranch) -ne $ReturnBranch) {
         & git merge --abort 2>$null | Out-Null
         & git rebase --abort 2>$null | Out-Null
     }
     throw
 }
 finally {
-    $Current = Get-CurrentBranch
-    if ($Current -ne $ReturnBranch) {
-        Write-Host "==> Return to $ReturnBranch"
-        Restore-DevBranch -Branch $ReturnBranch
-        $Returned = $true
+    if (-not $LeaveOnConflict) {
+        $Current = Get-CurrentBranch
+        if ($Current -ne $ReturnBranch) {
+            Write-Host "==> Return to $ReturnBranch"
+            Restore-DevBranch -Branch $ReturnBranch
+            $Returned = $true
+        }
     }
 }
 
-if (-not $Returned) {
-    Write-Host "==> Return to $ReturnBranch"
-    Restore-DevBranch -Branch $ReturnBranch
+if (-not $LeaveOnConflict) {
+    if (-not $Returned) {
+        Write-Host "==> Return to $ReturnBranch"
+        Restore-DevBranch -Branch $ReturnBranch
+    }
 }

--- a/scripts/maintain-test-combined.ps1
+++ b/scripts/maintain-test-combined.ps1
@@ -1,0 +1,610 @@
+<#
+.SYNOPSIS
+    Rebuild origin/test/combined from team/local config and optionally push.
+
+.DESCRIPTION
+    Reads team/test-combined.json (team/local by default), fetches base + extras
+    from origin, recreates the disposable test branch using remote tips only,
+    and optionally force-pushes with lease.
+
+    Local unpushed commits are never merged — tips are always origin/<branch>.
+    Missing remote extras abort the run.
+
+    Config resolution (first match wins):
+      scripts/test-combined.json          local override (gitignored)
+      team/test-combined.json             working tree
+      team/local:team/test-combined.json  from team/local via git show
+      scripts/test-combined.example.json  fallback
+
+.PARAMETER ConfigPath
+    Path or ref:path to a JSON config. Overrides the default search order.
+
+.PARAMETER TeamConfigRef
+    Git ref for team/test-combined.json via git show. Default: team/local
+
+.PARAMETER Remote
+    Remote name. Default: origin
+
+.PARAMETER Rebuild
+    Force recreate even when the stamp on the existing local test branch matches.
+
+.PARAMETER Push
+    After a successful rebuild (or reuse), push --force-with-lease to Remote.
+
+.PARAMETER BaseBranch / TestBranch / ExtraFeatureBranches / DeleteTestBranchFirst
+    Override individual config fields.
+
+.EXAMPLE
+    pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+
+.EXAMPLE
+    pwsh scripts/maintain-test-combined.ps1
+    Build locally without pushing (e.g. to resolve merge conflicts).
+#>
+
+[CmdletBinding()]
+param(
+    [string] $ConfigPath,
+    [string] $TeamConfigRef = "team/local",
+    [string] $Remote = "origin",
+    [switch] $Rebuild,
+    [switch] $Push,
+    [string] $BaseBranch,
+    [string] $TestBranch,
+    [string[]] $ExtraFeatureBranches,
+    [bool] $DeleteTestBranchFirst
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+Set-Location $RepoRoot
+
+function Invoke-GitCore {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs,
+        [switch] $Quiet
+    )
+    if ($GitArgs.Count -eq 0) {
+        throw "Invoke-GitCore: no arguments"
+    }
+
+    $Output = @(& git.exe @GitArgs 2>&1)
+    $ExitCode = $LASTEXITCODE
+
+    if (-not $Quiet) {
+        foreach ($Line in $Output) {
+            if ($Line -is [System.Management.Automation.ErrorRecord]) {
+                Write-Warning $Line.ToString()
+            }
+            else {
+                Write-Host $Line
+            }
+        }
+    }
+
+    $Stdout = @(
+        $Output |
+            Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] } |
+            ForEach-Object { [string] $_ }
+    )
+
+    return @{
+        ExitCode = $ExitCode
+        Output   = $Stdout
+    }
+}
+
+function Invoke-Git {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs
+    )
+    $Result = Invoke-GitCore @GitArgs
+    if ($Result.ExitCode -ne 0) {
+        throw "git $($GitArgs -join ' ') failed (exit $($Result.ExitCode))"
+    }
+    return $Result.Output
+}
+
+function Invoke-GitSoft {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs
+    )
+    return (Invoke-GitCore @GitArgs).ExitCode
+}
+
+function Test-GitRef {
+    param([string] $Ref)
+    & git show-ref --verify --quiet $Ref
+    return $LASTEXITCODE -eq 0
+}
+
+function Get-RefSha {
+    param([string] $Ref)
+    $Sha = ([string] (& git.exe rev-parse --verify "$Ref^{commit}" 2>$null)).Trim()
+    if ($LASTEXITCODE -ne 0 -or -not $Sha) {
+        return $null
+    }
+    return $Sha
+}
+
+function Sync-RemoteBranches {
+    param(
+        [string] $RemoteName,
+        [string[]] $Branches
+    )
+
+    $UniqueBranches = @($Branches | Where-Object { $_ } | Select-Object -Unique)
+    if ($UniqueBranches.Count -eq 0) {
+        return
+    }
+
+    Write-Host "==> Fetch $RemoteName $($UniqueBranches -join ', ')"
+    $Result = Invoke-GitCore -Quiet @(@('fetch', $RemoteName) + $UniqueBranches)
+    if ($Result.ExitCode -ne 0) {
+        $Detail = ($Result.Output -join "`n").Trim()
+        if ($Detail) {
+            throw "git fetch $RemoteName failed (exit $($Result.ExitCode)): $Detail"
+        }
+        throw "git fetch $RemoteName failed (exit $($Result.ExitCode))"
+    }
+}
+
+function Resolve-RemoteTip {
+    param(
+        [string] $Branch,
+        [string] $RemoteName
+    )
+
+    $RemoteRef = "$RemoteName/$Branch"
+    if (-not (Test-GitRef "refs/remotes/$RemoteName/$Branch")) {
+        return $null
+    }
+    $Sha = Get-RefSha -Ref $RemoteRef
+    if (-not $Sha) { return $null }
+    return @{
+        Branch   = $Branch
+        MergeRef = $RemoteRef
+        Sha      = $Sha
+        Source   = 'remote'
+    }
+}
+
+function Get-InputStamp {
+    param(
+        [string] $ConfigIdentity,
+        [string] $BaseName,
+        [string] $BaseSha,
+        [string[]] $ExtraPairs
+    )
+
+    $Parts = [System.Collections.Generic.List[string]]::new()
+    $Parts.Add("config=$ConfigIdentity")
+    $Parts.Add("base=$BaseName=$BaseSha")
+    foreach ($Pair in $ExtraPairs) {
+        if ($Pair) { $Parts.Add("extra=$Pair") }
+    }
+    return ($Parts -join '|')
+}
+
+function Get-TestCombinedStamp {
+    param([string] $Commit)
+    if (-not $Commit) { return $null }
+    $Lines = @(& git.exe notes --ref=test-combined show $Commit 2>$null)
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+    return (($Lines -join "`n").Trim())
+}
+
+function Set-TestCombinedStamp {
+    param(
+        [string] $Commit,
+        [string] $Stamp
+    )
+    $ExitCode = Invoke-GitSoft @(
+        'notes', '--ref=test-combined', 'add', '-f', '-m', $Stamp, $Commit
+    )
+    if ($ExitCode -ne 0) {
+        Write-Warning "Could not write test-combined stamp note on $Commit"
+    }
+}
+
+function ConvertTo-NormalizedStamp {
+    param([string] $Stamp)
+    if (-not $Stamp) { return $null }
+    $Normalized = $Stamp.Trim() -replace "`r`n", "`n" -replace "`r", "`n"
+    if ($Normalized.Contains("`n")) {
+        $Normalized = (($Normalized -split "`n") | ForEach-Object { $_.Trim() } | Where-Object { $_ }) -join '|'
+    }
+    return $Normalized
+}
+
+function Test-MergeInProgress {
+    $MergeHead = & git.exe rev-parse -q --verify MERGE_HEAD 2>$null
+    return [bool] $MergeHead
+}
+
+function Get-UnmergedPaths {
+    $Output = & git.exe diff --name-only --diff-filter=U 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        return @()
+    }
+    return @($Output | Where-Object { $_ })
+}
+
+function Resolve-IgnoredMergeConflicts {
+    param(
+        [string[]] $IgnoredPaths,
+        [ValidateSet('ours', 'theirs')]
+        [string] $Prefer = 'ours'
+    )
+
+    foreach ($Path in (Get-UnmergedPaths)) {
+        if ($Path -in $IgnoredPaths) {
+            Write-Host "==> Auto-resolve merge conflict in $Path ($Prefer)"
+            Invoke-Git @('checkout', "--$Prefer", '--', $Path)
+            Invoke-Git @('add', '--', $Path)
+        }
+    }
+
+    return @(Get-UnmergedPaths)
+}
+
+function Merge-FeatureBranch {
+    param(
+        [string] $MergeRef,
+        [string] $ExtraBranch,
+        [string[]] $IgnoredPaths
+    )
+
+    $MergeMessage = "test: merge $ExtraBranch for combined testing"
+    $ExitCode = Invoke-GitSoft @(
+        'merge', $MergeRef, '--no-edit', '-m', $MergeMessage
+    )
+    if ($ExitCode -eq 0) {
+        return
+    }
+
+    if (-not (Test-MergeInProgress)) {
+        throw "git merge $MergeRef failed (exit $ExitCode)"
+    }
+
+    $Remaining = Resolve-IgnoredMergeConflicts -IgnoredPaths $IgnoredPaths -Prefer 'ours'
+    if ($Remaining.Count -gt 0) {
+        throw "Merge conflict in: $($Remaining -join ', ')"
+    }
+
+    Invoke-Git @('commit', '--no-edit')
+}
+
+function Get-CurrentBranch {
+    return ([string] (Invoke-Git @('branch', '--show-current') | Select-Object -First 1)).Trim()
+}
+
+function Restore-DevBranch {
+    param([string] $Branch)
+    if ($Branch) {
+        Invoke-Git @('checkout', $Branch)
+    }
+}
+
+function Get-GitConfigJson {
+    param(
+        [string[]] $Refs,
+        [string] $RepoPath = "team/test-combined.json"
+    )
+
+    foreach ($Ref in $Refs) {
+        if (-not $Ref) { continue }
+        $Spec = "${Ref}:${RepoPath}"
+        $Json = & git show $Spec 2>$null
+        if ($LASTEXITCODE -eq 0 -and $Json) {
+            return @{ Source = $Spec; Json = [string] $Json }
+        }
+    }
+
+    return $null
+}
+
+function Resolve-ConfigSource {
+    param(
+        [string] $ExplicitPath,
+        [string] $TeamRef
+    )
+
+    if ($ExplicitPath) {
+        if (Test-Path $ExplicitPath) {
+            return @{
+                Source = (Resolve-Path $ExplicitPath).Path
+                Json   = $null
+            }
+        }
+        if ($ExplicitPath -match ':') {
+            $Json = & git show $ExplicitPath 2>$null
+            if ($LASTEXITCODE -eq 0 -and $Json) {
+                return @{ Source = $ExplicitPath; Json = [string] $Json }
+            }
+        }
+        throw "Config file not found: $ExplicitPath"
+    }
+
+    $LocalCandidates = @(
+        (Join-Path $RepoRoot "scripts/test-combined.json"),
+        (Join-Path $RepoRoot "team/test-combined.json")
+    )
+
+    foreach ($Candidate in $LocalCandidates) {
+        if (Test-Path $Candidate) {
+            return @{
+                Source = (Resolve-Path $Candidate).Path
+                Json   = $null
+            }
+        }
+    }
+
+    $GitRefs = @(
+        $TeamRef,
+        "origin/$TeamRef"
+    )
+    $FromGit = Get-GitConfigJson -Refs $GitRefs
+    if ($FromGit) {
+        return $FromGit
+    }
+
+    $Example = Join-Path $RepoRoot "scripts/test-combined.example.json"
+    if (Test-Path $Example) {
+        Write-Warning "Using example config ($Example). Copy to scripts/test-combined.json or update team/local."
+        return @{
+            Source = (Resolve-Path $Example).Path
+            Json   = $null
+        }
+    }
+
+    throw @"
+No test-combined config found.
+Fetch team/local (git fetch origin team/local) or create scripts/test-combined.json from scripts/test-combined.example.json.
+"@
+}
+
+function Read-TestCombinedConfig {
+    param(
+        [string] $Source,
+        [string] $Json
+    )
+
+    try {
+        if ($Json) {
+            $Config = $Json | ConvertFrom-Json
+        }
+        else {
+            $Config = Get-Content -Raw -Path $Source | ConvertFrom-Json
+        }
+    }
+    catch {
+        throw "Failed to parse config JSON at '$Source': $_"
+    }
+
+    foreach ($Required in @("baseBranch", "testBranch", "extraFeatureBranches")) {
+        if (-not ($Config.PSObject.Properties.Name -contains $Required)) {
+            throw "Config '$Source' is missing required field '$Required'."
+        }
+    }
+
+    return $Config
+}
+
+if (-not (Test-Path "FYPA.py")) {
+    throw "FYPA.py not found in $RepoRoot — run this script from the FYPA repo."
+}
+
+# Soft-fetch team config ref so git show origin/team/local:... works.
+if (-not $ConfigPath) {
+    try {
+        Sync-RemoteBranches -RemoteName $Remote -Branches @($TeamConfigRef)
+    }
+    catch {
+        Write-Warning "Fetch $Remote $TeamConfigRef failed; using existing refs if present."
+        Write-Warning "$_"
+    }
+}
+
+$ConfigSource = Resolve-ConfigSource -ExplicitPath $ConfigPath -TeamRef $TeamConfigRef
+Write-Host "==> Config: $($ConfigSource.Source)"
+$Config = Read-TestCombinedConfig -Source $ConfigSource.Source -Json $ConfigSource.Json
+
+$BaseBranch = if ($PSBoundParameters.ContainsKey("BaseBranch")) { $BaseBranch } else { [string] $Config.baseBranch }
+$TestBranch = if ($PSBoundParameters.ContainsKey("TestBranch")) { $TestBranch } else { [string] $Config.testBranch }
+$ExtraFeatureBranches = if ($PSBoundParameters.ContainsKey("ExtraFeatureBranches")) {
+    $ExtraFeatureBranches
+}
+else {
+    @($Config.extraFeatureBranches | ForEach-Object { [string] $_ })
+}
+$DeleteTestBranchFirst = if ($PSBoundParameters.ContainsKey("DeleteTestBranchFirst")) {
+    $DeleteTestBranchFirst
+}
+elseif ($Config.PSObject.Properties.Name -contains "deleteTestBranchFirst") {
+    [bool] $Config.deleteTestBranchFirst
+}
+else {
+    $false
+}
+
+if (-not $BaseBranch) { throw "baseBranch is empty." }
+if (-not $TestBranch) { throw "testBranch is empty." }
+
+Write-Host "==> Branch source: $Remote tips only (no local-ahead merge)"
+
+$ReturnBranch = Get-CurrentBranch
+if (-not $ReturnBranch) {
+    throw "Could not determine the current branch (detached HEAD?). Check out a branch first."
+}
+
+Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches + @($TestBranch))
+
+$BaseTarget = Resolve-RemoteTip -Branch $BaseBranch -RemoteName $Remote
+if (-not $BaseTarget) {
+    throw "Base branch '$BaseBranch' not found as $Remote/$BaseBranch. Push it first."
+}
+
+$BaseRef = $BaseTarget.MergeRef
+$BaseSha = $BaseTarget.Sha
+Write-Host "==> Base: $BaseRef"
+
+$ExtraStampPairs = [System.Collections.Generic.List[string]]::new()
+$ResolvedExtras = [System.Collections.Generic.List[hashtable]]::new()
+$MissingExtras = [System.Collections.Generic.List[string]]::new()
+foreach ($ExtraBranch in $ExtraFeatureBranches) {
+    if (-not $ExtraBranch) { continue }
+    $ExtraTarget = Resolve-RemoteTip -Branch $ExtraBranch -RemoteName $Remote
+    if (-not $ExtraTarget) {
+        $MissingExtras.Add($ExtraBranch)
+        continue
+    }
+    Write-Host "==> Extra: $($ExtraTarget.MergeRef)"
+    $ExtraStampPairs.Add("$ExtraBranch=$($ExtraTarget.Sha)")
+    $ResolvedExtras.Add(@{
+        Branch   = $ExtraTarget.Branch
+        MergeRef = $ExtraTarget.MergeRef
+    })
+}
+
+if ($MissingExtras.Count -gt 0) {
+    throw @"
+Missing on ${Remote}: $($MissingExtras -join ', ').
+Push each feature branch before maintaining $TestBranch.
+"@
+}
+
+$ConfigIdentity = @(
+    "base=$BaseBranch",
+    "test=$TestBranch",
+    "deleteFirst=$DeleteTestBranchFirst",
+    "extras=$($ExtraFeatureBranches -join ',')"
+) -join ';'
+
+$DesiredStamp = ConvertTo-NormalizedStamp (Get-InputStamp `
+    -ConfigIdentity $ConfigIdentity `
+    -BaseName $BaseBranch `
+    -BaseSha $BaseSha `
+    -ExtraPairs @($ExtraStampPairs))
+
+$TestBranchExists = Test-GitRef "refs/heads/$TestBranch"
+$ExistingTip = if ($TestBranchExists) { Get-RefSha -Ref $TestBranch } else { $null }
+$ExistingStamp = ConvertTo-NormalizedStamp (Get-TestCombinedStamp -Commit $ExistingTip)
+$CanReuse = (
+    -not $Rebuild -and
+    $TestBranchExists -and
+    $ExistingStamp -and
+    ($ExistingStamp -eq $DesiredStamp)
+)
+
+if (-not $CanReuse -and $TestBranchExists -and -not $Rebuild) {
+    if (-not $ExistingStamp) {
+        Write-Host "==> No reuse stamp on $TestBranch — will rebuild"
+    }
+    else {
+        Write-Host "==> Stamp mismatch on $TestBranch — will rebuild"
+    }
+}
+
+$IgnoredPaths = @('.gitignore', 'FYPA.code-workspace')
+$Status = @(Invoke-Git @('status', '--porcelain'))
+$BlockingStatus = @($Status | Where-Object {
+    $path = $_.Substring(3).Trim()
+    if ($path -match ' -> ') { $path = ($path -split ' -> ', 2)[-1].Trim() }
+    elseif ($path -match "`t") { $path = ($path -split "`t", 2)[-1].Trim() }
+    $path -notin $IgnoredPaths
+})
+if ($BlockingStatus.Count -gt 0) {
+    throw @"
+Uncommitted changes detected on '$ReturnBranch'.
+Commit or stash them before running maintain-test-combined.
+"@
+}
+
+$Returned = $false
+try {
+    if ($CanReuse) {
+        Write-Host "==> Reuse $TestBranch (inputs unchanged)"
+        if ((Get-CurrentBranch) -ne $TestBranch) {
+            Invoke-Git @('checkout', $TestBranch)
+        }
+    }
+    else {
+        if ($Rebuild) {
+            Write-Host "==> Rebuild requested — recreating $TestBranch"
+        }
+        elseif (-not $TestBranchExists) {
+            Write-Host "==> $TestBranch missing — creating from $BaseRef"
+        }
+        else {
+            Write-Host "==> Inputs changed — recreating $TestBranch from $BaseRef"
+        }
+
+        if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
+            Write-Host "==> Delete $TestBranch"
+            if ((Get-CurrentBranch) -eq $TestBranch) {
+                Invoke-Git @('checkout', $ReturnBranch)
+            }
+            Invoke-Git @('branch', '-D', $TestBranch)
+        }
+
+        if (Test-GitRef "refs/heads/$TestBranch") {
+            Write-Host "==> Recreate $TestBranch from $BaseRef"
+            Invoke-Git @('branch', '-f', $TestBranch, $BaseRef)
+            Invoke-Git @('checkout', $TestBranch)
+        }
+        else {
+            Write-Host "==> Create $TestBranch from $BaseRef"
+            Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
+        }
+
+        foreach ($Extra in $ResolvedExtras) {
+            Write-Host "==> Merge $($Extra.MergeRef) into $TestBranch"
+            Merge-FeatureBranch -MergeRef $Extra.MergeRef -ExtraBranch $Extra.Branch -IgnoredPaths $IgnoredPaths
+        }
+
+        $NewTip = Get-RefSha -Ref 'HEAD'
+        if ($NewTip) {
+            Set-TestCombinedStamp -Commit $NewTip -Stamp $DesiredStamp
+            Write-Host "==> Stamp written for $TestBranch"
+        }
+    }
+
+    $Tip = Get-RefSha -Ref 'HEAD'
+    Write-Host "==> $TestBranch tip: $Tip"
+
+    if ($Push) {
+        Write-Host "==> Push --force-with-lease $Remote $TestBranch"
+        Invoke-Git @('push', '--force-with-lease', $Remote, "HEAD:refs/heads/$TestBranch")
+        Write-Host "==> Pushed $Remote/$TestBranch"
+    }
+    else {
+        Write-Host "==> Local only (pass -Push to update $Remote/$TestBranch)"
+    }
+}
+catch {
+    if ((Get-CurrentBranch) -ne $ReturnBranch) {
+        & git merge --abort 2>$null | Out-Null
+        & git rebase --abort 2>$null | Out-Null
+    }
+    throw
+}
+finally {
+    $Current = Get-CurrentBranch
+    if ($Current -ne $ReturnBranch) {
+        Write-Host "==> Return to $ReturnBranch"
+        Restore-DevBranch -Branch $ReturnBranch
+        $Returned = $true
+    }
+}
+
+if (-not $Returned) {
+    Write-Host "==> Return to $ReturnBranch"
+    Restore-DevBranch -Branch $ReturnBranch
+}

--- a/scripts/test-combined.example.json
+++ b/scripts/test-combined.example.json
@@ -1,0 +1,9 @@
+{
+  "baseBranch": "main",
+  "testBranch": "test/combined",
+  "deleteTestBranchFirst": true,
+  "extraFeatureBranches": [
+    "feature/example-a",
+    "fix/example-b"
+  ]
+}

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -10,6 +10,7 @@
 #   pwsh scripts/test-combined.ps1
 #   pwsh scripts/test-combined.ps1 --local-only
 #   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
+#   pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
 #
 # By default baseBranch and extraFeatureBranches are fetched from origin and merged
 # via origin/<branch>. Pass --local-only to use local branches only.
@@ -30,7 +31,8 @@ param(
     [string] $BaseBranch,
     [string] $TestBranch,
     [string[]] $ExtraFeatureBranches,
-    [bool] $DeleteTestBranchFirst
+    [bool] $DeleteTestBranchFirst,
+    [string] $PrjPcb
 )
 
 $ErrorActionPreference = "Stop"
@@ -341,6 +343,14 @@ else {
     $false
 }
 
+$PrjPcbPath = $null
+if ($PrjPcb) {
+    if (-not (Test-Path -LiteralPath $PrjPcb)) {
+        throw "PrjPcb not found: $PrjPcb"
+    }
+    $PrjPcbPath = (Resolve-Path -LiteralPath $PrjPcb).Path
+}
+
 if (-not $BaseBranch) { throw "baseBranch is empty." }
 if (-not $TestBranch) { throw "testBranch is empty." }
 
@@ -434,7 +444,13 @@ try {
     }
 
     Write-Host "==> uv run FYPA.py"
-    & uv run --extra spacemouse FYPA.py
+    if ($PrjPcbPath) {
+        Write-Host "    Project: $PrjPcbPath"
+        & uv run --extra spacemouse FYPA.py gui $PrjPcbPath
+    }
+    else {
+        & uv run --extra spacemouse FYPA.py
+    }
     $FypaExit = $LASTEXITCODE
 }
 catch {

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -1,0 +1,463 @@
+# Build a local combined test branch from a base branch + feature branches, run tests/FYPA, then switch back.
+#
+# Config (first match wins):
+#   scripts/test-combined.json          local override (gitignored)
+#   team/test-combined.json             working tree
+#   team/local:team/test-combined.json  from team/local branch via git show (no checkout)
+#   scripts/test-combined.example.json  fallback
+#
+# Usage (from repo root, any branch):
+#   pwsh scripts/test-combined.ps1
+#   pwsh scripts/test-combined.ps1 --local-only
+#   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
+#
+# By default baseBranch and extraFeatureBranches are fetched from origin and merged
+# via origin/<branch>. Pass --local-only to use local branches only.
+#
+# Workflow:
+#   1. Remember current branch
+#   2. Optionally delete the test branch, then recreate it from the base branch
+#   3. Merge every extra feature branch (.gitignore conflicts auto-resolved with --ours)
+#   4. Run pytest topology suite, then uv run FYPA.py
+#   5. Return to the branch you started on (even if a step exits with an error)
+
+[CmdletBinding()]
+param(
+    [string] $ConfigPath,
+    [string] $TeamConfigRef = "team/local",
+    [string] $Remote = "origin",
+    [switch] $LocalOnly,
+    [string] $BaseBranch,
+    [string] $TestBranch,
+    [string[]] $ExtraFeatureBranches,
+    [bool] $DeleteTestBranchFirst
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+Set-Location $RepoRoot
+
+function Invoke-GitCore {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs,
+        [switch] $Quiet
+    )
+    if ($GitArgs.Count -eq 0) {
+        throw "Invoke-GitCore: no arguments"
+    }
+
+    $Output = @(& git.exe @GitArgs 2>&1)
+    $ExitCode = $LASTEXITCODE
+
+    if (-not $Quiet) {
+        foreach ($Line in $Output) {
+            if ($Line -is [System.Management.Automation.ErrorRecord]) {
+                Write-Warning $Line.ToString()
+            }
+            else {
+                Write-Host $Line
+            }
+        }
+    }
+
+    $Stdout = @(
+        $Output |
+            Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] } |
+            ForEach-Object { [string] $_ }
+    )
+
+    return @{
+        ExitCode = $ExitCode
+        Output   = $Stdout
+    }
+}
+
+function Invoke-Git {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs
+    )
+    $Result = Invoke-GitCore @GitArgs
+    if ($Result.ExitCode -ne 0) {
+        throw "git $($GitArgs -join ' ') failed (exit $($Result.ExitCode))"
+    }
+    return $Result.Output
+}
+
+function Invoke-GitSoft {
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)]
+        [string[]] $GitArgs
+    )
+    return (Invoke-GitCore @GitArgs).ExitCode
+}
+
+function Test-GitRef {
+    param([string] $Ref)
+    & git show-ref --verify --quiet $Ref
+    return $LASTEXITCODE -eq 0
+}
+
+function Get-BranchMergeRef {
+    param(
+        [string] $Branch,
+        [string] $RemoteName,
+        [bool] $UseLocalOnly
+    )
+
+    if ($UseLocalOnly) {
+        return $Branch
+    }
+    return "$RemoteName/$Branch"
+}
+
+function Test-BranchAvailable {
+    param(
+        [string] $Branch,
+        [string] $RemoteName,
+        [bool] $UseLocalOnly
+    )
+
+    if ($UseLocalOnly) {
+        return Test-GitRef "refs/heads/$Branch"
+    }
+    return Test-GitRef "refs/remotes/$RemoteName/$Branch"
+}
+
+function Sync-RemoteBranches {
+    param(
+        [string] $RemoteName,
+        [string[]] $Branches
+    )
+
+    $UniqueBranches = @($Branches | Where-Object { $_ } | Select-Object -Unique)
+    if ($UniqueBranches.Count -eq 0) {
+        return
+    }
+
+    Write-Host "==> Fetch $RemoteName $($UniqueBranches -join ', ')"
+    Invoke-Git @(@('fetch', $RemoteName) + $UniqueBranches)
+}
+
+function Test-MergeInProgress {
+    $MergeHead = & git.exe rev-parse -q --verify MERGE_HEAD 2>$null
+    return [bool] $MergeHead
+}
+
+function Get-UnmergedPaths {
+    $Output = & git.exe diff --name-only --diff-filter=U 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        return @()
+    }
+    return @($Output | Where-Object { $_ })
+}
+
+function Resolve-IgnoredMergeConflicts {
+    param(
+        [string[]] $IgnoredPaths,
+        [ValidateSet('ours', 'theirs')]
+        [string] $Prefer = 'ours'
+    )
+
+    foreach ($Path in (Get-UnmergedPaths)) {
+        if ($Path -in $IgnoredPaths) {
+            Write-Host "==> Auto-resolve merge conflict in $Path ($Prefer)"
+            Invoke-Git @('checkout', "--$Prefer", '--', $Path)
+            Invoke-Git @('add', '--', $Path)
+        }
+    }
+
+    return @(Get-UnmergedPaths)
+}
+
+function Merge-FeatureBranch {
+    param(
+        [string] $MergeRef,
+        [string] $ExtraBranch,
+        [string[]] $IgnoredPaths
+    )
+
+    $MergeMessage = "test: merge $ExtraBranch for local testing"
+    $ExitCode = Invoke-GitSoft @(
+        'merge', $MergeRef, '--no-edit', '-m', $MergeMessage
+    )
+    if ($ExitCode -eq 0) {
+        return
+    }
+
+    if (-not (Test-MergeInProgress)) {
+        throw "git merge $MergeRef failed (exit $ExitCode)"
+    }
+
+    $Remaining = Resolve-IgnoredMergeConflicts -IgnoredPaths $IgnoredPaths -Prefer 'ours'
+    if ($Remaining.Count -gt 0) {
+        throw "Merge conflict in: $($Remaining -join ', ')"
+    }
+
+    Invoke-Git @('commit', '--no-edit')
+}
+
+function Get-CurrentBranch {
+    return ([string] (Invoke-Git @('branch', '--show-current') | Select-Object -First 1)).Trim()
+}
+
+function Restore-DevBranch {
+    param([string] $Branch)
+    if ($Branch) {
+        Invoke-Git @('checkout', $Branch)
+    }
+}
+
+function Get-GitConfigJson {
+    param(
+        [string[]] $Refs,
+        [string] $RepoPath = "team/test-combined.json"
+    )
+
+    foreach ($Ref in $Refs) {
+        if (-not $Ref) { continue }
+        $Spec = "${Ref}:${RepoPath}"
+        $Json = & git show $Spec 2>$null
+        if ($LASTEXITCODE -eq 0 -and $Json) {
+            return @{ Source = $Spec; Json = [string] $Json }
+        }
+    }
+
+    return $null
+}
+
+function Resolve-ConfigSource {
+    param(
+        [string] $ExplicitPath,
+        [string] $TeamRef
+    )
+
+    if ($ExplicitPath) {
+        if (Test-Path $ExplicitPath) {
+            return @{
+                Source = (Resolve-Path $ExplicitPath).Path
+                Json   = $null
+            }
+        }
+        if ($ExplicitPath -match ':') {
+            $Json = & git show $ExplicitPath 2>$null
+            if ($LASTEXITCODE -eq 0 -and $Json) {
+                return @{ Source = $ExplicitPath; Json = [string] $Json }
+            }
+        }
+        throw "Config file not found: $ExplicitPath"
+    }
+
+    $LocalCandidates = @(
+        (Join-Path $RepoRoot "scripts/test-combined.json"),
+        (Join-Path $RepoRoot "team/test-combined.json")
+    )
+
+    foreach ($Candidate in $LocalCandidates) {
+        if (Test-Path $Candidate) {
+            return @{
+                Source = (Resolve-Path $Candidate).Path
+                Json   = $null
+            }
+        }
+    }
+
+    $GitRefs = @(
+        $TeamRef,
+        "origin/$TeamRef"
+    )
+    $FromGit = Get-GitConfigJson -Refs $GitRefs
+    if ($FromGit) {
+        return $FromGit
+    }
+
+    $Example = Join-Path $RepoRoot "scripts/test-combined.example.json"
+    if (Test-Path $Example) {
+        Write-Warning "Using example config ($Example). Copy to scripts/test-combined.json or update team/local."
+        return @{
+            Source = (Resolve-Path $Example).Path
+            Json   = $null
+        }
+    }
+
+    throw @"
+No test-combined config found.
+Fetch team/local (git fetch origin team/local) or create scripts/test-combined.json from scripts/test-combined.example.json.
+"@
+}
+
+function Read-TestCombinedConfig {
+    param(
+        [string] $Source,
+        [string] $Json
+    )
+
+    try {
+        if ($Json) {
+            $Config = $Json | ConvertFrom-Json
+        }
+        else {
+            $Config = Get-Content -Raw -Path $Source | ConvertFrom-Json
+        }
+    }
+    catch {
+        throw "Failed to parse config JSON at '$Source': $_"
+    }
+
+    foreach ($Required in @("baseBranch", "testBranch", "extraFeatureBranches")) {
+        if (-not ($Config.PSObject.Properties.Name -contains $Required)) {
+            throw "Config '$Source' is missing required field '$Required'."
+        }
+    }
+
+    return $Config
+}
+
+if (-not (Test-Path "FYPA.py")) {
+    throw "FYPA.py not found in $RepoRoot — run this script from the FYPA repo."
+}
+
+$ConfigSource = Resolve-ConfigSource -ExplicitPath $ConfigPath -TeamRef $TeamConfigRef
+Write-Host "==> Config: $($ConfigSource.Source)"
+$Config = Read-TestCombinedConfig -Source $ConfigSource.Source -Json $ConfigSource.Json
+
+$BaseBranch = if ($PSBoundParameters.ContainsKey("BaseBranch")) { $BaseBranch } else { [string] $Config.baseBranch }
+$TestBranch = if ($PSBoundParameters.ContainsKey("TestBranch")) { $TestBranch } else { [string] $Config.testBranch }
+$ExtraFeatureBranches = if ($PSBoundParameters.ContainsKey("ExtraFeatureBranches")) {
+    $ExtraFeatureBranches
+}
+else {
+    @($Config.extraFeatureBranches | ForEach-Object { [string] $_ })
+}
+$DeleteTestBranchFirst = if ($PSBoundParameters.ContainsKey("DeleteTestBranchFirst")) {
+    $DeleteTestBranchFirst
+}
+elseif ($Config.PSObject.Properties.Name -contains "deleteTestBranchFirst") {
+    [bool] $Config.deleteTestBranchFirst
+}
+else {
+    $false
+}
+
+if (-not $BaseBranch) { throw "baseBranch is empty." }
+if (-not $TestBranch) { throw "testBranch is empty." }
+
+$UseLocalOnly = [bool] $LocalOnly
+if ($UseLocalOnly) {
+    Write-Host "==> Branch source: local only"
+}
+else {
+    Write-Host "==> Branch source: $Remote (fetch + merge remote-tracking refs)"
+}
+
+$ReturnBranch = Get-CurrentBranch
+if (-not $ReturnBranch) {
+    throw "Could not determine the current branch."
+}
+
+if ($UseLocalOnly) {
+    if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $true)) {
+        throw "Base branch '$BaseBranch' not found locally."
+    }
+}
+else {
+    Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
+    if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $false)) {
+        throw "Remote branch '$Remote/$BaseBranch' not found after fetch."
+    }
+}
+
+$BaseRef = Get-BranchMergeRef -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+
+$IgnoredPaths = @('.gitignore', 'FYPA.code-workspace')
+$Status = @(Invoke-Git @('status', '--porcelain'))
+$BlockingStatus = @($Status | Where-Object {
+    $path = $_.Substring(3).Trim()
+    if ($path -match ' -> ') { $path = ($path -split ' -> ', 2)[-1].Trim() }
+    elseif ($path -match "`t") { $path = ($path -split "`t", 2)[-1].Trim() }
+    $path -notin $IgnoredPaths
+})
+if ($BlockingStatus.Count -gt 0) {
+    throw @"
+Uncommitted changes detected on '$ReturnBranch'.
+Commit or stash them before running the test script.
+"@
+}
+
+$Returned = $false
+$FypaExit = 0
+try {
+    if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
+        Write-Host "==> Delete $TestBranch"
+        if (Get-CurrentBranch -eq $TestBranch) {
+            Invoke-Git @('checkout', $ReturnBranch)
+        }
+        Invoke-Git @('branch', '-D', $TestBranch)
+    }
+
+    if (Test-GitRef "refs/heads/$TestBranch") {
+        Write-Host "==> Recreate $TestBranch from $BaseRef"
+        Invoke-Git @('branch', '-f', $TestBranch, $BaseRef)
+        Invoke-Git @('checkout', $TestBranch)
+    }
+    else {
+        Write-Host "==> Create $TestBranch from $BaseRef"
+        Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
+    }
+
+    foreach ($ExtraBranch in $ExtraFeatureBranches) {
+        if (-not $ExtraBranch) { continue }
+
+        $MergeRef = Get-BranchMergeRef -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+        if (Test-BranchAvailable -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly) {
+            Write-Host "==> Merge $MergeRef into $TestBranch"
+            Merge-FeatureBranch -MergeRef $MergeRef -ExtraBranch $ExtraBranch -IgnoredPaths $IgnoredPaths
+        }
+        else {
+            $Label = if ($UseLocalOnly) { "local branch" } else { "remote branch" }
+            Write-Warning "Extra feature $Label '$ExtraBranch' not found — continuing without it."
+        }
+    }
+
+    Write-Host "==> pytest topology tests"
+    & uv run python -m pytest `
+        tests/test_topology_invariants.py `
+        tests/test_topology_regressions.py `
+        tests/test_topology_layout.py `
+        tests/test_topology_geometry.py `
+        tests/test_topology_labels.py `
+        tests/test_pdn_topology.py -q
+    if ($LASTEXITCODE -ne 0) {
+        throw "pytest failed (exit $LASTEXITCODE)"
+    }
+
+    Write-Host "==> uv run FYPA.py"
+    & uv run --extra spacemouse FYPA.py
+    $FypaExit = $LASTEXITCODE
+}
+catch {
+    if (Get-CurrentBranch -ne $ReturnBranch) {
+        & git merge --abort 2>$null | Out-Null
+        & git rebase --abort 2>$null | Out-Null
+    }
+    throw
+}
+finally {
+    $Current = Get-CurrentBranch
+    if ($Current -ne $ReturnBranch) {
+        Write-Host "==> Return to $ReturnBranch"
+        Restore-DevBranch -Branch $ReturnBranch
+        $Returned = $true
+    }
+}
+
+if (-not $Returned) {
+    Write-Host "==> Return to $ReturnBranch"
+    Restore-DevBranch -Branch $ReturnBranch
+}
+
+if ($FypaExit -and $FypaExit -ne 0) {
+    exit $FypaExit
+}

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -1,36 +1,112 @@
-# Build a local combined test branch from a base branch + feature branches, run tests/FYPA, then switch back.
-#
-# Config (first match wins):
-#   scripts/test-combined.json          local override (gitignored)
-#   team/test-combined.json             working tree
-#   team/local:team/test-combined.json  from team/local branch via git show (no checkout)
-#   scripts/test-combined.example.json  fallback
-#
-# Usage (from repo root, any branch):
-#   pwsh scripts/test-combined.ps1
-#   pwsh scripts/test-combined.ps1 -LocalOnly
-#   pwsh scripts/test-combined.ps1 -Rebuild
-#   pwsh scripts/test-combined.ps1 -SkipTests
-#   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
-#   pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
-#
-# By default baseBranch and extraFeatureBranches are soft-fetched from origin.
-# Each input is resolved to the tip that includes local work: if the local branch
-# is ahead of (or diverged from) origin/<branch>, the local tip is merged; if
-# local is behind, origin/<branch> is used; local-only or remote-only branches
-# are accepted either way. If fetch fails (offline), existing refs are resolved
-# the same way. When input SHAs match the stamp on an existing test branch, that
-# branch is reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
-# Pass -LocalOnly to skip fetch and use local branches only.
-#
-# Workflow:
-#   1. Remember current branch
-#   2. Soft-fetch inputs (or local-only); resolve tips (prefer local when ahead);
-#      reuse test branch if stamp matches
-#   3. Otherwise optionally delete, recreate from base, merge feature branches
-#      (.gitignore conflicts auto-resolved with --ours); write stamp note
-#   4. Optionally run pytest topology suite (-SkipTests to skip), then uv run FYPA.py
-#   5. Return to the branch you started on (even if a step exits with an error)
+<#
+.SYNOPSIS
+    Build a local combined test branch, run tests/FYPA, then switch back.
+
+.DESCRIPTION
+    Merges a base branch plus feature branches into a disposable test branch,
+    optionally runs the pytest topology suite and FYPA.py, then returns to the
+    branch you started on (even if a step exits with an error).
+
+    Config resolution (first match wins):
+      scripts/test-combined.json          local override (gitignored)
+      team/test-combined.json             working tree
+      team/local:team/test-combined.json  from team/local via git show (no checkout)
+      scripts/test-combined.example.json  fallback
+
+    By default baseBranch and extraFeatureBranches are soft-fetched from origin.
+    Each input is resolved to the tip that includes local work: if the local
+    branch is ahead of (or diverged from) origin/<branch>, the local tip is
+    merged; if local is behind, origin/<branch> is used; local-only or
+    remote-only branches are accepted either way. If fetch fails (offline),
+    existing refs are resolved the same way.
+
+    When input SHAs match the stamp on an existing test branch, that branch is
+    reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
+    Pass -LocalOnly to skip fetch and use local branches only.
+
+    Workflow:
+      1. Remember current branch
+      2. Soft-fetch inputs (or local-only); resolve tips (prefer local when ahead);
+         reuse test branch if stamp matches
+      3. Otherwise optionally delete, recreate from base, merge feature branches
+         (.gitignore conflicts auto-resolved with --ours); write stamp note
+      4. Optionally run pytest topology suite (-SkipTests to skip), then uv run FYPA.py
+      5. Return to the starting branch
+
+.PARAMETER ConfigPath
+    Path to a JSON config file. Overrides the default config search order.
+
+.PARAMETER TeamConfigRef
+    Git ref used when reading team/test-combined.json via git show.
+    Default: team/local
+
+.PARAMETER Remote
+    Remote name used for soft-fetch and tip resolution. Default: origin
+
+.PARAMETER LocalOnly
+    Skip fetch; resolve and merge local branches only.
+
+.PARAMETER Rebuild
+    Force delete/recreate of the test branch even when the stamp matches.
+
+.PARAMETER SkipTests
+    Skip the pytest topology suite; still runs FYPA.py unless the script exits earlier.
+
+.PARAMETER BaseBranch
+    Override config baseBranch (branch the test branch is created from).
+
+.PARAMETER TestBranch
+    Override config testBranch (name of the disposable combined branch).
+
+.PARAMETER ExtraFeatureBranches
+    Override config extraFeatureBranches (branches merged onto the base).
+
+.PARAMETER DeleteTestBranchFirst
+    Override config deleteTestBranchFirst. When true, delete the existing test
+    branch before recreating it.
+
+.PARAMETER PrjPcb
+    Path to a .PrjPcb passed through to FYPA.py.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1
+
+    Use default config resolution, soft-fetch, reuse or rebuild the test branch,
+    run tests and FYPA, then switch back.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1 -LocalOnly
+
+    Skip remote fetch; use local branch tips only.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1 -Rebuild
+
+    Force a clean recreate of the test branch.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1 -SkipTests
+
+    Build/reuse the test branch and run FYPA without pytest.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
+
+    Use an explicit local config file.
+
+.EXAMPLE
+    pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
+
+    Pass a project file through to FYPA.py.
+
+.EXAMPLE
+    Get-Help .\scripts\test-combined.ps1 -Full
+
+    Show this help. Equivalent: pwsh scripts/test-combined.ps1 -?
+
+.NOTES
+    Run from the repo root (or any branch); the script cds to the repo root itself.
+#>
 
 [CmdletBinding()]
 param(

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -9,17 +9,23 @@
 # Usage (from repo root, any branch):
 #   pwsh scripts/test-combined.ps1
 #   pwsh scripts/test-combined.ps1 --local-only
+#   pwsh scripts/test-combined.ps1 -Rebuild
+#   pwsh scripts/test-combined.ps1 -SkipTests
 #   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
 #   pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
 #
-# By default baseBranch and extraFeatureBranches are fetched from origin and merged
-# via origin/<branch>. Pass --local-only to use local branches only.
+# By default baseBranch and extraFeatureBranches are soft-fetched from origin and
+# merged via origin/<branch>. If fetch fails (offline), local refs are used.
+# When input SHAs match the stamp on an existing test branch, that branch is
+# reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
+# Pass --local-only to skip fetch and use local branches only.
 #
 # Workflow:
 #   1. Remember current branch
-#   2. Optionally delete the test branch, then recreate it from the base branch
-#   3. Merge every extra feature branch (.gitignore conflicts auto-resolved with --ours)
-#   4. Run pytest topology suite, then uv run FYPA.py
+#   2. Soft-fetch inputs (or local-only); reuse test branch if stamp matches
+#   3. Otherwise optionally delete, recreate from base, merge feature branches
+#      (.gitignore conflicts auto-resolved with --ours); write stamp note
+#   4. Optionally run pytest topology suite (-SkipTests to skip), then uv run FYPA.py
 #   5. Return to the branch you started on (even if a step exits with an error)
 
 [CmdletBinding()]
@@ -28,6 +34,8 @@ param(
     [string] $TeamConfigRef = "team/local",
     [string] $Remote = "origin",
     [switch] $LocalOnly,
+    [switch] $Rebuild,
+    [switch] $SkipTests,
     [string] $BaseBranch,
     [string] $TestBranch,
     [string[]] $ExtraFeatureBranches,
@@ -140,7 +148,78 @@ function Sync-RemoteBranches {
     }
 
     Write-Host "==> Fetch $RemoteName $($UniqueBranches -join ', ')"
-    Invoke-Git @(@('fetch', $RemoteName) + $UniqueBranches)
+    # git writes progress to stderr; don't surface it as PowerShell warnings.
+    $Result = Invoke-GitCore -Quiet @(@('fetch', $RemoteName) + $UniqueBranches)
+    if ($Result.ExitCode -ne 0) {
+        $Detail = ($Result.Output -join "`n").Trim()
+        if ($Detail) {
+            throw "git fetch $RemoteName failed (exit $($Result.ExitCode)): $Detail"
+        }
+        throw "git fetch $RemoteName failed (exit $($Result.ExitCode))"
+    }
+}
+
+function Get-RefSha {
+    param([string] $Ref)
+    $Sha = ([string] (& git.exe rev-parse --verify "$Ref^{commit}" 2>$null)).Trim()
+    if ($LASTEXITCODE -ne 0 -or -not $Sha) {
+        return $null
+    }
+    return $Sha
+}
+
+function Get-InputStamp {
+    param(
+        [string] $ConfigIdentity,
+        [string] $BaseName,
+        [string] $BaseSha,
+        [string[]] $ExtraPairs
+    )
+
+    # Single-line stamp: PowerShell [string] casts of multi-line git output join
+    # with spaces and would break equality checks if we used newlines.
+    $Parts = [System.Collections.Generic.List[string]]::new()
+    $Parts.Add("config=$ConfigIdentity")
+    $Parts.Add("base=$BaseName=$BaseSha")
+    foreach ($Pair in $ExtraPairs) {
+        if ($Pair) { $Parts.Add("extra=$Pair") }
+    }
+    return ($Parts -join '|')
+}
+
+function Get-TestCombinedStamp {
+    param([string] $Commit)
+    if (-not $Commit) { return $null }
+    $Lines = @(& git.exe notes --ref=test-combined show $Commit 2>$null)
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+    # Join exactly as written; Trim only outer whitespace.
+    return (($Lines -join "`n").Trim())
+}
+
+function Set-TestCombinedStamp {
+    param(
+        [string] $Commit,
+        [string] $Stamp
+    )
+    $ExitCode = Invoke-GitSoft @(
+        'notes', '--ref=test-combined', 'add', '-f', '-m', $Stamp, $Commit
+    )
+    if ($ExitCode -ne 0) {
+        Write-Warning "Could not write test-combined stamp note on $Commit"
+    }
+}
+
+function ConvertTo-NormalizedStamp {
+    param([string] $Stamp)
+    if (-not $Stamp) { return $null }
+    # Accept legacy multiline notes (joined with `n) and new single-line (`|`) form.
+    $Normalized = $Stamp.Trim() -replace "`r`n", "`n" -replace "`r", "`n"
+    if ($Normalized.Contains("`n")) {
+        $Normalized = (($Normalized -split "`n") | ForEach-Object { $_.Trim() } | Where-Object { $_ }) -join '|'
+    }
+    return $Normalized
 }
 
 function Test-MergeInProgress {
@@ -359,7 +438,7 @@ if ($UseLocalOnly) {
     Write-Host "==> Branch source: local only"
 }
 else {
-    Write-Host "==> Branch source: $Remote (fetch + merge remote-tracking refs)"
+    Write-Host "==> Branch source: $Remote (soft-fetch + merge remote-tracking refs)"
 }
 
 $ReturnBranch = Get-CurrentBranch
@@ -373,13 +452,87 @@ if ($UseLocalOnly) {
     }
 }
 else {
-    Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
-    if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $false)) {
-        throw "Remote branch '$Remote/$BaseBranch' not found after fetch."
+    try {
+        Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
+        if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $false)) {
+            throw "Remote branch '$Remote/$BaseBranch' not found after fetch."
+        }
+    }
+    catch {
+        Write-Warning "Fetch from $Remote failed or remote base missing; falling back to local refs."
+        Write-Warning "$_"
+        $UseLocalOnly = $true
+        if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $true)) {
+            throw "Base branch '$BaseBranch' not found locally after soft-fetch fallback."
+        }
+        Write-Host "==> Branch source: local only (fallback)"
     }
 }
 
 $BaseRef = Get-BranchMergeRef -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+$BaseSha = Get-RefSha -Ref $BaseRef
+if (-not $BaseSha) {
+    throw "Could not resolve SHA for base ref '$BaseRef'."
+}
+
+$ExtraStampPairs = [System.Collections.Generic.List[string]]::new()
+$ResolvedExtras = [System.Collections.Generic.List[hashtable]]::new()
+foreach ($ExtraBranch in $ExtraFeatureBranches) {
+    if (-not $ExtraBranch) { continue }
+    $MergeRef = Get-BranchMergeRef -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+    if (Test-BranchAvailable -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly) {
+        $ExtraSha = Get-RefSha -Ref $MergeRef
+        if (-not $ExtraSha) {
+            Write-Warning "Could not resolve SHA for '$MergeRef' — continuing without it."
+            continue
+        }
+        $ExtraStampPairs.Add("$ExtraBranch=$ExtraSha")
+        $ResolvedExtras.Add(@{
+            Branch   = $ExtraBranch
+            MergeRef = $MergeRef
+        })
+    }
+    else {
+        $Label = if ($UseLocalOnly) { "local branch" } else { "remote branch" }
+        Write-Warning "Extra feature $Label '$ExtraBranch' not found — continuing without it."
+    }
+}
+
+$ConfigIdentity = @(
+    "base=$BaseBranch",
+    "test=$TestBranch",
+    "deleteFirst=$DeleteTestBranchFirst",
+    "extras=$($ExtraFeatureBranches -join ',')"
+) -join ';'
+
+$DesiredStamp = ConvertTo-NormalizedStamp (Get-InputStamp `
+    -ConfigIdentity $ConfigIdentity `
+    -BaseName $BaseBranch `
+    -BaseSha $BaseSha `
+    -ExtraPairs @($ExtraStampPairs))
+
+$TestBranchExists = Test-GitRef "refs/heads/$TestBranch"
+$ExistingTip = if ($TestBranchExists) { Get-RefSha -Ref $TestBranch } else { $null }
+$ExistingStampRaw = $null
+if ($ExistingTip) {
+    $ExistingStampRaw = Get-TestCombinedStamp -Commit $ExistingTip
+}
+$ExistingStamp = ConvertTo-NormalizedStamp $ExistingStampRaw
+$CanReuse = (
+    -not $Rebuild -and
+    $TestBranchExists -and
+    $ExistingStamp -and
+    ($ExistingStamp -eq $DesiredStamp)
+)
+
+if (-not $CanReuse -and $TestBranchExists -and -not $Rebuild) {
+    if (-not $ExistingStamp) {
+        Write-Host "==> No reuse stamp on $TestBranch — will rebuild"
+    }
+    else {
+        Write-Host "==> Stamp mismatch on $TestBranch — will rebuild"
+    }
+}
 
 $IgnoredPaths = @('.gitignore', 'FYPA.code-workspace')
 $Status = @(Invoke-Git @('status', '--porcelain'))
@@ -399,48 +552,68 @@ Commit or stash them before running the test script.
 $Returned = $false
 $FypaExit = 0
 try {
-    if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
-        Write-Host "==> Delete $TestBranch"
-        if (Get-CurrentBranch -eq $TestBranch) {
-            Invoke-Git @('checkout', $ReturnBranch)
+    if ($CanReuse) {
+        Write-Host "==> Reuse $TestBranch (inputs unchanged)"
+        if ((Get-CurrentBranch) -ne $TestBranch) {
+            Invoke-Git @('checkout', $TestBranch)
         }
-        Invoke-Git @('branch', '-D', $TestBranch)
-    }
-
-    if (Test-GitRef "refs/heads/$TestBranch") {
-        Write-Host "==> Recreate $TestBranch from $BaseRef"
-        Invoke-Git @('branch', '-f', $TestBranch, $BaseRef)
-        Invoke-Git @('checkout', $TestBranch)
     }
     else {
-        Write-Host "==> Create $TestBranch from $BaseRef"
-        Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
-    }
-
-    foreach ($ExtraBranch in $ExtraFeatureBranches) {
-        if (-not $ExtraBranch) { continue }
-
-        $MergeRef = Get-BranchMergeRef -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
-        if (Test-BranchAvailable -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly) {
-            Write-Host "==> Merge $MergeRef into $TestBranch"
-            Merge-FeatureBranch -MergeRef $MergeRef -ExtraBranch $ExtraBranch -IgnoredPaths $IgnoredPaths
+        if ($Rebuild) {
+            Write-Host "==> Rebuild requested — recreating $TestBranch"
+        }
+        elseif (-not $TestBranchExists) {
+            Write-Host "==> $TestBranch missing — creating from $BaseRef"
         }
         else {
-            $Label = if ($UseLocalOnly) { "local branch" } else { "remote branch" }
-            Write-Warning "Extra feature $Label '$ExtraBranch' not found — continuing without it."
+            Write-Host "==> Inputs changed — recreating $TestBranch from $BaseRef"
+        }
+
+        if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
+            Write-Host "==> Delete $TestBranch"
+            if ((Get-CurrentBranch) -eq $TestBranch) {
+                Invoke-Git @('checkout', $ReturnBranch)
+            }
+            Invoke-Git @('branch', '-D', $TestBranch)
+        }
+
+        if (Test-GitRef "refs/heads/$TestBranch") {
+            Write-Host "==> Recreate $TestBranch from $BaseRef"
+            Invoke-Git @('branch', '-f', $TestBranch, $BaseRef)
+            Invoke-Git @('checkout', $TestBranch)
+        }
+        else {
+            Write-Host "==> Create $TestBranch from $BaseRef"
+            Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
+        }
+
+        foreach ($Extra in $ResolvedExtras) {
+            Write-Host "==> Merge $($Extra.MergeRef) into $TestBranch"
+            Merge-FeatureBranch -MergeRef $Extra.MergeRef -ExtraBranch $Extra.Branch -IgnoredPaths $IgnoredPaths
+        }
+
+        $NewTip = Get-RefSha -Ref 'HEAD'
+        if ($NewTip) {
+            Set-TestCombinedStamp -Commit $NewTip -Stamp $DesiredStamp
+            Write-Host "==> Stamp written for $TestBranch"
         }
     }
 
-    Write-Host "==> pytest topology tests"
-    & uv run python -m pytest `
-        tests/test_topology_invariants.py `
-        tests/test_topology_regressions.py `
-        tests/test_topology_layout.py `
-        tests/test_topology_geometry.py `
-        tests/test_topology_labels.py `
-        tests/test_pdn_topology.py -q
-    if ($LASTEXITCODE -ne 0) {
-        throw "pytest failed (exit $LASTEXITCODE)"
+    if ($SkipTests) {
+        Write-Host "==> Skip pytest (-SkipTests)"
+    }
+    else {
+        Write-Host "==> pytest topology tests"
+        & uv run python -m pytest `
+            tests/test_topology_invariants.py `
+            tests/test_topology_regressions.py `
+            tests/test_topology_layout.py `
+            tests/test_topology_geometry.py `
+            tests/test_topology_labels.py `
+            tests/test_pdn_topology.py -q
+        if ($LASTEXITCODE -ne 0) {
+            throw "pytest failed (exit $LASTEXITCODE)"
+        }
     }
 
     Write-Host "==> uv run FYPA.py"

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -8,7 +8,7 @@
 #
 # Usage (from repo root, any branch):
 #   pwsh scripts/test-combined.ps1
-#   pwsh scripts/test-combined.ps1 --local-only
+#   pwsh scripts/test-combined.ps1 -LocalOnly
 #   pwsh scripts/test-combined.ps1 -Rebuild
 #   pwsh scripts/test-combined.ps1 -SkipTests
 #   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
@@ -21,7 +21,7 @@
 # are accepted either way. If fetch fails (offline), existing refs are resolved
 # the same way. When input SHAs match the stamp on an existing test branch, that
 # branch is reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
-# Pass --local-only to skip fetch and use local branches only.
+# Pass -LocalOnly to skip fetch and use local branches only.
 #
 # Workflow:
 #   1. Remember current branch

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -14,15 +14,19 @@
 #   pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
 #   pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
 #
-# By default baseBranch and extraFeatureBranches are soft-fetched from origin and
-# merged via origin/<branch>. If fetch fails (offline), local refs are used.
-# When input SHAs match the stamp on an existing test branch, that branch is
-# reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
+# By default baseBranch and extraFeatureBranches are soft-fetched from origin.
+# Each input is resolved to the tip that includes local work: if the local branch
+# is ahead of (or diverged from) origin/<branch>, the local tip is merged; if
+# local is behind, origin/<branch> is used; local-only or remote-only branches
+# are accepted either way. If fetch fails (offline), existing refs are resolved
+# the same way. When input SHAs match the stamp on an existing test branch, that
+# branch is reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
 # Pass --local-only to skip fetch and use local branches only.
 #
 # Workflow:
 #   1. Remember current branch
-#   2. Soft-fetch inputs (or local-only); reuse test branch if stamp matches
+#   2. Soft-fetch inputs (or local-only); resolve tips (prefer local when ahead);
+#      reuse test branch if stamp matches
 #   3. Otherwise optionally delete, recreate from base, merge feature branches
 #      (.gitignore conflicts auto-resolved with --ours); write stamp note
 #   4. Optionally run pytest topology suite (-SkipTests to skip), then uv run FYPA.py
@@ -110,30 +114,120 @@ function Test-GitRef {
     return $LASTEXITCODE -eq 0
 }
 
-function Get-BranchMergeRef {
+function Test-GitAncestor {
     param(
-        [string] $Branch,
-        [string] $RemoteName,
-        [bool] $UseLocalOnly
+        [string] $Ancestor,
+        [string] $Descendant
     )
-
-    if ($UseLocalOnly) {
-        return $Branch
-    }
-    return "$RemoteName/$Branch"
+    & git.exe merge-base --is-ancestor $Ancestor $Descendant 2>$null | Out-Null
+    return $LASTEXITCODE -eq 0
 }
 
-function Test-BranchAvailable {
+function Resolve-BranchMergeTarget {
     param(
         [string] $Branch,
         [string] $RemoteName,
         [bool] $UseLocalOnly
     )
 
+    $LocalRef = $Branch
+    $RemoteRef = "$RemoteName/$Branch"
+    $HasLocal = Test-GitRef "refs/heads/$Branch"
+    $HasRemote = Test-GitRef "refs/remotes/$RemoteName/$Branch"
+
     if ($UseLocalOnly) {
-        return Test-GitRef "refs/heads/$Branch"
+        if (-not $HasLocal) { return $null }
+        $Sha = Get-RefSha -Ref $LocalRef
+        if (-not $Sha) { return $null }
+        return @{
+            Branch   = $Branch
+            MergeRef = $LocalRef
+            Sha      = $Sha
+            Source   = 'local'
+        }
     }
-    return Test-GitRef "refs/remotes/$RemoteName/$Branch"
+
+    if ($HasLocal -and $HasRemote) {
+        $LocalSha = Get-RefSha -Ref $LocalRef
+        $RemoteSha = Get-RefSha -Ref $RemoteRef
+        if (-not $LocalSha -and -not $RemoteSha) { return $null }
+        if (-not $LocalSha) {
+            return @{
+                Branch   = $Branch
+                MergeRef = $RemoteRef
+                Sha      = $RemoteSha
+                Source   = 'remote'
+            }
+        }
+        if (-not $RemoteSha) {
+            return @{
+                Branch   = $Branch
+                MergeRef = $LocalRef
+                Sha      = $LocalSha
+                Source   = 'local'
+            }
+        }
+        if ($LocalSha -eq $RemoteSha) {
+            return @{
+                Branch   = $Branch
+                MergeRef = $LocalRef
+                Sha      = $LocalSha
+                Source   = 'local'
+            }
+        }
+        # Local contains remote → unpushed local commits; keep them.
+        if (Test-GitAncestor -Ancestor $RemoteSha -Descendant $LocalSha) {
+            Write-Host "==> ${Branch}: using local (ahead of $RemoteRef)"
+            return @{
+                Branch   = $Branch
+                MergeRef = $LocalRef
+                Sha      = $LocalSha
+                Source   = 'local'
+            }
+        }
+        # Remote contains local → local checkout is stale; take remote.
+        if (Test-GitAncestor -Ancestor $LocalSha -Descendant $RemoteSha) {
+            return @{
+                Branch   = $Branch
+                MergeRef = $RemoteRef
+                Sha      = $RemoteSha
+                Source   = 'remote'
+            }
+        }
+        # Diverged: never drop local work.
+        Write-Warning "${Branch}: local and $RemoteRef have diverged — using local tip"
+        return @{
+            Branch   = $Branch
+            MergeRef = $LocalRef
+            Sha      = $LocalSha
+            Source   = 'local'
+        }
+    }
+
+    if ($HasLocal) {
+        $Sha = Get-RefSha -Ref $LocalRef
+        if (-not $Sha) { return $null }
+        Write-Host "==> ${Branch}: no $RemoteRef — using local"
+        return @{
+            Branch   = $Branch
+            MergeRef = $LocalRef
+            Sha      = $Sha
+            Source   = 'local'
+        }
+    }
+
+    if ($HasRemote) {
+        $Sha = Get-RefSha -Ref $RemoteRef
+        if (-not $Sha) { return $null }
+        return @{
+            Branch   = $Branch
+            MergeRef = $RemoteRef
+            Sha      = $Sha
+            Source   = 'remote'
+        }
+    }
+
+    return $null
 }
 
 function Sync-RemoteBranches {
@@ -438,7 +532,7 @@ if ($UseLocalOnly) {
     Write-Host "==> Branch source: local only"
 }
 else {
-    Write-Host "==> Branch source: $Remote (soft-fetch + merge remote-tracking refs)"
+    Write-Host "==> Branch source: $Remote (soft-fetch; prefer local when ahead/diverged)"
 }
 
 $ReturnBranch = Get-CurrentBranch
@@ -446,56 +540,42 @@ if (-not $ReturnBranch) {
     throw "Could not determine the current branch."
 }
 
-if ($UseLocalOnly) {
-    if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $true)) {
-        throw "Base branch '$BaseBranch' not found locally."
-    }
-}
-else {
+if (-not $UseLocalOnly) {
     try {
         Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
-        if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $false)) {
-            throw "Remote branch '$Remote/$BaseBranch' not found after fetch."
-        }
     }
     catch {
-        Write-Warning "Fetch from $Remote failed or remote base missing; falling back to local refs."
+        Write-Warning "Fetch from $Remote failed; resolving from existing local/remote-tracking refs."
         Write-Warning "$_"
-        $UseLocalOnly = $true
-        if (-not (Test-BranchAvailable -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $true)) {
-            throw "Base branch '$BaseBranch' not found locally after soft-fetch fallback."
-        }
-        Write-Host "==> Branch source: local only (fallback)"
     }
 }
 
-$BaseRef = Get-BranchMergeRef -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
-$BaseSha = Get-RefSha -Ref $BaseRef
-if (-not $BaseSha) {
-    throw "Could not resolve SHA for base ref '$BaseRef'."
+$BaseTarget = Resolve-BranchMergeTarget -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+if (-not $BaseTarget) {
+    $Where = if ($UseLocalOnly) { "locally" } else { "locally or as $Remote/$BaseBranch" }
+    throw "Base branch '$BaseBranch' not found $Where."
 }
+
+$BaseRef = $BaseTarget.MergeRef
+$BaseSha = $BaseTarget.Sha
+Write-Host "==> Base: $BaseRef ($($BaseTarget.Source))"
 
 $ExtraStampPairs = [System.Collections.Generic.List[string]]::new()
 $ResolvedExtras = [System.Collections.Generic.List[hashtable]]::new()
 foreach ($ExtraBranch in $ExtraFeatureBranches) {
     if (-not $ExtraBranch) { continue }
-    $MergeRef = Get-BranchMergeRef -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
-    if (Test-BranchAvailable -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly) {
-        $ExtraSha = Get-RefSha -Ref $MergeRef
-        if (-not $ExtraSha) {
-            Write-Warning "Could not resolve SHA for '$MergeRef' — continuing without it."
-            continue
-        }
-        $ExtraStampPairs.Add("$ExtraBranch=$ExtraSha")
-        $ResolvedExtras.Add(@{
-            Branch   = $ExtraBranch
-            MergeRef = $MergeRef
-        })
+    $ExtraTarget = Resolve-BranchMergeTarget -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
+    if (-not $ExtraTarget) {
+        $Where = if ($UseLocalOnly) { "locally" } else { "locally or on $Remote" }
+        Write-Warning "Extra feature branch '$ExtraBranch' not found $Where — continuing without it."
+        continue
     }
-    else {
-        $Label = if ($UseLocalOnly) { "local branch" } else { "remote branch" }
-        Write-Warning "Extra feature $Label '$ExtraBranch' not found — continuing without it."
-    }
+    Write-Host "==> Extra: $($ExtraTarget.MergeRef) ($($ExtraTarget.Source))"
+    $ExtraStampPairs.Add("$ExtraBranch=$($ExtraTarget.Sha)")
+    $ResolvedExtras.Add(@{
+        Branch   = $ExtraTarget.Branch
+        MergeRef = $ExtraTarget.MergeRef
+    })
 }
 
 $ConfigIdentity = @(

--- a/scripts/test-combined.ps1
+++ b/scripts/test-combined.ps1
@@ -1,69 +1,26 @@
 <#
 .SYNOPSIS
-    Build a local combined test branch, run tests/FYPA, then switch back.
+    Check out origin/test/combined, optionally run tests/FYPA, then switch back.
 
 .DESCRIPTION
-    Merges a base branch plus feature branches into a disposable test branch,
-    optionally runs the pytest topology suite and FYPA.py, then returns to the
-    branch you started on (even if a step exits with an error).
+    The combined branch is maintained centrally (see scripts/maintain-test-combined.ps1).
+    This script only fetches and checks out the remote tip — it does not merge
+    feature branches.
 
-    Config resolution (first match wins):
-      scripts/test-combined.json          local override (gitignored)
-      team/test-combined.json             working tree
-      team/local:team/test-combined.json  from team/local via git show (no checkout)
-      scripts/test-combined.example.json  fallback
-
-    By default baseBranch and extraFeatureBranches are soft-fetched from origin.
-    Each input is resolved to the tip that includes local work: if the local
-    branch is ahead of (or diverged from) origin/<branch>, the local tip is
-    merged; if local is behind, origin/<branch> is used; local-only or
-    remote-only branches are accepted either way. If fetch fails (offline),
-    existing refs are resolved the same way.
-
-    When input SHAs match the stamp on an existing test branch, that branch is
-    reused instead of rebuilt. Pass -Rebuild to force a clean recreate.
-    Pass -LocalOnly to skip fetch and use local branches only.
-
-    Workflow:
-      1. Remember current branch
-      2. Soft-fetch inputs (or local-only); resolve tips (prefer local when ahead);
-         reuse test branch if stamp matches
-      3. Otherwise optionally delete, recreate from base, merge feature branches
-         (.gitignore conflicts auto-resolved with --ours); write stamp note
-      4. Optionally run pytest topology suite (-SkipTests to skip), then uv run FYPA.py
-      5. Return to the starting branch
-
-.PARAMETER ConfigPath
-    Path to a JSON config file. Overrides the default config search order.
-
-.PARAMETER TeamConfigRef
-    Git ref used when reading team/test-combined.json via git show.
-    Default: team/local
+    To rebuild and push test/combined:
+      pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
 
 .PARAMETER Remote
-    Remote name used for soft-fetch and tip resolution. Default: origin
+    Remote name. Default: origin
 
-.PARAMETER LocalOnly
-    Skip fetch; resolve and merge local branches only.
+.PARAMETER TestBranch
+    Combined branch name. Default: test/combined
 
 .PARAMETER Rebuild
-    Force delete/recreate of the test branch even when the stamp matches.
+    Not supported here — prints how to run maintain-test-combined.ps1 and exits 1.
 
 .PARAMETER SkipTests
     Skip the pytest topology suite; still runs FYPA.py unless the script exits earlier.
-
-.PARAMETER BaseBranch
-    Override config baseBranch (branch the test branch is created from).
-
-.PARAMETER TestBranch
-    Override config testBranch (name of the disposable combined branch).
-
-.PARAMETER ExtraFeatureBranches
-    Override config extraFeatureBranches (branches merged onto the base).
-
-.PARAMETER DeleteTestBranchFirst
-    Override config deleteTestBranchFirst. When true, delete the existing test
-    branch before recreating it.
 
 .PARAMETER PrjPcb
     Path to a .PrjPcb passed through to FYPA.py.
@@ -71,55 +28,16 @@
 .EXAMPLE
     pwsh scripts/test-combined.ps1
 
-    Use default config resolution, soft-fetch, reuse or rebuild the test branch,
-    run tests and FYPA, then switch back.
-
 .EXAMPLE
-    pwsh scripts/test-combined.ps1 -LocalOnly
-
-    Skip remote fetch; use local branch tips only.
-
-.EXAMPLE
-    pwsh scripts/test-combined.ps1 -Rebuild
-
-    Force a clean recreate of the test branch.
-
-.EXAMPLE
-    pwsh scripts/test-combined.ps1 -SkipTests
-
-    Build/reuse the test branch and run FYPA without pytest.
-
-.EXAMPLE
-    pwsh scripts/test-combined.ps1 -ConfigPath scripts/test-combined.json
-
-    Use an explicit local config file.
-
-.EXAMPLE
-    pwsh scripts/test-combined.ps1 -PrjPcb path\to\YourBoard.PrjPcb
-
-    Pass a project file through to FYPA.py.
-
-.EXAMPLE
-    Get-Help .\scripts\test-combined.ps1 -Full
-
-    Show this help. Equivalent: pwsh scripts/test-combined.ps1 -?
-
-.NOTES
-    Run from the repo root (or any branch); the script cds to the repo root itself.
+    pwsh scripts/test-combined.ps1 -SkipTests -PrjPcb path\to\Board.PrjPcb
 #>
 
 [CmdletBinding()]
 param(
-    [string] $ConfigPath,
-    [string] $TeamConfigRef = "team/local",
     [string] $Remote = "origin",
-    [switch] $LocalOnly,
+    [string] $TestBranch = "test/combined",
     [switch] $Rebuild,
     [switch] $SkipTests,
-    [string] $BaseBranch,
-    [string] $TestBranch,
-    [string[]] $ExtraFeatureBranches,
-    [bool] $DeleteTestBranchFirst,
     [string] $PrjPcb
 )
 
@@ -127,6 +45,18 @@ $ErrorActionPreference = "Stop"
 
 $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
 Set-Location $RepoRoot
+
+if ($Rebuild) {
+    Write-Error @"
+-Rebuild is no longer supported by test-combined.ps1.
+Rebuild and publish the shared branch with:
+
+  pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+
+Then re-run this script to check out $Remote/$TestBranch.
+"@
+    exit 1
+}
 
 function Invoke-GitCore {
     param(
@@ -176,12 +106,8 @@ function Invoke-Git {
     return $Result.Output
 }
 
-function Invoke-GitSoft {
-    param(
-        [Parameter(Mandatory, ValueFromRemainingArguments)]
-        [string[]] $GitArgs
-    )
-    return (Invoke-GitCore @GitArgs).ExitCode
+function Get-CurrentBranch {
+    return ([string] (Invoke-Git @('branch', '--show-current') | Select-Object -First 1)).Trim()
 }
 
 function Test-GitRef {
@@ -190,406 +116,8 @@ function Test-GitRef {
     return $LASTEXITCODE -eq 0
 }
 
-function Test-GitAncestor {
-    param(
-        [string] $Ancestor,
-        [string] $Descendant
-    )
-    & git.exe merge-base --is-ancestor $Ancestor $Descendant 2>$null | Out-Null
-    return $LASTEXITCODE -eq 0
-}
-
-function Resolve-BranchMergeTarget {
-    param(
-        [string] $Branch,
-        [string] $RemoteName,
-        [bool] $UseLocalOnly
-    )
-
-    $LocalRef = $Branch
-    $RemoteRef = "$RemoteName/$Branch"
-    $HasLocal = Test-GitRef "refs/heads/$Branch"
-    $HasRemote = Test-GitRef "refs/remotes/$RemoteName/$Branch"
-
-    if ($UseLocalOnly) {
-        if (-not $HasLocal) { return $null }
-        $Sha = Get-RefSha -Ref $LocalRef
-        if (-not $Sha) { return $null }
-        return @{
-            Branch   = $Branch
-            MergeRef = $LocalRef
-            Sha      = $Sha
-            Source   = 'local'
-        }
-    }
-
-    if ($HasLocal -and $HasRemote) {
-        $LocalSha = Get-RefSha -Ref $LocalRef
-        $RemoteSha = Get-RefSha -Ref $RemoteRef
-        if (-not $LocalSha -and -not $RemoteSha) { return $null }
-        if (-not $LocalSha) {
-            return @{
-                Branch   = $Branch
-                MergeRef = $RemoteRef
-                Sha      = $RemoteSha
-                Source   = 'remote'
-            }
-        }
-        if (-not $RemoteSha) {
-            return @{
-                Branch   = $Branch
-                MergeRef = $LocalRef
-                Sha      = $LocalSha
-                Source   = 'local'
-            }
-        }
-        if ($LocalSha -eq $RemoteSha) {
-            return @{
-                Branch   = $Branch
-                MergeRef = $LocalRef
-                Sha      = $LocalSha
-                Source   = 'local'
-            }
-        }
-        # Local contains remote → unpushed local commits; keep them.
-        if (Test-GitAncestor -Ancestor $RemoteSha -Descendant $LocalSha) {
-            Write-Host "==> ${Branch}: using local (ahead of $RemoteRef)"
-            return @{
-                Branch   = $Branch
-                MergeRef = $LocalRef
-                Sha      = $LocalSha
-                Source   = 'local'
-            }
-        }
-        # Remote contains local → local checkout is stale; take remote.
-        if (Test-GitAncestor -Ancestor $LocalSha -Descendant $RemoteSha) {
-            return @{
-                Branch   = $Branch
-                MergeRef = $RemoteRef
-                Sha      = $RemoteSha
-                Source   = 'remote'
-            }
-        }
-        # Diverged: never drop local work.
-        Write-Warning "${Branch}: local and $RemoteRef have diverged — using local tip"
-        return @{
-            Branch   = $Branch
-            MergeRef = $LocalRef
-            Sha      = $LocalSha
-            Source   = 'local'
-        }
-    }
-
-    if ($HasLocal) {
-        $Sha = Get-RefSha -Ref $LocalRef
-        if (-not $Sha) { return $null }
-        Write-Host "==> ${Branch}: no $RemoteRef — using local"
-        return @{
-            Branch   = $Branch
-            MergeRef = $LocalRef
-            Sha      = $Sha
-            Source   = 'local'
-        }
-    }
-
-    if ($HasRemote) {
-        $Sha = Get-RefSha -Ref $RemoteRef
-        if (-not $Sha) { return $null }
-        return @{
-            Branch   = $Branch
-            MergeRef = $RemoteRef
-            Sha      = $Sha
-            Source   = 'remote'
-        }
-    }
-
-    return $null
-}
-
-function Sync-RemoteBranches {
-    param(
-        [string] $RemoteName,
-        [string[]] $Branches
-    )
-
-    $UniqueBranches = @($Branches | Where-Object { $_ } | Select-Object -Unique)
-    if ($UniqueBranches.Count -eq 0) {
-        return
-    }
-
-    Write-Host "==> Fetch $RemoteName $($UniqueBranches -join ', ')"
-    # git writes progress to stderr; don't surface it as PowerShell warnings.
-    $Result = Invoke-GitCore -Quiet @(@('fetch', $RemoteName) + $UniqueBranches)
-    if ($Result.ExitCode -ne 0) {
-        $Detail = ($Result.Output -join "`n").Trim()
-        if ($Detail) {
-            throw "git fetch $RemoteName failed (exit $($Result.ExitCode)): $Detail"
-        }
-        throw "git fetch $RemoteName failed (exit $($Result.ExitCode))"
-    }
-}
-
-function Get-RefSha {
-    param([string] $Ref)
-    $Sha = ([string] (& git.exe rev-parse --verify "$Ref^{commit}" 2>$null)).Trim()
-    if ($LASTEXITCODE -ne 0 -or -not $Sha) {
-        return $null
-    }
-    return $Sha
-}
-
-function Get-InputStamp {
-    param(
-        [string] $ConfigIdentity,
-        [string] $BaseName,
-        [string] $BaseSha,
-        [string[]] $ExtraPairs
-    )
-
-    # Single-line stamp: PowerShell [string] casts of multi-line git output join
-    # with spaces and would break equality checks if we used newlines.
-    $Parts = [System.Collections.Generic.List[string]]::new()
-    $Parts.Add("config=$ConfigIdentity")
-    $Parts.Add("base=$BaseName=$BaseSha")
-    foreach ($Pair in $ExtraPairs) {
-        if ($Pair) { $Parts.Add("extra=$Pair") }
-    }
-    return ($Parts -join '|')
-}
-
-function Get-TestCombinedStamp {
-    param([string] $Commit)
-    if (-not $Commit) { return $null }
-    $Lines = @(& git.exe notes --ref=test-combined show $Commit 2>$null)
-    if ($LASTEXITCODE -ne 0) {
-        return $null
-    }
-    # Join exactly as written; Trim only outer whitespace.
-    return (($Lines -join "`n").Trim())
-}
-
-function Set-TestCombinedStamp {
-    param(
-        [string] $Commit,
-        [string] $Stamp
-    )
-    $ExitCode = Invoke-GitSoft @(
-        'notes', '--ref=test-combined', 'add', '-f', '-m', $Stamp, $Commit
-    )
-    if ($ExitCode -ne 0) {
-        Write-Warning "Could not write test-combined stamp note on $Commit"
-    }
-}
-
-function ConvertTo-NormalizedStamp {
-    param([string] $Stamp)
-    if (-not $Stamp) { return $null }
-    # Accept legacy multiline notes (joined with `n) and new single-line (`|`) form.
-    $Normalized = $Stamp.Trim() -replace "`r`n", "`n" -replace "`r", "`n"
-    if ($Normalized.Contains("`n")) {
-        $Normalized = (($Normalized -split "`n") | ForEach-Object { $_.Trim() } | Where-Object { $_ }) -join '|'
-    }
-    return $Normalized
-}
-
-function Test-MergeInProgress {
-    $MergeHead = & git.exe rev-parse -q --verify MERGE_HEAD 2>$null
-    return [bool] $MergeHead
-}
-
-function Get-UnmergedPaths {
-    $Output = & git.exe diff --name-only --diff-filter=U 2>$null
-    if ($LASTEXITCODE -ne 0) {
-        return @()
-    }
-    return @($Output | Where-Object { $_ })
-}
-
-function Resolve-IgnoredMergeConflicts {
-    param(
-        [string[]] $IgnoredPaths,
-        [ValidateSet('ours', 'theirs')]
-        [string] $Prefer = 'ours'
-    )
-
-    foreach ($Path in (Get-UnmergedPaths)) {
-        if ($Path -in $IgnoredPaths) {
-            Write-Host "==> Auto-resolve merge conflict in $Path ($Prefer)"
-            Invoke-Git @('checkout', "--$Prefer", '--', $Path)
-            Invoke-Git @('add', '--', $Path)
-        }
-    }
-
-    return @(Get-UnmergedPaths)
-}
-
-function Merge-FeatureBranch {
-    param(
-        [string] $MergeRef,
-        [string] $ExtraBranch,
-        [string[]] $IgnoredPaths
-    )
-
-    $MergeMessage = "test: merge $ExtraBranch for local testing"
-    $ExitCode = Invoke-GitSoft @(
-        'merge', $MergeRef, '--no-edit', '-m', $MergeMessage
-    )
-    if ($ExitCode -eq 0) {
-        return
-    }
-
-    if (-not (Test-MergeInProgress)) {
-        throw "git merge $MergeRef failed (exit $ExitCode)"
-    }
-
-    $Remaining = Resolve-IgnoredMergeConflicts -IgnoredPaths $IgnoredPaths -Prefer 'ours'
-    if ($Remaining.Count -gt 0) {
-        throw "Merge conflict in: $($Remaining -join ', ')"
-    }
-
-    Invoke-Git @('commit', '--no-edit')
-}
-
-function Get-CurrentBranch {
-    return ([string] (Invoke-Git @('branch', '--show-current') | Select-Object -First 1)).Trim()
-}
-
-function Restore-DevBranch {
-    param([string] $Branch)
-    if ($Branch) {
-        Invoke-Git @('checkout', $Branch)
-    }
-}
-
-function Get-GitConfigJson {
-    param(
-        [string[]] $Refs,
-        [string] $RepoPath = "team/test-combined.json"
-    )
-
-    foreach ($Ref in $Refs) {
-        if (-not $Ref) { continue }
-        $Spec = "${Ref}:${RepoPath}"
-        $Json = & git show $Spec 2>$null
-        if ($LASTEXITCODE -eq 0 -and $Json) {
-            return @{ Source = $Spec; Json = [string] $Json }
-        }
-    }
-
-    return $null
-}
-
-function Resolve-ConfigSource {
-    param(
-        [string] $ExplicitPath,
-        [string] $TeamRef
-    )
-
-    if ($ExplicitPath) {
-        if (Test-Path $ExplicitPath) {
-            return @{
-                Source = (Resolve-Path $ExplicitPath).Path
-                Json   = $null
-            }
-        }
-        if ($ExplicitPath -match ':') {
-            $Json = & git show $ExplicitPath 2>$null
-            if ($LASTEXITCODE -eq 0 -and $Json) {
-                return @{ Source = $ExplicitPath; Json = [string] $Json }
-            }
-        }
-        throw "Config file not found: $ExplicitPath"
-    }
-
-    $LocalCandidates = @(
-        (Join-Path $RepoRoot "scripts/test-combined.json"),
-        (Join-Path $RepoRoot "team/test-combined.json")
-    )
-
-    foreach ($Candidate in $LocalCandidates) {
-        if (Test-Path $Candidate) {
-            return @{
-                Source = (Resolve-Path $Candidate).Path
-                Json   = $null
-            }
-        }
-    }
-
-    $GitRefs = @(
-        $TeamRef,
-        "origin/$TeamRef"
-    )
-    $FromGit = Get-GitConfigJson -Refs $GitRefs
-    if ($FromGit) {
-        return $FromGit
-    }
-
-    $Example = Join-Path $RepoRoot "scripts/test-combined.example.json"
-    if (Test-Path $Example) {
-        Write-Warning "Using example config ($Example). Copy to scripts/test-combined.json or update team/local."
-        return @{
-            Source = (Resolve-Path $Example).Path
-            Json   = $null
-        }
-    }
-
-    throw @"
-No test-combined config found.
-Fetch team/local (git fetch origin team/local) or create scripts/test-combined.json from scripts/test-combined.example.json.
-"@
-}
-
-function Read-TestCombinedConfig {
-    param(
-        [string] $Source,
-        [string] $Json
-    )
-
-    try {
-        if ($Json) {
-            $Config = $Json | ConvertFrom-Json
-        }
-        else {
-            $Config = Get-Content -Raw -Path $Source | ConvertFrom-Json
-        }
-    }
-    catch {
-        throw "Failed to parse config JSON at '$Source': $_"
-    }
-
-    foreach ($Required in @("baseBranch", "testBranch", "extraFeatureBranches")) {
-        if (-not ($Config.PSObject.Properties.Name -contains $Required)) {
-            throw "Config '$Source' is missing required field '$Required'."
-        }
-    }
-
-    return $Config
-}
-
 if (-not (Test-Path "FYPA.py")) {
     throw "FYPA.py not found in $RepoRoot — run this script from the FYPA repo."
-}
-
-$ConfigSource = Resolve-ConfigSource -ExplicitPath $ConfigPath -TeamRef $TeamConfigRef
-Write-Host "==> Config: $($ConfigSource.Source)"
-$Config = Read-TestCombinedConfig -Source $ConfigSource.Source -Json $ConfigSource.Json
-
-$BaseBranch = if ($PSBoundParameters.ContainsKey("BaseBranch")) { $BaseBranch } else { [string] $Config.baseBranch }
-$TestBranch = if ($PSBoundParameters.ContainsKey("TestBranch")) { $TestBranch } else { [string] $Config.testBranch }
-$ExtraFeatureBranches = if ($PSBoundParameters.ContainsKey("ExtraFeatureBranches")) {
-    $ExtraFeatureBranches
-}
-else {
-    @($Config.extraFeatureBranches | ForEach-Object { [string] $_ })
-}
-$DeleteTestBranchFirst = if ($PSBoundParameters.ContainsKey("DeleteTestBranchFirst")) {
-    $DeleteTestBranchFirst
-}
-elseif ($Config.PSObject.Properties.Name -contains "deleteTestBranchFirst") {
-    [bool] $Config.deleteTestBranchFirst
-}
-else {
-    $false
 }
 
 $PrjPcbPath = $null
@@ -600,94 +128,9 @@ if ($PrjPcb) {
     $PrjPcbPath = (Resolve-Path -LiteralPath $PrjPcb).Path
 }
 
-if (-not $BaseBranch) { throw "baseBranch is empty." }
-if (-not $TestBranch) { throw "testBranch is empty." }
-
-$UseLocalOnly = [bool] $LocalOnly
-if ($UseLocalOnly) {
-    Write-Host "==> Branch source: local only"
-}
-else {
-    Write-Host "==> Branch source: $Remote (soft-fetch; prefer local when ahead/diverged)"
-}
-
 $ReturnBranch = Get-CurrentBranch
 if (-not $ReturnBranch) {
     throw "Could not determine the current branch."
-}
-
-if (-not $UseLocalOnly) {
-    try {
-        Sync-RemoteBranches -RemoteName $Remote -Branches (@($BaseBranch) + $ExtraFeatureBranches)
-    }
-    catch {
-        Write-Warning "Fetch from $Remote failed; resolving from existing local/remote-tracking refs."
-        Write-Warning "$_"
-    }
-}
-
-$BaseTarget = Resolve-BranchMergeTarget -Branch $BaseBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
-if (-not $BaseTarget) {
-    $Where = if ($UseLocalOnly) { "locally" } else { "locally or as $Remote/$BaseBranch" }
-    throw "Base branch '$BaseBranch' not found $Where."
-}
-
-$BaseRef = $BaseTarget.MergeRef
-$BaseSha = $BaseTarget.Sha
-Write-Host "==> Base: $BaseRef ($($BaseTarget.Source))"
-
-$ExtraStampPairs = [System.Collections.Generic.List[string]]::new()
-$ResolvedExtras = [System.Collections.Generic.List[hashtable]]::new()
-foreach ($ExtraBranch in $ExtraFeatureBranches) {
-    if (-not $ExtraBranch) { continue }
-    $ExtraTarget = Resolve-BranchMergeTarget -Branch $ExtraBranch -RemoteName $Remote -UseLocalOnly $UseLocalOnly
-    if (-not $ExtraTarget) {
-        $Where = if ($UseLocalOnly) { "locally" } else { "locally or on $Remote" }
-        Write-Warning "Extra feature branch '$ExtraBranch' not found $Where — continuing without it."
-        continue
-    }
-    Write-Host "==> Extra: $($ExtraTarget.MergeRef) ($($ExtraTarget.Source))"
-    $ExtraStampPairs.Add("$ExtraBranch=$($ExtraTarget.Sha)")
-    $ResolvedExtras.Add(@{
-        Branch   = $ExtraTarget.Branch
-        MergeRef = $ExtraTarget.MergeRef
-    })
-}
-
-$ConfigIdentity = @(
-    "base=$BaseBranch",
-    "test=$TestBranch",
-    "deleteFirst=$DeleteTestBranchFirst",
-    "extras=$($ExtraFeatureBranches -join ',')"
-) -join ';'
-
-$DesiredStamp = ConvertTo-NormalizedStamp (Get-InputStamp `
-    -ConfigIdentity $ConfigIdentity `
-    -BaseName $BaseBranch `
-    -BaseSha $BaseSha `
-    -ExtraPairs @($ExtraStampPairs))
-
-$TestBranchExists = Test-GitRef "refs/heads/$TestBranch"
-$ExistingTip = if ($TestBranchExists) { Get-RefSha -Ref $TestBranch } else { $null }
-$ExistingStampRaw = $null
-if ($ExistingTip) {
-    $ExistingStampRaw = Get-TestCombinedStamp -Commit $ExistingTip
-}
-$ExistingStamp = ConvertTo-NormalizedStamp $ExistingStampRaw
-$CanReuse = (
-    -not $Rebuild -and
-    $TestBranchExists -and
-    $ExistingStamp -and
-    ($ExistingStamp -eq $DesiredStamp)
-)
-
-if (-not $CanReuse -and $TestBranchExists -and -not $Rebuild) {
-    if (-not $ExistingStamp) {
-        Write-Host "==> No reuse stamp on $TestBranch — will rebuild"
-    }
-    else {
-        Write-Host "==> Stamp mismatch on $TestBranch — will rebuild"
-    }
 }
 
 $IgnoredPaths = @('.gitignore', 'FYPA.code-workspace')
@@ -705,55 +148,27 @@ Commit or stash them before running the test script.
 "@
 }
 
+$RemoteRef = "$Remote/$TestBranch"
+Write-Host "==> Fetch $Remote $TestBranch"
+$FetchResult = Invoke-GitCore -Quiet @('fetch', $Remote, $TestBranch)
+if ($FetchResult.ExitCode -ne 0) {
+    Write-Warning "Fetch failed; using existing $RemoteRef if present."
+}
+
+if (-not (Test-GitRef "refs/remotes/$Remote/$TestBranch")) {
+    throw @"
+$RemoteRef not found.
+Publish the shared branch first:
+  pwsh scripts/maintain-test-combined.ps1 -Rebuild -Push
+"@
+}
+
 $Returned = $false
 $FypaExit = 0
 try {
-    if ($CanReuse) {
-        Write-Host "==> Reuse $TestBranch (inputs unchanged)"
-        if ((Get-CurrentBranch) -ne $TestBranch) {
-            Invoke-Git @('checkout', $TestBranch)
-        }
-    }
-    else {
-        if ($Rebuild) {
-            Write-Host "==> Rebuild requested — recreating $TestBranch"
-        }
-        elseif (-not $TestBranchExists) {
-            Write-Host "==> $TestBranch missing — creating from $BaseRef"
-        }
-        else {
-            Write-Host "==> Inputs changed — recreating $TestBranch from $BaseRef"
-        }
-
-        if ($DeleteTestBranchFirst -and (Test-GitRef "refs/heads/$TestBranch")) {
-            Write-Host "==> Delete $TestBranch"
-            if ((Get-CurrentBranch) -eq $TestBranch) {
-                Invoke-Git @('checkout', $ReturnBranch)
-            }
-            Invoke-Git @('branch', '-D', $TestBranch)
-        }
-
-        if (Test-GitRef "refs/heads/$TestBranch") {
-            Write-Host "==> Recreate $TestBranch from $BaseRef"
-            Invoke-Git @('branch', '-f', $TestBranch, $BaseRef)
-            Invoke-Git @('checkout', $TestBranch)
-        }
-        else {
-            Write-Host "==> Create $TestBranch from $BaseRef"
-            Invoke-Git @('checkout', '-b', $TestBranch, $BaseRef)
-        }
-
-        foreach ($Extra in $ResolvedExtras) {
-            Write-Host "==> Merge $($Extra.MergeRef) into $TestBranch"
-            Merge-FeatureBranch -MergeRef $Extra.MergeRef -ExtraBranch $Extra.Branch -IgnoredPaths $IgnoredPaths
-        }
-
-        $NewTip = Get-RefSha -Ref 'HEAD'
-        if ($NewTip) {
-            Set-TestCombinedStamp -Commit $NewTip -Stamp $DesiredStamp
-            Write-Host "==> Stamp written for $TestBranch"
-        }
-    }
+    Write-Host "==> Checkout $TestBranch from $RemoteRef"
+    Invoke-Git @('checkout', '-B', $TestBranch, $RemoteRef)
+    Invoke-Git @('reset', '--hard', $RemoteRef)
 
     if ($SkipTests) {
         Write-Host "==> Skip pytest (-SkipTests)"
@@ -783,24 +198,20 @@ try {
     $FypaExit = $LASTEXITCODE
 }
 catch {
-    if (Get-CurrentBranch -ne $ReturnBranch) {
-        & git merge --abort 2>$null | Out-Null
-        & git rebase --abort 2>$null | Out-Null
-    }
     throw
 }
 finally {
     $Current = Get-CurrentBranch
     if ($Current -ne $ReturnBranch) {
         Write-Host "==> Return to $ReturnBranch"
-        Restore-DevBranch -Branch $ReturnBranch
+        Invoke-Git @('checkout', $ReturnBranch)
         $Returned = $true
     }
 }
 
 if (-not $Returned) {
     Write-Host "==> Return to $ReturnBranch"
-    Restore-DevBranch -Branch $ReturnBranch
+    Invoke-Git @('checkout', $ReturnBranch)
 }
 
 if ($FypaExit -and $FypaExit -ne 0) {

--- a/tests/test_nettie_auto.py
+++ b/tests/test_nettie_auto.py
@@ -1,0 +1,262 @@
+"""Auto-bridge Altium Net Tie components without PDN_ROLE=SERIES."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fypa.altium.annotations import (
+    COMPONENT_KIND_NET_TIE_BOM,
+    COMPONENT_KIND_NET_TIE_NO_BOM,
+    NET_TIE_BRIDGE_RESISTANCE_OHM,
+    ResistorSpec,
+    parse_annotations,
+)
+from fypa.altium.extract import (
+    ExtractedProject,
+    Pt2D,
+    RawNet,
+    RawPad,
+    RawPcbComponent,
+    RawSchComponent,
+    RawStackupLayer,
+)
+from fypa.altium.loader import (
+    NET_MERGE_RESISTANCE_THRESHOLD_OHM,
+    _build_net_merge_map,
+)
+
+
+def _minimal_stackup() -> tuple[RawStackupLayer, ...]:
+    return (
+        RawStackupLayer(
+            layer_id=1, name="Top", copper_thickness_mm=0.035,
+            dielectric_thickness_mm=0.0, next_layer_id=0,
+            is_plane=False, plane_net_name=None, mech_enabled=True,
+        ),
+    )
+
+
+def _minimal_proj(**overrides) -> ExtractedProject:
+    base = {
+        "prjpcb_path": Path("t.PrjPcb"),
+        "pcbdoc_path": Path("t.PcbDoc"),
+        "tracks": (), "arcs": (), "vias": (), "pads": (), "regions": (),
+        "shape_based_regions": (), "fills": (),
+        "pcb_components": (), "nets": (), "stackup": _minimal_stackup(),
+        "sch_components": (),
+        "compiled_netlist": None,
+    }
+    base.update(overrides)
+    return ExtractedProject(**base)
+
+
+def _pad(comp_idx: int, pin: str, net_index: int, x: float = 0.0) -> RawPad:
+    return RawPad(
+        center=Pt2D(x, 0), width_mm=1, height_mm=1, hole_mm=0,
+        shape=2, rotation_deg=0, layer_id=1, net_index=net_index,
+        designator=pin, component_index=comp_idx,
+        is_through_hole=False, is_smt=True,
+    )
+
+
+def _nettie_proj(
+    *,
+    kind: int = COMPONENT_KIND_NET_TIE_NO_BOM,
+    parameters: dict[str, str] | None = None,
+    designator: str = "NT1",
+) -> ExtractedProject:
+    return _minimal_proj(
+        nets=(RawNet("VIN"), RawNet("VOUT"), RawNet("GND")),
+        sch_components=(
+            RawSchComponent(
+                designator=designator,
+                schdoc_name="Pwr.SchDoc",
+                parameters=dict(parameters or {}),
+                pin_designators=("1", "2"),
+                component_kind=kind,
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator=designator, center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="NetTie2",
+                source_designator=designator,
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 0, 0.0),  # VIN
+            _pad(0, "2", 1, 1.0),  # VOUT
+        ),
+    )
+
+
+def test_nettie_bridge_resistance_below_merge_threshold():
+    assert NET_TIE_BRIDGE_RESISTANCE_OHM < NET_MERGE_RESISTANCE_THRESHOLD_OHM
+
+
+def test_nettie_auto_emits_low_r_series():
+    result = parse_annotations(_nettie_proj(), enabled_layers=[1])
+    assert result.ok
+    resistors = [d for d in result.directives if isinstance(d, ResistorSpec)]
+    assert len(resistors) == 1
+    assert resistors[0].designator == "NT1"
+    assert resistors[0].resistance == NET_TIE_BRIDGE_RESISTANCE_OHM
+    nets = {
+        pin.net_index
+        for term in (resistors[0].p, resistors[0].n)
+        for pin in term.pins
+    }
+    assert nets == {0, 1}
+    assert any("auto-bridged" in w for w in result.warnings)
+
+
+def test_nettie_bom_kind_also_auto_bridges():
+    result = parse_annotations(
+        _nettie_proj(kind=COMPONENT_KIND_NET_TIE_BOM),
+        enabled_layers=[1],
+    )
+    assert result.ok
+    assert sum(1 for d in result.directives if isinstance(d, ResistorSpec)) == 1
+
+
+def test_explicit_series_on_nettie_skips_auto():
+    result = parse_annotations(
+        _nettie_proj(parameters={
+            "PDN_ROLE": "SERIES",
+            "PDN_R": "0.01",
+        }),
+        enabled_layers=[1],
+    )
+    assert result.ok
+    resistors = [d for d in result.directives if isinstance(d, ResistorSpec)]
+    assert len(resistors) == 1
+    assert resistors[0].resistance == 0.01
+    assert not any("auto-bridged" in w for w in result.warnings)
+
+
+def test_pcb_eco_series_on_nettie_skips_auto():
+    """Blanket/ECO PDN_ROLE on the PCB placement must override auto-bridge."""
+    proj = _minimal_proj(
+        nets=(RawNet("VIN"), RawNet("VOUT"), RawNet("GND")),
+        sch_components=(
+            RawSchComponent(
+                designator="NT1",
+                schdoc_name="Pwr.SchDoc",
+                parameters={},
+                pin_designators=("1", "2"),
+                component_kind=COMPONENT_KIND_NET_TIE_NO_BOM,
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="NT1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="NetTie2",
+                source_designator="NT1",
+                parameters={"PDN_ROLE": "SERIES", "PDN_R": "0.02"},
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 0, 0.0),
+            _pad(0, "2", 1, 1.0),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok
+    resistors = [d for d in result.directives if isinstance(d, ResistorSpec)]
+    assert len(resistors) == 1
+    assert resistors[0].resistance == 0.02
+    assert not any("auto-bridged" in w for w in result.warnings)
+
+
+def test_partial_pdn_params_on_nettie_skip_auto():
+    """Stray PDN_R without ROLE must not still get a synthetic merge short."""
+    result = parse_annotations(
+        _nettie_proj(parameters={"PDN_R": "0.01"}),
+        enabled_layers=[1],
+    )
+    assert not any(isinstance(d, ResistorSpec) for d in result.directives)
+    assert not any("auto-bridged" in w for w in result.warnings)
+
+
+def test_indexed_pdn_params_on_nettie_skip_auto():
+    result = parse_annotations(
+        _nettie_proj(parameters={"PDN1_R": "0.01"}),
+        enabled_layers=[1],
+    )
+    assert not any(isinstance(d, ResistorSpec) for d in result.directives)
+    assert not any("auto-bridged" in w for w in result.warnings)
+
+
+def test_standard_component_without_pdn_is_not_bridged():
+    proj = _nettie_proj(kind=0)  # ComponentKind.STANDARD
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok
+    assert not any(isinstance(d, ResistorSpec) for d in result.directives)
+
+
+def test_nettie_absorbed_by_net_merge_map():
+    proj = _nettie_proj()
+    annotations = parse_annotations(proj, enabled_layers=[1])
+    remap, skipped, bridges = _build_net_merge_map(annotations, proj)
+    assert remap  # VOUT → VIN (or vice versa)
+    assert "NT1" in {d.upper() for d in skipped}
+    assert len(bridges) == 1
+    assert bridges[0].designator == "NT1"
+
+
+def test_nettie_multi_pcb_instance():
+    proj = _minimal_proj(
+        nets=(RawNet("VIN"), RawNet("VOUT"), RawNet("VIN_B"), RawNet("VOUT_B")),
+        sch_components=(
+            RawSchComponent(
+                designator="NT1",
+                schdoc_name="Pwr.SchDoc",
+                parameters={},
+                pin_designators=("1", "2"),
+                component_kind=COMPONENT_KIND_NET_TIE_NO_BOM,
+            ),
+        ),
+        pcb_components=(
+            RawPcbComponent(
+                designator="NT1_CH1", center=Pt2D(0, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="NetTie2",
+                source_designator="NT1",
+            ),
+            RawPcbComponent(
+                designator="NT1_CH2", center=Pt2D(10, 0), rotation_deg=0.0,
+                layer_name="TOP", footprint="NetTie2",
+                source_designator="NT1",
+            ),
+        ),
+        pads=(
+            _pad(0, "1", 0, 0.0),
+            _pad(0, "2", 1, 1.0),
+            _pad(1, "1", 2, 10.0),
+            _pad(1, "2", 3, 11.0),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok
+    resistors = [d for d in result.directives if isinstance(d, ResistorSpec)]
+    assert {d.designator for d in resistors} == {"NT1_CH1", "NT1_CH2"}
+
+
+def test_skip_designators_suppresses_nettie_resynth():
+    """After merge, pass-2 must not re-emit NetTie shorts on same-net pads."""
+    proj = _nettie_proj()
+    first = parse_annotations(proj, enabled_layers=[1])
+    _, skipped, _ = _build_net_merge_map(first, proj)
+    # Simulate merged pads: both on net 0.
+    merged = _minimal_proj(
+        nets=(RawNet("VIN"), RawNet("VOUT"), RawNet("GND")),
+        sch_components=proj.sch_components,
+        pcb_components=proj.pcb_components,
+        pads=(
+            _pad(0, "1", 0, 0.0),
+            _pad(0, "2", 0, 1.0),
+        ),
+    )
+    second = parse_annotations(
+        merged, enabled_layers=[1], skip_designators=skipped,
+    )
+    assert not any(isinstance(d, ResistorSpec) for d in second.directives)


### PR DESCRIPTION
## Summary
- Altium Net Tie / Net Tie (No BOM) schematic components (`ComponentKind` 3/4) are detected at extract time and auto-bridged with a sub-threshold SERIES short so the existing net-merge path connects their nets in the FEM.
- Motivation: boards with many NetTies otherwise need a `PDN_ROLE=SERIES` (+ `PDN_R`) on every tie; without that, NetTie nets stay electrically separate and PDN analysis cannot push current across them.
- Explicit or partial `PDN_*` / `PDN<n>_*` on the symbol or PCB placement opts out so user annotations win.
- Docs: user-guide §3.0; unit tests cover auto-bridge, merge absorption, multi-instance, and opt-out cases.

## Test plan
- [ ] `pytest tests/test_nettie_auto.py`
- [ ] Load a project with Net Tie symbols (no PDN on those parts) and confirm nets merge / rails connect without manual SERIES
- [ ] Confirm a Net Tie with explicit `PDN_ROLE=SERIES` keeps the user `PDN_R` and is not auto-bridged