### PR TITLE
Fix REPEAT local net labels collapsing distinct rails across rooms

### DIFF
--- a/docs/user-guide/03-series-elements.md
+++ b/docs/user-guide/03-series-elements.md
@@ -163,9 +163,12 @@ The viewer labels indexed channels `FB1#1`, `FB1#2`, and so on.
 
 Once a SERIES directive is in place:
 
-- The two rails it bridges are treated as **one rail** in the side
-  panel — the solver propagates current from a source on one side to a
-  sink on the other through the lumped resistor.
+- The two nets of **that instance** are treated as **one rail** in the
+  side panel — the solver propagates current from a source on one side
+  to a sink on the other through the lumped resistor. On repeated
+  sheets, a local label such as `P_IN` still resolves per room; it does
+  **not** merge rails across rooms that share the same local name but
+  are not connected on the PCB.
 - A SERIES marker is drawn on the board at the part location.
 - The Nodes tab shows the voltage on each side of the SERIES part, and
   hovering over the marker reports the current through it.
@@ -186,7 +189,8 @@ for the full explanation, VIP example, and troubleshooting table.
 
 Auto-inference of P/N nets on 2-pin SERIES parts (Section 3.2) works per
 PCB instance the same way: each repeated `R63.N` infers from its own
-pads.
+pads. Rail grouping follows the same rule: a shared local name does not
+create a rail bridge between rooms whose copper is separate on the PCB.
 
 ## 3.5 Troubleshooting
 

--- a/fypa/caploop/identify.py
+++ b/fypa/caploop/identify.py
@@ -34,6 +34,7 @@ from fypa.altium.loader import _layer_z_centers_mm, _via_pad_layer_span
 from fypa.altium_geometry import _pad_polygon
 from fypa.caploop.constants import CapLoopSettings
 from fypa.caploop.packages import detect_package
+from fypa.rail_groups import unique_requested_net_aliases
 from fypa.topology.net_aliases import is_gnd_alias
 
 # Altium layer ids (see fypa.altium_geometry / fypa.altium.annotations).
@@ -646,10 +647,19 @@ def select_reference_cavity(
 
 # --- rail metadata lookups ----------------------------------------------------
 
-def _terminal_nets(term: dict) -> set[str]:
+def _terminal_nets(
+    term: dict,
+    *,
+    unique_aliases: frozenset[str] = frozenset(),
+) -> set[str]:
+    """PCB nets (and safe ``requested_net`` aliases) for rail membership.
+
+    Shared REPEAT local labels that resolve onto multiple PCB nets are
+    excluded — they must not match every room's rail group.
+    """
     nets = {p.get("net") for p in term.get("pins", []) if p.get("net")}
     req = term.get("requested_net")
-    if req:
+    if req and (req in nets or req in unique_aliases):
         nets.add(req)
     return nets
 
@@ -662,12 +672,13 @@ def design_voltage_for_rail(
     any member net of the cap's rail group."""
     if not directives:
         return None
+    unique_aliases = unique_requested_net_aliases(directives)
     for want_role, term_name in (("SOURCE", "P"), ("REGULATOR", "OUT_P")):
         for d in directives:
             if d.get("role") != want_role:
                 continue
             term = (d.get("terminals") or {}).get(term_name) or {}
-            if _terminal_nets(term) & rail_members:
+            if _terminal_nets(term, unique_aliases=unique_aliases) & rail_members:
                 value = d.get("value")
                 if value is not None:
                     return float(value)
@@ -695,12 +706,13 @@ def default_target_for_rail(
     """
     if not directives:
         return None, (), ()
+    unique_aliases = unique_requested_net_aliases(directives)
     best: dict | None = None
     for d in directives:
         if d.get("role") != "SINK":
             continue
         term = (d.get("terminals") or {}).get("P") or {}
-        if not (_terminal_nets(term) & rail_members):
+        if not (_terminal_nets(term, unique_aliases=unique_aliases) & rail_members):
             continue
         if best is None or float(d.get("value") or 0.0) > \
                 float(best.get("value") or 0.0):
@@ -718,6 +730,7 @@ def eligible_target_labels(
     """Directive labels a cap on this rail may target: every SINK or
     REGULATOR whose consuming terminal lands on a member net. Feeds the
     Capacitors tab's target picker."""
+    unique_aliases = unique_requested_net_aliases(directives)
     out: list[str] = []
     for d in directives or []:
         if d.get("role") not in ("SINK", "REGULATOR"):
@@ -725,7 +738,9 @@ def eligible_target_labels(
         terms = d.get("terminals") or {}
         term = terms.get("P") or terms.get("OUT_P") or {}
         label = d.get("label")
-        if label and (_terminal_nets(term) & rail_members) \
+        if label and (
+                _terminal_nets(term, unique_aliases=unique_aliases)
+                & rail_members) \
                 and label not in out:
             out.append(label)
     return out

--- a/fypa/rail_groups.py
+++ b/fypa/rail_groups.py
@@ -17,6 +17,60 @@ class RailTreeNode:
     children: tuple[RailTreeNode, ...] = ()
 
 
+def unique_requested_net_aliases(
+    directives: list[dict] | None,
+    canon_map: dict[str, str] | None = None,
+) -> frozenset[str]:
+    """``requested_net`` labels safe to use as a global rail-alias key.
+
+    A label is safe when every terminal that uses it shares at least one
+    canonical pin net — e.g. ``5V_LOCAL`` → ``+5V`` everywhere, or a
+    multi-pin SOURCE whose pads all sit on ``VIN`` / ``VIN_ALIAS``.
+
+    Labels that resolve onto *disjoint* copper across terminals (REPEAT
+    ``P_IN`` → ``P_IN.1`` on one room and ``P_IN.2`` on another) are
+    excluded so they cannot hub unconnected PCB nets.
+    """
+    if not directives:
+        return frozenset()
+    canon_map = canon_map or {}
+
+    def _canonical(net: str) -> str:
+        if not net:
+            return net
+        return canon_map.get(net.upper(), net)
+
+    # req -> pin-net sets, one frozenset per terminal occurrence
+    occs: dict[str, list[frozenset[str]]] = {}
+    for d in directives:
+        for t in (d.get("terminals") or {}).values():
+            req = t.get("requested_net")
+            if not req:
+                continue
+            nets = frozenset(
+                _canonical(p.get("net"))
+                for p in (t.get("pins") or [])
+                if p.get("net")
+            )
+            if not nets:
+                continue
+            occs.setdefault(req, []).append(nets)
+
+    safe: set[str] = set()
+    for req, groups in occs.items():
+        if len(groups) == 1:
+            safe.add(req)
+            continue
+        common = set(groups[0])
+        for g in groups[1:]:
+            common &= set(g)
+            if not common:
+                break
+        if common:
+            safe.add(req)
+    return frozenset(safe)
+
+
 def compute_rail_groups(
     metadata: TopologyMetadata | None,
 ) -> tuple[list[str], dict[str, list[str]]]:
@@ -37,6 +91,9 @@ def compute_rail_groups(
     resolved (via the bridge) onto ``+DM_SW1`` still gives a rail named
     ``GND``, not ``+DM_SW1``. Returns
     ``(rail_names_sorted, {primary_name: [all member nets]})``.
+
+    Local ``requested_net`` labels that resolve onto *different* PCB nets
+    across REPEAT rooms are display-only: they do not union those nets.
     """
     if metadata is None:
         return [], {}
@@ -60,6 +117,8 @@ def compute_rail_groups(
     regulator_in_rails: set[str] = set()
     regulator_out_rails: set[str] = set()
     canon_map: dict[str, str] = metadata.get("net_canonical") or {}
+    directives = metadata.get("directives") or []
+    safe_aliases = unique_requested_net_aliases(directives, canon_map)
 
     def _canonical(net: str) -> str:
         if not net:
@@ -73,7 +132,7 @@ def compute_rail_groups(
         if net:
             primary_candidates.add(_note_rail(net))
 
-    for d in metadata.get("directives", []):
+    for d in directives:
         role = d.get("role", "")
         terms = d.get("terminals") or {}
         for tname, t in terms.items():
@@ -81,12 +140,15 @@ def compute_rail_groups(
             req = t.get("requested_net")
             for n in nets:
                 find(n)  # ensure presence in union-find
-            if req:
+            # Only alias-union when the label names one copper net. A shared
+            # REPEAT local name (P_IN → P_IN.1 and P_IN.2) must not hub rooms.
+            if req and req in safe_aliases:
                 find(req)
                 for n in nets:
                     union(req, n)
             if role in ("SOURCE", "SINK", "REGULATOR"):
-                if t.get("resolved_via_local") and nets:
+                if (t.get("resolved_via_local") or (
+                        req and req not in safe_aliases)) and nets:
                     for n in nets:
                         _add_primary(n)
                 elif req:
@@ -98,21 +160,24 @@ def compute_rail_groups(
                     for n in nets:
                         _add_primary(n)
             if role == "SOURCE" and tname == "P":
-                if t.get("resolved_via_local") and nets:
+                if (t.get("resolved_via_local") or (
+                        req and req not in safe_aliases)) and nets:
                     source_rails.update(_note_rail(n) for n in nets)
                 elif req:
                     source_rails.add(_note_rail(req))
                 elif nets:
                     source_rails.update(_note_rail(n) for n in nets)
             if role == "REGULATOR" and tname == "IN_P":
-                if t.get("resolved_via_local") and nets:
+                if (t.get("resolved_via_local") or (
+                        req and req not in safe_aliases)) and nets:
                     regulator_in_rails.update(_note_rail(n) for n in nets)
                 elif req:
                     regulator_in_rails.add(_note_rail(req))
                 elif nets:
                     regulator_in_rails.update(_note_rail(n) for n in nets)
             if role == "REGULATOR" and tname == "OUT_P":
-                if t.get("resolved_via_local") and nets:
+                if (t.get("resolved_via_local") or (
+                        req and req not in safe_aliases)) and nets:
                     regulator_out_rails.update(_note_rail(n) for n in nets)
                 elif req:
                     regulator_out_rails.add(_note_rail(req))
@@ -257,12 +322,15 @@ def _rail_tree_adjacency(
       rail grouper uses), plus each name ↔ its ``net_canonical`` form
 
     Alias edges let BFS start at the primary and still walk bridges that
-    were annotated only on a local label.
+    were annotated only on a local label. Shared REPEAT local names that
+    resolve onto multiple PCB nets are not aliased into a cross-room hub.
     """
     adj: dict[str, set[str]] = {}
     if metadata is None:
         return adj
     canon_map: dict[str, str] = metadata.get("net_canonical") or {}
+    directives = metadata.get("directives") or []
+    safe_aliases = unique_requested_net_aliases(directives, canon_map)
 
     def _canonical(net: str) -> str:
         if not net:
@@ -275,13 +343,13 @@ def _rail_tree_adjacency(
                 continue
             _add_undirected_edge(adj, net, _canonical(net))
 
-    for d in metadata.get("directives", []):
+    for d in directives:
         terms = d.get("terminals") or {}
         for t in terms.values():
             nets = {p.get("net") for p in t.get("pins", []) if p.get("net")}
             req = t.get("requested_net")
             _note_aliases(*(nets or set()), req or "")
-            if req:
+            if req and req in safe_aliases:
                 for n in nets:
                     _add_undirected_edge(adj, req, n)
         for a, b in resistor_bridge_pairs(d):

--- a/tests/test_rail_trees.py
+++ b/tests/test_rail_trees.py
@@ -195,6 +195,76 @@ def test_rail_tree_local_label_series_nests_via_alias():
     ]
 
 
+def test_rail_tree_repeat_local_labels_do_not_cross_instances():
+    """Shared P_IN/P_OUT labels must not nest one REPEAT room under another."""
+    metadata = {
+        "directives": [
+            {
+                "role": "SINK",
+                "terminals": {
+                    "P": {
+                        "requested_net": "P_OUT",
+                        "resolved_via_local": True,
+                        "pins": [{"net": "P_OUT.1"}],
+                    },
+                    "N": {"requested_net": "GND", "pins": [{"net": "GND"}]},
+                },
+            },
+            {
+                "role": "SINK",
+                "terminals": {
+                    "P": {
+                        "requested_net": "P_OUT",
+                        "resolved_via_local": True,
+                        "pins": [{"net": "P_OUT.2"}],
+                    },
+                    "N": {"requested_net": "GND", "pins": [{"net": "GND"}]},
+                },
+            },
+            {
+                "role": "RESISTOR",
+                "terminals": {
+                    "P": {
+                        "requested_net": "P_IN",
+                        "resolved_via_local": True,
+                        "pins": [{"net": "P_IN.1"}],
+                    },
+                    "N": {
+                        "requested_net": "P_OUT",
+                        "resolved_via_local": True,
+                        "pins": [{"net": "P_OUT.1"}],
+                    },
+                },
+            },
+            {
+                "role": "RESISTOR",
+                "terminals": {
+                    "P": {
+                        "requested_net": "P_IN",
+                        "resolved_via_local": True,
+                        "pins": [{"net": "P_IN.2"}],
+                    },
+                    "N": {
+                        "requested_net": "P_OUT",
+                        "resolved_via_local": True,
+                        "pins": [{"net": "P_OUT.2"}],
+                    },
+                },
+            },
+        ],
+    }
+    _, members = compute_rail_groups(metadata)
+    trees = build_rail_trees(metadata, members)
+    assert set(trees) >= {"P_OUT.1", "P_OUT.2"}
+    flat1 = flatten_rail_tree(trees["P_OUT.1"])
+    flat2 = flatten_rail_tree(trees["P_OUT.2"])
+    names1 = {n for n, _ in flat1}
+    names2 = {n for n, _ in flat2}
+    assert names1 == {"P_OUT.1", "P_IN.1"}
+    assert names2 == {"P_OUT.2", "P_IN.2"}
+    assert names1.isdisjoint(names2)
+
+
 def test_rail_tree_orphan_component_keeps_series_nesting():
     """SERIES chain unreachable from primary stays nested under an orphan root."""
     # Explicit membership (not from compute_rail_groups): PRIMARY shares the

--- a/tests/test_rails.py
+++ b/tests/test_rails.py
@@ -247,3 +247,121 @@ def test_rail_groups_prefer_source_rail_over_bridged_led_nets():
     assert "LED_R" in members["VDD_3V3_PWR"]
     assert "VDD_3V3_PWR" in members["VDD_3V3_PWR"]
     assert members["VDD_1V8"] == ["VDD_1V8"]
+
+
+def test_rail_groups_keep_repeat_series_instances_separate():
+    """Shared local P_IN/P_OUT labels must not hub distinct REPEAT rooms."""
+    metadata = {
+        "directives": [
+            {
+                "role": "SINK",
+                "terminals": {
+                    "P": {
+                        "requested_net": "P_OUT",
+                        "resolved_via_local": True,
+                        "pins": [{"net": "P_OUT.1"}],
+                    },
+                    "N": {"requested_net": "GND", "pins": [{"net": "GND"}]},
+                },
+            },
+            {
+                "role": "SINK",
+                "terminals": {
+                    "P": {
+                        "requested_net": "P_OUT",
+                        "resolved_via_local": True,
+                        "pins": [{"net": "P_OUT.2"}],
+                    },
+                    "N": {"requested_net": "GND", "pins": [{"net": "GND"}]},
+                },
+            },
+            {
+                "role": "RESISTOR",
+                "terminals": {
+                    "P": {
+                        "requested_net": "P_IN",
+                        "resolved_via_local": True,
+                        "pins": [{"net": "P_IN.1"}],
+                    },
+                    "N": {
+                        "requested_net": "P_OUT",
+                        "resolved_via_local": True,
+                        "pins": [{"net": "P_OUT.1"}],
+                    },
+                },
+            },
+            {
+                "role": "RESISTOR",
+                "terminals": {
+                    "P": {
+                        "requested_net": "P_IN",
+                        "resolved_via_local": True,
+                        "pins": [{"net": "P_IN.2"}],
+                    },
+                    "N": {
+                        "requested_net": "P_OUT",
+                        "resolved_via_local": True,
+                        "pins": [{"net": "P_OUT.2"}],
+                    },
+                },
+            },
+        ],
+    }
+    names, members = compute_rail_groups(metadata)
+    assert "P_OUT.1" in names
+    assert "P_OUT.2" in names
+    assert set(members["P_OUT.1"]) == {"P_IN.1", "P_OUT.1"}
+    assert set(members["P_OUT.2"]) == {"P_IN.2", "P_OUT.2"}
+    assert "P_IN.2" not in members["P_OUT.1"]
+    assert "P_OUT.2" not in members["P_OUT.1"]
+
+
+def test_rail_groups_keep_repeat_regulator_outs_separate():
+    """REGULATOR OUT local labels stay per-instance; shared IN stays one rail."""
+    metadata = {
+        "directives": [
+            {
+                "role": "REGULATOR",
+                "terminals": {
+                    "IN_P": {
+                        "requested_net": "VDD_MOTOR",
+                        "pins": [{"net": "VDD_MOTOR"}],
+                    },
+                    "IN_N": {"requested_net": "GND", "pins": [{"net": "GND"}]},
+                    "OUT_P": {
+                        "requested_net": "P_IN1",
+                        "resolved_via_local": True,
+                        "pins": [{"net": "P_IN1.1"}],
+                    },
+                    "OUT_N": {"requested_net": "GND", "pins": [{"net": "GND"}]},
+                },
+            },
+            {
+                "role": "REGULATOR",
+                "terminals": {
+                    "IN_P": {
+                        "requested_net": "VDD_MOTOR",
+                        "pins": [{"net": "VDD_MOTOR"}],
+                    },
+                    "IN_N": {"requested_net": "GND", "pins": [{"net": "GND"}]},
+                    "OUT_P": {
+                        "requested_net": "P_IN1",
+                        "resolved_via_local": True,
+                        "pins": [{"net": "P_IN1.2"}],
+                    },
+                    "OUT_N": {"requested_net": "GND", "pins": [{"net": "GND"}]},
+                },
+            },
+        ],
+    }
+    names, members = compute_rail_groups(metadata)
+    assert "VDD_MOTOR" in names
+    assert "P_IN1.1" in names
+    assert "P_IN1.2" in names
+    assert members["VDD_MOTOR"] == ["VDD_MOTOR"]
+    assert members["P_IN1.1"] == ["P_IN1.1"]
+    assert members["P_IN1.2"] == ["P_IN1.2"]
+    assert "P_IN1.2" not in members["P_IN1.1"]
+    # Shared local label must not appear as a cross-room hub member.
+    assert "P_IN1" not in members["P_IN1.1"]
+    assert "P_IN1" not in members["P_IN1.2"]

--- a/tests/test_topology_labels.py
+++ b/tests/test_topology_labels.py
@@ -137,7 +137,12 @@ def test_topology_sink_multi_pin_port_lists_all_nets():
 
 
 def test_topology_port_labels_not_rail_primaries():
-    """Pin nets on labels even when rails merge members (not rail primary names)."""
+    """Pin nets on labels even when rails merge members (not rail primary names).
+
+    A shared ``requested_net`` with disjoint pin nets is not a global alias;
+    SERIES still unions the copper. The rail primary is then a pin net, not
+    the annotation label — port labels must still show each pin net.
+    """
     meta = {
         "directives": [
             {
@@ -178,10 +183,27 @@ def test_topology_port_labels_not_rail_primaries():
                     "N": {"requested_net": "GND", "pins": [{"net": "GND", "pad": "2"}]},
                 },
             },
+            {
+                "role": "RESISTOR",
+                "designator": "R1",
+                "terminals": {
+                    "P": {"pins": [{"net": "VDD_48V_IN"}]},
+                    "N": {"pins": [{"net": "VDD_48V_RP"}]},
+                },
+            },
+            {
+                "role": "RESISTOR",
+                "designator": "R2",
+                "terminals": {
+                    "P": {"pins": [{"net": "VOUT"}]},
+                    "N": {"pins": [{"net": "VDD_48V_PORT.1"}]},
+                },
+            },
         ],
     }
     _, members = compute_rail_groups(meta)
-    assert {"VDD_48V_IN", "VDD_48V_RP"} <= set(members["VDD_48V"])
+    assert {"VDD_48V_IN", "VDD_48V_RP"} <= set(members["VDD_48V_IN"])
+    assert "VDD_48V" not in members
     assert "VDD_48V_PORT.1" in members["VOUT"]
     model = build_topology_model(meta)
     j1 = next(n for n in model.nodes if n.designator == "J1")


### PR DESCRIPTION
## Summary
- Local schematic net names on REPEAT sheets (e.g. `P_IN`) were used as a global rail-group alias, so unconnected PCB nets (`P_IN.1`, `P_IN.2`, …) were merged into one mega-rail in the Rails list / topology / copper eyes.
- Alias-union `requested_net` ↔ pin nets only when every terminal sharing that label resolves onto shared copper; REPEAT labels with disjoint pin nets stay display-only. Per-instance SERIES bridges and unique local→canonical aliases (e.g. `5V_LOCAL` → `+5V`) are unchanged.
- Caploop rail membership follows the same rule so a shared local name cannot match every room’s rail.

## Motivation
Users correctly annotate child sheets with local names (`PDN_P_NET=P_IN`), not flattened PCB names. The solver already resolved terminals per instance, but the rail grouper treated the bare local string as one net identity. That made multi-motor / multi-channel designs look shorted in the UI even when copper and the FEM were separate — and hid the per-instance rails people expect after modelling drivers as REGULATORs.

## Test plan
- [ ] `pytest tests/test_rails.py tests/test_rail_trees.py tests/test_caploop_identify.py`
- [ ] On a REPEAT design: two SERIES instances with the same local `P_IN`/`P_OUT` → two rails, members only within each room
- [ ] REGULATOR outs with shared local `P_IN1` and shared `VDD_MOTOR` in → separate OUT rails, one IN rail
- [ ] Existing local-alias case (`5V_LOCAL` → `+5V`) still groups and nests correctly