### PR TITLE
Add support for external-FET SMPSs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,8 @@ jobs:
       - name: Lint (ruff)
         run: uv run ruff check .
 
+      - name: Type check (ty)
+        run: uv run ty check
+
       - name: Test (pytest)
         run: uv run pytest

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ define the power-delivery topology:
 | `SOURCE`     | `PDN_V`, `PDN_P_NET`, `PDN_N_NET` — *or* `PDN_V`, `PDN_NET`                                              | Voltage source (e.g. a connector pin or regulator)            |
 | `SINK`       | `PDN_I`, `PDN_P_NET`, `PDN_N_NET` — *or* `PDN_I`, `PDN_NET`                                              | Current sink  (e.g. an IC load)                   |
 | `SERIES`     | `PDN_R`, `PDN_P_NET`\*, `PDN_N_NET`\*                                                                   | Series resistance / fuse / ferrite / inductor DCR (rail bridge)       |
-| `REGULATOR`  | `PDN_V`, `PDN_REGULATOR_TYPE`, `PDN_REGULATOR_EFFICIENCY`, optional `PDN_QUIESCENT` — *or* `PDN_GAIN`, plus `PDN_OUT_*` / `PDN_IN_*` nets | On-board regulator (LDO / buck) — models BOTH input and output rails  |
+| `PATH`       | `PDN_R`; optional pin filters; optional `PDN_SMPS_HOST`                                               | External-FET SMPS path (HS/LS/shunt/L) — bound to a REGULATOR stage   |
+| `REGULATOR`  | `PDN_V`, `PDN_REGULATOR_TYPE`, `PDN_REGULATOR_EFFICIENCY`, optional `PDN_QUIESCENT` — *or* `PDN_GAIN`, plus `PDN_OUT_*` / `PDN_IN_*` nets; for external FETs also `PDN_SMPS_TOPOLOGY` and `PDN_SW1_NET` / `PDN_SW2_NET` | On-board regulator (LDO / buck / boost / inverter) — models BOTH input and output rails  |
 
 Optional two-terminal helpers (SOURCE / SINK):
 
@@ -360,6 +361,12 @@ Set `PDN_REGULATOR_TYPE` (`LDO` or `SMPS`) and optionally
 `PDN_REGULATOR_EFFICIENCY` to auto-compute gain, or set `PDN_GAIN` manually.
 Use **Adaptive SMPS gain** in the viewer (or `--adaptive-regulator-gain` on
 the CLI) to refine SMPS gain from the solved input voltage.
+
+External FETs: put `PDN_SMPS_TOPOLOGY` (`BUCK` / `BOOST` / `BUCKBOOST` /
+`INVERTER`) and switch-node nets on the controller; mark FETs / shunt / L as
+`PDN_ROLE=PATH` with `PDN_R`. Host binding is automatic; `PDN_SMPS_HOST` is
+only a disambiguation fallback. See
+[External-FET SMPS](docs/user-guide/04-regulators.md#47-external-fet-smps-path--topology).
 
 | Regulator type            | Gain                                              |
 |---------------------------|---------------------------------------------------|

--- a/docs/user-guide/04-regulators.md
+++ b/docs/user-guide/04-regulators.md
@@ -262,7 +262,86 @@ regulator, so a 500 mA `+3V3` load shows as 500 mA on the `+5V` rail
 between U2 and U3, and 250 mA on the `+12V` rail between J1 and U2
 (via the buck's gain).
 
-## 4.7 Troubleshooting
+## 4.7 External-FET SMPS (`PATH` + topology)
+
+An integrated SMPS can put `PDN_IN_*` / `PDN_OUT_*` on the same IC: those
+pads are the current boundaries. With **external** FETs, shunt, and
+inductor, those boundaries sit on the path parts — not on the controller.
+A plain `SERIES` chain `VIN → HS → L → HS → VOUT` would bridge two
+voltage-forced rails and short them through RDSon.
+
+FYPA keeps the same `VoltageRegulator` element, moves its ports to the
+**inductor cut**, and stamps MOSFET / shunt path currents as multiples of
+the regulator's output current. Without any `PATH` parts, behaviour is
+unchanged (internal FETs on the controller).
+
+### Controller (`REGULATOR`)
+
+Keep the usual SMPS parameters (`PDN_V`, `PDN_REGULATOR_TYPE=SMPS`,
+efficiency, `PDN_IN_*` / `PDN_OUT_*`, optional pins and quiescent). Add the
+stage map:
+
+| Parameter | Purpose |
+|-----------|---------|
+| `PDN_SMPS_TOPOLOGY` | `BUCK`, `BOOST`, `BUCKBOOST`, or `INVERTER` |
+| `PDN_SW1_NET` / `PDN_SW2_NET` | Switch-node nets (buck-boost: both sides of L) |
+| `PDN_SW1_PINS` / `PDN_SW2_PINS` | Optional pins **on the controller** only |
+
+Do **not** put RDSon, shunt R, or DCR on the controller — those live on
+`PATH` parts.
+
+### Path parts (`PDN_ROLE=PATH`)
+
+On each FET, sense resistor, and inductor in the stage:
+
+| Parameter | Purpose |
+|-----------|---------|
+| `PDN_ROLE` | `PATH` |
+| `PDN_R` | RDSon, shunt, or inductor DCR |
+| `PDN_P_PINS` / `PDN_N_PINS` / allowlists | Optional — drop gate or Kelvin pads |
+
+FYPA classifies each part from pad-net intersection with the host stage
+nets (HS_IN, LS_IN, HS_OUT, LS_OUT, shunt, inductor). Host binding is
+automatic when the part's non-GND pads hit exactly one REGULATOR's stage
+nets. Set `PDN_SMPS_HOST` only if that match is ambiguous.
+
+Example — buck-boost controller with external FETs (generic nets):
+
+```text
+U2 (controller):
+  PDN_ROLE                  = REGULATOR
+  PDN_REGULATOR_TYPE        = SMPS
+  PDN_SMPS_TOPOLOGY         = BUCKBOOST
+  PDN_V                     = 24
+  PDN_REGULATOR_EFFICIENCY  = 0.9
+  PDN_IN_P_NET  = VIN     PDN_IN_N_NET  = GND
+  PDN_OUT_P_NET = VOUT    PDN_OUT_N_NET = GND
+  PDN_SW1_NET   = SW1     PDN_SW2_NET   = SW2
+
+Q_HS_IN / Q_HS_OUT / Q_LS_* / R_SHUNT / L1:
+  PDN_ROLE = PATH
+  PDN_R    = <RDSon or shunt or DCR>
+```
+
+Rules of thumb:
+
+- **Inductor** between SW1 and SW2 is the cut — not a rail-merging
+  `SERIES`.
+- **High-side / shunt** stay island bridges (`SERIES`-like) on VIN or VOUT
+  copper.
+- **Low-side** FETs must not `SERIES` SW to GND (that would short the
+  switch node). FYPA stamps them as averaged current sources instead.
+- Adaptive Vin senses at the HS_IN / input island, including FET and shunt
+  drop.
+
+### `INVERTER` (motor / multi-phase driver)
+
+Same switch-stage idea, different gain: the DC bus is not stepped to a
+second `PDN_V`. Use `PDN_SMPS_TOPOLOGY=INVERTER` with one `OUT_*` channel
+per phase. Internal FETs need no `PATH` parts; external HS/LS use `PATH`
+bound via phase nets. Do not model the stage as `BUCKBOOST`.
+
+## 4.8 Troubleshooting
 
 | Message or symptom                                                 | Likely cause                                                                | Fix                                                                          |
 |--------------------------------------------------------------------|------------------------------------------------------------------------------|------------------------------------------------------------------------------|
@@ -270,6 +349,8 @@ between U2 and U3, and 250 mA on the `+12V` rail between J1 and U2
 | `REGULATOR on U2: missing PDN_GAIN or PDN_REGULATOR_TYPE`            | Neither manual gain nor regulator type was set.                               | Add `PDN_REGULATOR_TYPE=LDO` or `SMPS` (and `PDN_REGULATOR_EFFICIENCY` for SMPS), or set `PDN_GAIN` explicitly. |
 | Input rail still solves to a flat voltage everywhere                | The regulator was added as a `SOURCE`, not a `REGULATOR`.                   | Change `PDN_ROLE` to `REGULATOR` and add the input-side net parameters.      |
 | Output voltage in the solve is not `PDN_V`                          | A SINK on the output rail has its `PDN_P_NET` mis-spelled, so the rail has no closed loop and the solver falls back to a degenerate result. | Check spelling against the PCB netlist (see [1.5](01-sources-and-sinks.md#15-pre-import-checks)). |
+| `PATH stage with SW1/SW2 needs exactly one inductor`                | No unique SW1↔SW2 inductor PATH, or SW2 aliased so L looked like HS_OUT.   | Annotate L as `PATH` with pads on SW1 and SW2; fix stage nets.               |
+| `PATH … matches multiple regulators; set PDN_SMPS_HOST`           | Pad nets hit more than one stage.                                           | Set `PDN_SMPS_HOST` to the controller designator.                            |
 
 ## Next steps
 

--- a/fypa/altium/annotations.py
+++ b/fypa/altium/annotations.py
@@ -25,10 +25,14 @@ SOURCE         PDN_V                           PDN_P_NET, PDN_N_NET  (overrides:
 SINK           PDN_I                           PDN_P_NET, PDN_N_NET  (overrides: *_PINS, *_DES)
                                                *or* PDN_NET         (overrides: PDN_PINS)
 SERIES         PDN_R                           PDN_P_NET, PDN_N_NET (optional) (overrides: *_PINS)
+PATH           PDN_R                           PDN_P_NET, PDN_N_NET (optional) (overrides: *_PINS)
+                                               PDN_SMPS_HOST (optional)
 REGULATOR      PDN_V                           PDN_OUT_P_NET, PDN_OUT_N_NET,
                PDN_REGULATOR_TYPE              PDN_IN_P_NET,  PDN_IN_N_NET    (overrides: *_PINS)
                PDN_REGULATOR_EFFICIENCY        *or* PDN_GAIN (fixed override)
                PDN_QUIESCENT (optional)
+               PDN_SMPS_TOPOLOGY (optional)    PDN_SW1_NET, PDN_SW2_NET (optional)
+               BUCK|BOOST|BUCKBOOST|INVERTER   PDN_SW1_PINS, PDN_SW2_PINS (optional)
 ============   =============================   ==================================================
 
 Multi-connector P / N pads (``*_DES``)
@@ -272,7 +276,9 @@ _SHEET_OVERRIDE_KEY_RE = re.compile(
 # two nets).
 _RESISTOR_LIKE_ROLES: frozenset[str] = frozenset({"SERIES"})
 
-VALID_ROLES: frozenset[str] = frozenset({"SOURCE", "SINK", "REGULATOR"}) | _RESISTOR_LIKE_ROLES
+VALID_ROLES: frozenset[str] = (
+    frozenset({"SOURCE", "SINK", "REGULATOR", "PATH"}) | _RESISTOR_LIKE_ROLES
+)
 
 # Altium ``ComponentKind`` values that are Net Ties (altium_monkey.ComponentKind).
 COMPONENT_KIND_NET_TIE_BOM: int = 3
@@ -334,9 +340,14 @@ _KNOWN_SUFFIXES_BY_ROLE: dict[str, frozenset[str]] = {
         "OUT_P_NET", "OUT_N_NET", "OUT_P_PINS", "OUT_N_PINS",
         "IN_P_NET", "IN_N_NET", "IN_P_PINS", "IN_N_PINS",
         "IGNORE_PINS",
+        "SMPS_TOPOLOGY", "SW1_NET", "SW2_NET", "SW1_PINS", "SW2_PINS",
     }) | _PART_WIDE_PIN_FILTER_SUFFIXES,
     "SERIES": frozenset({
         "R", "P_NET", "N_NET", "P_PINS", "N_PINS", "IGNORE_PINS",
+    }) | _PART_WIDE_PIN_FILTER_SUFFIXES,
+    "PATH": frozenset({
+        "R", "P_NET", "N_NET", "P_PINS", "N_PINS", "IGNORE_PINS",
+        "SMPS_HOST",
     }) | _PART_WIDE_PIN_FILTER_SUFFIXES,
 }
 
@@ -386,6 +397,7 @@ _TERMINAL_SUFFIXES_BY_ROLE: dict[str, frozenset[str]] = {
         "OUT_P_NET", "OUT_N_NET", "OUT_P_PINS", "OUT_N_PINS",
     }),
     "SERIES": _TWO_TERMINAL_SUFFIXES,
+    "PATH": _TWO_TERMINAL_SUFFIXES,
 }
 
 
@@ -855,7 +867,7 @@ def _unindexed_has_defining_terminals(
             or _ci_get(params, _channel_key("N_PINS", None)) is not None
         )
         return has_p and has_n
-    if role == "SERIES":
+    if role in ("SERIES", "PATH"):
         has_p = (
             _ci_get(params, _channel_key("P_NET", None)) is not None
             or _ci_get(params, _channel_key("P_PINS", None)) is not None
@@ -938,6 +950,7 @@ def _channel_label(designator: str, index: int | None) -> str:
 # channel itself or inherited from the unindexed template) to be present.
 _VALUE_SUFFIX_BY_ROLE: dict[str, str] = {
     "SOURCE": "V", "SINK": "I", "SERIES": "R", "REGULATOR": "V",
+    "PATH": "R",
 }
 
 
@@ -2475,8 +2488,8 @@ def _resolve_local_net_pins(
         return [], _LOCAL_NET_TIER_ALIAS
     des_candidates = _designator_candidates(sch_designator, pcb_designator)
 
-    # (tier, pin) candidates; lower tier wins.
-    scored: list[tuple[int, str]] = []
+    # (tier, pin, unscoped) candidates; lower tier wins.
+    scored: list[tuple[int, str, bool]] = []
     unscoped_used = False
     for net in netlist.nets:
         aliases = list(getattr(net, "aliases", ()) or ())
@@ -2489,7 +2502,7 @@ def _resolve_local_net_pins(
         )
         if not name_match and not alias_match:
             continue
-        net_sheets = list(getattr(net, "source_sheets", ()) or ())
+        net_sheets: list[str] = list(getattr(net, "source_sheets", ()) or ())
         if not _sheet_name_matches(schdoc_name, net_sheets,
                                    sheet_map=sheet_map):
             continue
@@ -3476,7 +3489,44 @@ class ResistorSpec(_BaseSpec):
     solve_excluded: bool = False  # see SourceSpec.solve_excluded
 
 
+@dataclass(frozen=True)
+class PathSpec(_BaseSpec):
+    """External-FET SMPS path element (inductor, HS/LS FET).
+
+    Parsed from ``PDN_ROLE=PATH``. Similar to :class:`ResistorSpec` with an
+    optional ``smps_host`` designator that binds this part to a specific
+    REGULATOR controller. ``finalize_smps_stages`` consumes these after the
+    main parse loop and replaces them with :class:`ResistorSpec` (HS bridges)
+    or :class:`SwitchPathLeg` entries on the host :class:`RegulatorSpec`.
+    """
+
+    resistance: float
+    p: TerminalSpec
+    n: TerminalSpec
+    channel_index: int | None = None
+    smps_host: str | None = None  # explicit PDN_SMPS_HOST designator
+
+
 _REGULATOR_TYPES: frozenset[str] = frozenset({"LDO", "SMPS"})
+
+_SMPS_TOPOLOGIES: frozenset[str] = frozenset({
+    "BUCK",
+    "BOOST",
+    "BUCKBOOST",
+    "INVERTER",
+})
+
+
+@dataclass(frozen=True)
+class SwitchPathLeg:
+    """One low-side switch leg bound to a REGULATOR from a PATH element."""
+
+    designator: str
+    kind: str  # "ls_in" | "ls_out"
+    resistance: float
+    p: TerminalSpec
+    n: TerminalSpec
+    coeff: float  # multiplier on i_v (output current)
 
 
 @dataclass(frozen=True)
@@ -3493,9 +3543,17 @@ class RegulatorSpec(_BaseSpec):
     efficiency: float = 1.0
     adaptive_gain_eligible: bool = False  # SMPS without explicit PDN_GAIN
     quiescent_current: float = 0.0  # constant input current (A), optional PDN_QUIESCENT
+    # External-FET SMPS extensions (set by finalize_smps_stages)
+    smps_topology: str | None = None  # BUCK | BOOST | BUCKBOOST | INVERTER
+    sw1_net: str | None = None  # switch-node net name (annotation)
+    sw2_net: str | None = None  # second switch-node net name (BUCKBOOST)
+    switch_path_legs: tuple[SwitchPathLeg, ...] = ()
+    vin_sense_p: TerminalSpec | None = None  # VIN-side sense pads (from HS bridge)
+    vin_sense_n: TerminalSpec | None = None
+    inductor_dcr: float | None = None  # from PATH inductor PDN_R
 
 
-DirectiveSpec = SourceSpec | SinkSpec | ResistorSpec | RegulatorSpec
+DirectiveSpec = SourceSpec | SinkSpec | ResistorSpec | RegulatorSpec | PathSpec
 
 
 @dataclass
@@ -4505,7 +4563,7 @@ def _collect_supply_voltages_by_net(
     parameter_sources: list[PdnParameterSource],
     proj: ExtractedProject,
     net_remap: dict[int, int] | None = None,
-) -> dict[str, float]:
+) -> tuple[dict[str, float], frozenset[str]]:
     """Map canonical supply net names to nominal voltages from SOURCE /
     REGULATOR schematic parameters (before pad resolution).
 
@@ -4518,6 +4576,8 @@ def _collect_supply_voltages_by_net(
     (e.g. ``LX`` → ``LX.2``) so multi-channel regulators with different
     ``PDN_V`` do not collide on the shared child-sheet label. Unique voltages
     then propagate along SERIES edges to fixpoint.
+
+    Returns ``(supply_map, declared_supply_names)``.
     """
     raw: dict[str, set[float]] = {}
 
@@ -4855,6 +4915,14 @@ def _resolve_regulator_gain(
         )
         return None
 
+    # INVERTER topology: gain = 1/eff, no upstream Vin needed. The output
+    # voltage is irrelevant for gain derivation — the inverter converts
+    # power with a fixed duty model and no reference to Vin.
+    topo_key = _channel_key("SMPS_TOPOLOGY", idx)
+    topo_raw = _ci_get(params, topo_key)
+    if topo_raw is not None and topo_raw.strip().upper() == "INVERTER":
+        return 1.0 / eff, reg_type, eff, False
+
     if v_out <= 0:
         result.errors.append(
             f"{role_diag}: PDN_V must be positive, got {v_out}"
@@ -5062,6 +5130,23 @@ def _parse_regulator(comp, proj, enabled_layers, result,
             )
             if out is None or in_ is None:
                 continue
+            # SMPS_TOPOLOGY and switch-node net names (annotation-level only;
+            # finalize_smps_stages binds PATH elements to these later).
+            topo_key = _channel_key("SMPS_TOPOLOGY", idx)
+            topo_raw = _ci_get(params, topo_key)
+            smps_topology: str | None = None
+            if topo_raw is not None:
+                topo_val = topo_raw.strip().upper()
+                if topo_val not in _SMPS_TOPOLOGIES:
+                    _append_error_once(
+                        result,
+                        f"{value_diag}: {topo_key}={topo_raw!r} — must be one "
+                        f"of {sorted(_SMPS_TOPOLOGIES)}",
+                    )
+                    continue
+                smps_topology = topo_val
+            sw1_net = _ci_get(params, _channel_key("SW1_NET", idx))
+            sw2_net = _ci_get(params, _channel_key("SW2_NET", idx))
             specs.append(RegulatorSpec(
                 designator=pcb_des, schdoc_name=comp.schdoc_name,
                 voltage=v, gain=g,
@@ -5072,6 +5157,140 @@ def _parse_regulator(comp, proj, enabled_layers, result,
                 efficiency=eff,
                 adaptive_gain_eligible=adaptive,
                 quiescent_current=quiescent,
+                smps_topology=smps_topology,
+                sw1_net=sw1_net,
+                sw2_net=sw2_net,
+            ))
+    return specs
+
+
+def _parse_path(comp, proj, enabled_layers, result,
+                net_remap=None, supply_map=None, only_indices=None,
+                series_graph=None, **_kw):
+    """Parse ``PDN_ROLE=PATH`` channels — external-FET SMPS path elements."""
+    role_raw = "PATH"
+    role_diag_base = f"{role_raw} on {comp.designator}"
+    discovery = _discovery_pdn_params(comp, proj)
+    if _has_single_net_params(discovery, only_indices):
+        result.errors.append(
+            f"{role_diag_base}: PDN_NET is only valid on SOURCE/SINK — a "
+            f"PATH directive bridges two nets, use PDN_P_NET and PDN_N_NET"
+        )
+        return []
+    if only_indices is not None:
+        indices = list(only_indices)
+    else:
+        indices = _discover_channel_indices(discovery, "R")
+        if not indices:
+            _append_error_once(
+                result,
+                f"PATH on {comp.lookup_designator}: missing PDN_R "
+                f"(or PDN<n>_R for an indexed channel)",
+            )
+            return []
+
+    pcb_indices = _pcb_indices_for_source(comp, proj)
+    if not pcb_indices:
+        result.errors.append(
+            f"{role_diag_base}: component {comp.designator!r} is not placed "
+            f"on the PCB"
+        )
+        return []
+    if len(pcb_indices) > 1:
+        names = ", ".join(proj.pcb_components[i].designator for i in pcb_indices)
+        result.warnings.append(
+            f"{role_raw} on {comp.designator}: expanding to "
+            f"{len(pcb_indices)} multi-channel PCB instances ({names})"
+        )
+
+    specs: list[PathSpec] = []
+    multi = _sibling_pcb_count(proj, comp.lookup_designator) > 1
+    logical = comp.lookup_designator
+    sch_ignored = _sch_ignored_pins(
+        proj, comp.lookup_designator, comp.schdoc_name,
+    )
+    for idx in indices:
+        role_diag = f"{role_raw} on {_channel_label(logical, idx)}"
+        for pcb_idx in pcb_indices:
+            params = _materialize_channel_params(
+                _instance_pdn_params(comp, proj, pcb_idx, result=result),
+                idx, role_raw,
+            )
+            ignore_pins = _ignore_pins_for_channel(params, idx, sch_ignored)
+            allow_pins = _allow_pins_for_part(params)
+            pcb_des = proj.pcb_components[pcb_idx].designator
+            inst_diag = (
+                f"{role_raw} on {_channel_label(pcb_des, idx)}"
+                if multi else role_diag
+            )
+            value_diag = role_diag if multi else inst_diag
+            r = _require_value(
+                params, _channel_key("R", idx), value_diag, result,
+            )
+            if r is None:
+                continue
+            if r <= 0:
+                _append_error_once(
+                    result,
+                    f"{value_diag}: {_channel_key('R', idx)} must be positive, "
+                    f"got {r}",
+                )
+                continue
+            given = any(
+                _ci_get(params, _channel_key(k, idx)) is not None
+                for k in ("P_NET", "N_NET", "P_PINS", "N_PINS")
+            )
+            resolve_params = dict(params)
+            if not given:
+                if len(indices) > 1:
+                    _append_error_once(
+                        result,
+                        f"{value_diag}: multi-channel PATH requires explicit "
+                        f"{_channel_key('P_NET', idx)} / {_channel_key('N_NET', idx)} "
+                        f"or {_channel_key('P_PINS', idx)} / "
+                        f"{_channel_key('N_PINS', idx)} per channel",
+                    )
+                    continue
+                inferred = _autoinfer_2pin_nets(proj, pcb_idx)
+                if inferred is None:
+                    reason = _autoinfer_failure_reason(proj, pcb_idx)
+                    result.errors.append(
+                        f"{inst_diag}: {_channel_key('P_NET', idx)} and "
+                        f"{_channel_key('N_NET', idx)} are required "
+                        f"({reason}, so the two nets cannot be auto-inferred) — "
+                        f"set them explicitly (or use "
+                        f"{_channel_key('P_PINS', idx)} / "
+                        f"{_channel_key('N_PINS', idx)})"
+                    )
+                    continue
+                resolve_params[_channel_key("P_NET", idx)] = inferred[0]
+                resolve_params[_channel_key("N_NET", idx)] = inferred[1]
+                result.warnings.append(
+                    f"{inst_diag}: auto-inferred "
+                    f"{_channel_key('P_NET', idx)}={inferred[0]!r}, "
+                    f"{_channel_key('N_NET', idx)}={inferred[1]!r} "
+                    f"from 2-pin connectivity"
+                )
+            pair = _resolve_two_terminal(
+                proj, pcb_idx, resolve_params,
+                _channel_key("P_NET", idx), _channel_key("N_NET", idx),
+                _channel_key("P_PINS", idx), _channel_key("N_PINS", idx),
+                enabled_layers, inst_diag, result,
+                net_remap=net_remap,
+                sch_lookup_designator=comp.lookup_designator,
+                schdoc_name=comp.schdoc_name,
+                param_diag=value_diag,
+                ignore_pins=ignore_pins,
+                allow_pins=allow_pins,
+            )
+            if pair is None:
+                continue
+            smps_host_raw = _ci_get(params, _channel_key("SMPS_HOST", idx))
+            smps_host = smps_host_raw.strip() if smps_host_raw else None
+            specs.append(PathSpec(
+                designator=pcb_des, schdoc_name=comp.schdoc_name,
+                resistance=r, p=pair[0], n=pair[1], channel_index=idx,
+                smps_host=smps_host,
             ))
     return specs
 
@@ -5081,6 +5300,7 @@ _PARSER_BY_ROLE = {
     "SINK": _parse_sink,
     "SERIES": _parse_resistance,
     "REGULATOR": _parse_regulator,
+    "PATH": _parse_path,
 }
 
 
@@ -5091,9 +5311,12 @@ def _spec_terminals(d: DirectiveSpec) -> list[TerminalSpec]:
     no N terminal (its return is ideal), so only its P terminal is listed."""
     if isinstance(d, RegulatorSpec):
         return [d.out_p, d.out_n, d.in_p, d.in_n]
-    terms = [d.p]
-    if getattr(d, "n", None) is not None:
-        terms.append(d.n)
+    if isinstance(d, PathSpec):
+        return [d.p, d.n]
+    terms: list[TerminalSpec] = [d.p]
+    n_term = getattr(d, "n", None)
+    if isinstance(n_term, TerminalSpec):
+        terms.append(n_term)
     return terms
 
 
@@ -5164,9 +5387,13 @@ def _validate_directive_groups(result: AnnotationResult,
     for root, members in groups.items():
         single = [d for d in members
                   if isinstance(d, (SourceSpec, SinkSpec)) and d.n is None]
-        two = [d for d in members
-               if isinstance(d, (SourceSpec, SinkSpec)) and d.n is not None]
-        two += [d for d in members if isinstance(d, RegulatorSpec)]
+        two: list[DirectiveSpec] = [
+            d for d in members
+            if isinstance(d, (SourceSpec, SinkSpec)) and d.n is not None
+        ]
+        two.extend(
+            d for d in members if isinstance(d, (RegulatorSpec, PathSpec))
+        )
         labels = ", ".join(sorted(
             _channel_label(d.designator, getattr(d, "channel_index", None))
             for d in members
@@ -5932,6 +6159,12 @@ def parse_annotations(proj: ExtractedProject,
         no_auto_bridge={d.strip().upper() for d in (no_auto_bridge or set())},
     ))
 
+    # External-FET SMPS binding: consume PathSpec directives, emit
+    # ResistorSpec bridges and update host RegulatorSpec with switch legs.
+    from fypa.altium.smps_stage import finalize_smps_stages
+
+    finalize_smps_stages(result, proj, net_remap=net_remap)
+
     # Cross-directive checks (mode consistency, open-loop) + return grouping.
     _validate_directive_groups(result, proj, parameter_sources)
     return result
@@ -5971,6 +6204,10 @@ def _describe_directive(d: DirectiveSpec) -> str:
     if isinstance(d, ResistorSpec):
         return head + f"  R={d.resistance:g} Ω\n" + \
             _describe_terminal("P", d.p) + "\n" + _describe_terminal("N", d.n)
+    if isinstance(d, PathSpec):
+        host = f", host={d.smps_host}" if d.smps_host else ""
+        return head + f"  R={d.resistance:g} Ω{host}\n" + \
+            _describe_terminal("P", d.p) + "\n" + _describe_terminal("N", d.n)
     if isinstance(d, RegulatorSpec):
         extra = ""
         if d.regulator_type:
@@ -5979,6 +6216,12 @@ def _describe_directive(d: DirectiveSpec) -> str:
                 extra += f", eff={d.efficiency:g}"
             if d.adaptive_gain_eligible:
                 extra += ", adaptive"
+        if d.smps_topology:
+            extra += f", topo={d.smps_topology}"
+        if d.switch_path_legs:
+            extra += f", {len(d.switch_path_legs)} LS leg(s)"
+        if d.inductor_dcr is not None:
+            extra += f", Ldcr={d.inductor_dcr:g} Ω"
         return head + f"  V={d.voltage:g} V, gain={d.gain:g}{extra}\n" + \
             _describe_terminal("OUT_P", d.out_p) + "\n" + _describe_terminal("OUT_N", d.out_n) + "\n" + \
             _describe_terminal("IN_P", d.in_p) + "\n" + _describe_terminal("IN_N", d.in_n)

--- a/fypa/altium/loader.py
+++ b/fypa/altium/loader.py
@@ -598,7 +598,16 @@ def _directive_terminals(d: DirectiveSpec) -> list[TerminalSpec]:
     A single-net (PDN_NET) SOURCE/SINK has no N terminal — its return is an
     ideal node, not copper — so only its P terminal is returned."""
     if isinstance(d, RegulatorSpec):
-        return [d.out_p, d.out_n, d.in_p, d.in_n]
+        terms = [d.out_p, d.out_n, d.in_p, d.in_n]
+        for leg in getattr(d, "switch_path_legs", ()) or ():
+            terms.extend((leg.p, leg.n))
+        vin_p = getattr(d, "vin_sense_p", None)
+        vin_n = getattr(d, "vin_sense_n", None)
+        if vin_p is not None:
+            terms.append(vin_p)
+        if vin_n is not None:
+            terms.append(vin_n)
+        return terms
     if d.n is None:
         return [d.p]
     return [d.p, d.n]
@@ -904,15 +913,40 @@ def _directive_to_network(
     elif isinstance(d, RegulatorSpec):
         node_vp, node_vn = _pp.NodeID(), _pp.NodeID()
         node_sf, node_st = _pp.NodeID(), _pp.NodeID()
+        # External-FET LS legs: one NodeID pair per SwitchPathLeg, current
+        # coupled to the regulator's i_v with PWM compensation in the stamp.
+        switch_leg_nodes: list[tuple[_pp.NodeID, _pp.NodeID, float]] = []
+        leg_terminals: list[tuple] = []
+        for leg in getattr(d, "switch_path_legs", ()) or ():
+            if leg.coeff == 0.0:
+                continue
+            node_f, node_t = _pp.NodeID(), _pp.NodeID()
+            switch_leg_nodes.append((node_f, node_t, float(leg.coeff)))
+            # Drain (switch node) → f, source (GND) → t.
+            r_coup = (
+                float(leg.resistance)
+                if leg.resistance and leg.resistance > 0
+                else COUPLING_RESISTANCE_OHM
+            )
+            leg_terminals.append((leg.p, node_f, r_coup, f"LS_{leg.kind}_P"))
+            leg_terminals.append((leg.n, node_t, r_coup, f"LS_{leg.kind}_N"))
         element = _pp.VoltageRegulator(
             v_p=node_vp, v_n=node_vn, s_f=node_sf, s_t=node_st,
             voltage=d.voltage, gain=d.gain,
+            switch_legs=tuple(switch_leg_nodes),
         )
+        # Optional inductor DCR on the input-side coupling (never bridges
+        # IN↔OUT — the lumped regulator *is* the cut).
+        in_coup = COUPLING_RESISTANCE_OHM
+        dcr = getattr(d, "inductor_dcr", None)
+        if dcr is not None and dcr > 0:
+            in_coup = float(dcr)
         conns, aux = _gather(
             (d.out_p, node_vp, SOURCE_COUPLING_RESISTANCE_OHM, "OUT_P"),
             (d.out_n, node_vn, SOURCE_COUPLING_RESISTANCE_OHM, "OUT_N"),
-            (d.in_p, node_sf, COUPLING_RESISTANCE_OHM, "IN_P"),
+            (d.in_p, node_sf, in_coup, "IN_P"),
             (d.in_n, node_st, COUPLING_RESISTANCE_OHM, "IN_N"),
+            *leg_terminals,
         )
         network_elements: list[_pp.BaseLumped] = [element]
         if d.quiescent_current > 0:
@@ -1946,14 +1980,16 @@ def _measured_regulator_vin(
     loaded: LoadedProject,
     reg: RegulatorSpec,
 ) -> float | None:
-    """Differential input voltage (IN_P − IN_N) averaged over resolved pads."""
+    """Differential input voltage averaged over Vin-sense (or IN) pads."""
+    sense_p = getattr(reg, "vin_sense_p", None) or reg.in_p
+    sense_n = getattr(reg, "vin_sense_n", None) or reg.in_n
     vp: list[float] = []
     vn: list[float] = []
-    for p in reg.in_p.pins:
+    for p in sense_p.pins:
         v = _sample_voltage_at_pin(solution, loaded, p)
         if v is not None:
             vp.append(v)
-    for p in reg.in_n.pins:
+    for p in sense_n.pins:
         v = _sample_voltage_at_pin(solution, loaded, p)
         if v is not None:
             vn.append(v)
@@ -2375,6 +2411,8 @@ def build_solve_metadata(
             value_str = f"V={d.voltage:.4g} V, gain={d.gain:.3g}"
             if d.quiescent_current > 0:
                 value_str += f", Iq={d.quiescent_current * 1000:.4g} mA"
+            if getattr(d, "smps_topology", None):
+                value_str += f", topo={d.smps_topology}"
             common["value_str"] = value_str
             common["gain"] = d.gain
             common["quiescent_current"] = d.quiescent_current
@@ -2382,6 +2420,18 @@ def build_solve_metadata(
             if d.regulator_type is not None:
                 common["regulator_type"] = d.regulator_type
                 common["efficiency"] = d.efficiency
+            if getattr(d, "smps_topology", None):
+                common["smps_topology"] = d.smps_topology
+            if getattr(d, "switch_path_legs", None):
+                common["switch_path_legs"] = [
+                    {
+                        "designator": leg.designator,
+                        "kind": leg.kind,
+                        "coeff": leg.coeff,
+                        "resistance_ohm": leg.resistance,
+                    }
+                    for leg in d.switch_path_legs
+                ]
             common["terminals"] = {
                 "OUT_P": _terminal_summary(d.out_p, nets),
                 "OUT_N": _terminal_summary(d.out_n, nets),

--- a/fypa/altium/smps_stage.py
+++ b/fypa/altium/smps_stage.py
@@ -1,0 +1,630 @@
+"""External-FET SMPS stage binding — connect PATH elements to REGULATOR hosts.
+
+Called by :func:`fypa.altium.annotations.parse_annotations` after the main
+parse loop to replace :class:`PathSpec` directives with :class:`ResistorSpec`
+(high-side bridges) and :class:`SwitchPathLeg` entries on the host
+:class:`RegulatorSpec`.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import replace
+
+from fypa.altium.annotations import (
+    AnnotationResult,
+    PathSpec,
+    RegulatorSpec,
+    ResistorSpec,
+    SwitchPathLeg,
+    TerminalSpec,
+    _append_error_once,
+    _net_indices_by_name,
+)
+from fypa.altium.extract import ExtractedProject, NO_NET
+
+log = logging.getLogger(__name__)
+
+# Topologies that support external-FET PATH binding.
+_BINDABLE_TOPOLOGIES: frozenset[str] = frozenset(
+    {
+        "BUCK",
+        "BOOST",
+        "BUCKBOOST",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Net helpers
+# ---------------------------------------------------------------------------
+
+
+def _net_index_set(
+    proj: ExtractedProject,
+    net_name: str | None,
+    net_remap: dict[int, int] | None,
+) -> frozenset[int]:
+    """Resolve a net name to the set of remapped net indices."""
+    if not net_name:
+        return frozenset()
+    indices = _net_indices_by_name(proj, net_name.strip())
+    if net_remap:
+        indices = [net_remap.get(i, i) for i in indices]
+    return frozenset(i for i in indices if i != NO_NET)
+
+
+def _terminal_net_indices(
+    term: TerminalSpec,
+    net_remap: dict[int, int] | None,
+) -> frozenset[int]:
+    """Net indices reachable from *term*'s pins (after remap)."""
+    out: set[int] = set()
+    for pin in term.pins:
+        idx = pin.net_index
+        if net_remap:
+            idx = net_remap.get(idx, idx)
+        if idx != NO_NET:
+            out.add(idx)
+    return frozenset(out)
+
+
+def _spec_pad_net_indices(
+    spec: PathSpec | ResistorSpec,
+    net_remap: dict[int, int] | None,
+) -> frozenset[int]:
+    """All net indices a two-terminal spec's pads sit on (after remap)."""
+    return _terminal_net_indices(spec.p, net_remap) | _terminal_net_indices(
+        spec.n,
+        net_remap,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Host identification
+# ---------------------------------------------------------------------------
+
+
+def _regulator_stage_nets(
+    reg: RegulatorSpec,
+    proj: ExtractedProject,
+    net_remap: dict[int, int] | None,
+) -> frozenset[int]:
+    """Non-GND net indices declared by a regulator's terminals and SW nets.
+
+    Used for host matching: a PATH part's pad nets must intersect these.
+    GND (index 0 by convention, but we filter any net whose *name* is a
+    common ground label) is excluded so ground planes don't cause false
+    matches.
+    """
+    gnd_names = frozenset({"GND", "AGND", "DGND", "PGND", "VSS", "AVSS"})
+    nets: set[int] = set()
+    for term in (reg.out_p, reg.out_n, reg.in_p, reg.in_n):
+        nets |= _terminal_net_indices(term, net_remap)
+    for sw_name in (reg.sw1_net, reg.sw2_net):
+        nets |= _net_index_set(proj, sw_name, net_remap)
+    # Filter ground nets by name.
+    filtered: set[int] = set()
+    for ni in nets:
+        if 0 <= ni < len(proj.nets):
+            name = proj.nets[ni].name.strip().upper()
+            if name not in gnd_names:
+                filtered.add(ni)
+        else:
+            filtered.add(ni)
+    return frozenset(filtered)
+
+
+def _find_host_regulator(
+    path: PathSpec,
+    regulators: list[RegulatorSpec],
+    proj: ExtractedProject,
+    net_remap: dict[int, int] | None,
+    result: AnnotationResult,
+) -> RegulatorSpec | None:
+    """Find the unique REGULATOR host for a PATH element."""
+    pad_nets = _spec_pad_net_indices(path, net_remap)
+    diag = f"PATH on {path.designator}"
+
+    if path.smps_host:
+        host_u = path.smps_host.strip().upper()
+        candidates = [r for r in regulators if r.designator.upper() == host_u]
+        if not candidates:
+            _append_error_once(
+                result,
+                f"{diag}: PDN_SMPS_HOST={path.smps_host!r} does not match any REGULATOR designator",
+            )
+            return None
+        if len(candidates) > 1:
+            _append_error_once(
+                result,
+                f"{diag}: PDN_SMPS_HOST={path.smps_host!r} matches multiple "
+                f"REGULATOR channels — use a unique designator",
+            )
+            return None
+        return candidates[0]
+
+    # Auto-match: intersect PATH pad nets with each regulator's stage nets.
+    matches: list[RegulatorSpec] = []
+    for reg in regulators:
+        stage_nets = _regulator_stage_nets(reg, proj, net_remap)
+        if pad_nets & stage_nets:
+            matches.append(reg)
+    if not matches:
+        _append_error_once(
+            result,
+            f"{diag}: could not bind to a REGULATOR host — none of the "
+            f"declared regulators share a non-GND net with this part's pads",
+        )
+        return None
+    if len(matches) > 1:
+        host_names = ", ".join(m.designator for m in matches)
+        _append_error_once(
+            result,
+            f"{diag}: ambiguous host — pads touch nets from multiple "
+            f"regulators ({host_names}); set PDN_SMPS_HOST to disambiguate",
+        )
+        return None
+    return matches[0]
+
+
+# ---------------------------------------------------------------------------
+# Phase / leg classification
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# SW1↔SW2 chain walk (shunt + inductor)
+# ---------------------------------------------------------------------------
+
+
+def _path_edge_nets(
+    path: PathSpec,
+    net_remap: dict[int, int] | None,
+) -> tuple[frozenset[int], frozenset[int]]:
+    return (
+        _terminal_net_indices(path.p, net_remap),
+        _terminal_net_indices(path.n, net_remap),
+    )
+
+
+def _assign_sw_chain_roles(
+    unclassified: list[PathSpec],
+    sw1_nets: frozenset[int],
+    sw2_nets: frozenset[int],
+    net_remap: dict[int, int] | None,
+    host_des: str,
+    result: AnnotationResult,
+) -> dict[int, str]:
+    """Walk PATH edges from SW1 to SW2; last edge = inductor, earlier = shunt.
+
+    Returns ``{id(path): role}`` for paths that sit on the chain.
+    """
+    if not unclassified or not sw1_nets or not sw2_nets:
+        return {}
+
+    # Graph: net_index -> list of (other_net_index, path)
+    adj: dict[int, list[tuple[int, PathSpec]]] = defaultdict(list)
+    for path in unclassified:
+        p_nets, n_nets = _path_edge_nets(path, net_remap)
+        # 2-pin idealisation: each terminal contributes one net (take any).
+        if not p_nets or not n_nets:
+            continue
+        # Connect every p-net to every n-net (normally one each).
+        for a in p_nets:
+            for b in n_nets:
+                if a == b:
+                    continue
+                adj[a].append((b, path))
+                adj[b].append((a, path))
+
+    # BFS from SW1 looking for SW2; record parent edge path.
+    start = next(iter(sw1_nets))
+    goals = set(sw2_nets)
+    queue = [start]
+    visited: set[int] = {start}
+    # net -> (prev_net, path_used)
+    came_from: dict[int, tuple[int, PathSpec]] = {}
+    found: int | None = None
+    while queue:
+        cur = queue.pop(0)
+        if cur in goals and cur != start:
+            found = cur
+            break
+        for nxt, path in adj.get(cur, []):
+            if nxt in visited:
+                continue
+            visited.add(nxt)
+            came_from[nxt] = (cur, path)
+            queue.append(nxt)
+
+    if found is None:
+        # Direct SW1↔SW2 single-part inductor already classified elsewhere;
+        # leftover unknown parts are reported by the caller.
+        return {}
+
+    # Reconstruct edge sequence start → found.
+    edges: list[PathSpec] = []
+    cur = found
+    while cur != start:
+        prev, path = came_from[cur]
+        edges.append(path)
+        cur = prev
+    edges.reverse()
+    if not edges:
+        return {}
+
+    roles: dict[int, str] = {}
+    for path in edges[:-1]:
+        roles[id(path)] = "shunt"
+    roles[id(edges[-1])] = "inductor"
+
+    # Ambiguous extra PATH parts touching the chain but not on the unique path.
+    on_chain = {id(p) for p in edges}
+    for path in unclassified:
+        if id(path) in on_chain:
+            continue
+        pad_nets = _spec_pad_net_indices(path, net_remap)
+        chain_nets = set(came_from.keys()) | {start, found}
+        if pad_nets & chain_nets:
+            _append_error_once(
+                result,
+                f"PATH on {path.designator}: ambiguous SW1↔SW2 chain on host "
+                f"{host_des} — part touches the inductor path but is not on "
+                f"the unique shortest route; check PDN_P_NET / PDN_N_NET",
+            )
+    return roles
+
+
+def _classify_path(
+    path: PathSpec,
+    reg: RegulatorSpec,
+    proj: ExtractedProject,
+    net_remap: dict[int, int] | None,
+) -> str:
+    """Classify a bound PATH element's role in the stage.
+
+    Returns one of:
+        ``"hs_in"`` / ``"ls_in"`` / ``"hs_out"`` / ``"ls_out"`` /
+        ``"inductor"`` / ``"shunt"`` / ``"unknown"``
+    """
+    p_nets = _terminal_net_indices(path.p, net_remap)
+    n_nets = _terminal_net_indices(path.n, net_remap)
+    all_nets = p_nets | n_nets
+
+    in_p_nets = _terminal_net_indices(reg.in_p, net_remap)
+    in_n_nets = _terminal_net_indices(reg.in_n, net_remap)
+    out_p_nets = _terminal_net_indices(reg.out_p, net_remap)
+    out_n_nets = _terminal_net_indices(reg.out_n, net_remap)
+    sw1_nets = _net_index_set(proj, reg.sw1_net, net_remap)
+    sw2_nets = _net_index_set(proj, reg.sw2_net, net_remap)
+
+    # Direct SW1↔SW2 bridge (no intermediate net) → inductor.
+    # Checked before HS_OUT: when SW2_NET aliases OUT_P (common BUCK
+    # annotation), a SW1↔VOUT inductor would otherwise look like hs_out.
+    if sw1_nets and sw2_nets:
+        if all_nets & sw1_nets and all_nets & sw2_nets:
+            return "inductor"
+
+    # IN_P ∩ SW1 → hs_in (bridge)
+    if all_nets & in_p_nets and all_nets & sw1_nets:
+        return "hs_in"
+    # SW1 ∩ IN_N → ls_in (switch leg)
+    if all_nets & sw1_nets and all_nets & in_n_nets:
+        return "ls_in"
+    # SW2 ∩ OUT_P → hs_out (bridge)
+    if all_nets & sw2_nets and all_nets & out_p_nets:
+        return "hs_out"
+    # SW2 ∩ OUT_N → ls_out
+    if all_nets & out_n_nets and all_nets & sw2_nets:
+        return "ls_out"
+    # Single SW-node topologies (BUCK/BOOST) that declare only SW1:
+    if sw1_nets and not sw2_nets:
+        if all_nets & out_p_nets and all_nets & sw1_nets:
+            return "ls_out"
+        if all_nets & sw1_nets and all_nets & out_n_nets:
+            return "ls_out"
+
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Coefficient computation
+# ---------------------------------------------------------------------------
+
+
+def _compute_ls_coeffs(
+    topology: str,
+    gain: float,
+) -> tuple[float, float]:
+    """Return ``(ls_in_coeff, ls_out_coeff)`` for the given topology + gain.
+
+    Coefficients are multiplied by i_v (output current) in the MNA stamp.
+    """
+    if topology == "BUCK":
+        return (max(0.0, 1.0 - gain), 0.0)
+    if topology == "BOOST":
+        return (0.0, max(0.0, gain - 1.0))
+    # BUCKBOOST: use boost coefficients when G >= 1, else buck.
+    if gain >= 1.0:
+        return (0.0, max(0.0, gain - 1.0))
+    return (max(0.0, 1.0 - gain), 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def finalize_smps_stages(
+    result: AnnotationResult,
+    proj: ExtractedProject,
+    net_remap: dict[int, int] | None = None,
+) -> None:
+    """Bind PATH elements to REGULATOR hosts, mutating *result.directives*.
+
+    * PATH elements classified as **hs_in** / **hs_out** / **shunt** become
+      :class:`ResistorSpec` so the downstream net-merge and rail_groups logic
+      handles them as ordinary series bridges.
+    * PATH elements classified as **ls_in** / **ls_out** become
+      :class:`SwitchPathLeg` entries on the host :class:`RegulatorSpec`
+      (``switch_path_legs``).
+    * The inductor PATH becomes ``inductor_dcr`` on the host and its
+      terminals replace the regulator's in_p/out_p (depending on SW1/SW2
+      orientation).
+    * Vin-sense terminals are propagated from hs_in's P-side (or the
+      regulator's original in_p if no hs_in exists).
+    """
+    paths: list[PathSpec] = [d for d in result.directives if isinstance(d, PathSpec)]
+    if not paths:
+        return
+
+    regulators: list[RegulatorSpec] = [d for d in result.directives if isinstance(d, RegulatorSpec)]
+    if not regulators:
+        for p in paths:
+            _append_error_once(
+                result,
+                f"PATH on {p.designator}: could not bind to a REGULATOR host "
+                f"— no REGULATOR directives found",
+            )
+        return
+
+    # Group paths by host regulator.
+    host_map: dict[str, RegulatorSpec] = {}
+    path_groups: dict[str, list[tuple[PathSpec, str]]] = defaultdict(list)
+    bound_path_ids: set[int] = set()
+
+    for p in paths:
+        host = _find_host_regulator(p, regulators, proj, net_remap, result)
+        if host is None:
+            continue
+        topo = host.smps_topology
+        if topo is None and not (host.sw1_net or host.sw2_net):
+            _append_error_once(
+                result,
+                f"PATH on {p.designator}: host {host.designator} has no "
+                f"PDN_SMPS_TOPOLOGY and no SW nets — cannot bind",
+            )
+            continue
+        if topo and topo == "INVERTER":
+            result.warnings.append(
+                f"PATH on {p.designator}: host {host.designator} uses INVERTER "
+                f"topology — external-FET binding is not yet supported for "
+                f"INVERTER; skipping",
+            )
+            continue
+        if topo and topo not in _BINDABLE_TOPOLOGIES:
+            _append_error_once(
+                result,
+                f"PATH on {p.designator}: host {host.designator} has "
+                f"unsupported SMPS_TOPOLOGY={topo!r}",
+            )
+            continue
+        role = _classify_path(p, host, proj, net_remap)
+        host_key = f"{host.designator}#{host.channel_index}"
+        host_map[host_key] = host
+        path_groups[host_key].append((p, role))
+        bound_path_ids.add(id(p))
+
+    # Second pass: resolve SW1↔SW2 chain for parts still classified unknown.
+    for host_key, grouped in list(path_groups.items()):
+        host = host_map[host_key]
+        sw1_nets = _net_index_set(proj, host.sw1_net, net_remap)
+        sw2_nets = _net_index_set(proj, host.sw2_net, net_remap)
+        unknowns = [p for p, role in grouped if role == "unknown"]
+        if not unknowns:
+            continue
+        chain_roles = _assign_sw_chain_roles(
+            unknowns,
+            sw1_nets,
+            sw2_nets,
+            net_remap,
+            host.designator,
+            result,
+        )
+        new_grouped: list[tuple[PathSpec, str]] = []
+        for path, role in grouped:
+            if role == "unknown" and id(path) in chain_roles:
+                new_grouped.append((path, chain_roles[id(path)]))
+            elif role == "unknown":
+                _append_error_once(
+                    result,
+                    f"PATH on {path.designator}: could not classify pad nets "
+                    f"against host {host.designator}'s stage nets "
+                    f"(IN/OUT/SW) — check net names or set PDN_P_NET / "
+                    f"PDN_N_NET explicitly",
+                )
+                bound_path_ids.discard(id(path))
+            else:
+                new_grouped.append((path, role))
+        path_groups[host_key] = new_grouped
+
+    # Drop host groups that lost every path after chain resolution.
+    path_groups = {k: v for k, v in path_groups.items() if v}
+
+    # Check for unbound PATH elements.
+    for p in paths:
+        if id(p) not in bound_path_ids:
+            # Error already appended by _find_host_regulator or topology check.
+            pass
+
+    # Build replacement directives.
+    new_directives: list = []
+    replaced_reg_ids: set[int] = set()
+
+    for host_key, grouped in path_groups.items():
+        host = host_map[host_key]
+        topo = host.smps_topology or "BUCK"
+        ls_in_coeff, ls_out_coeff = _compute_ls_coeffs(topo, host.gain)
+
+        hs_bridges: list[ResistorSpec] = []
+        ls_legs: list[SwitchPathLeg] = []
+        inductor_path: PathSpec | None = None
+        inductor_dcr: float | None = None
+        hs_in_spec: PathSpec | None = None
+
+        for path, role in grouped:
+            if role in ("hs_in", "hs_out", "shunt"):
+                hs_bridges.append(
+                    ResistorSpec(
+                        designator=path.designator,
+                        schdoc_name=path.schdoc_name,
+                        resistance=path.resistance,
+                        p=path.p,
+                        n=path.n,
+                        channel_index=path.channel_index,
+                    )
+                )
+                if role == "hs_in":
+                    hs_in_spec = path
+            elif role == "ls_in":
+                if ls_in_coeff > 0:
+                    sw1_nets = _net_index_set(proj, host.sw1_net, net_remap)
+                    p_term, n_term = path.p, path.n
+                    if not (_terminal_net_indices(p_term, net_remap) & sw1_nets):
+                        p_term, n_term = path.n, path.p
+                    ls_legs.append(
+                        SwitchPathLeg(
+                            designator=path.designator,
+                            kind="ls_in",
+                            resistance=path.resistance,
+                            p=p_term,
+                            n=n_term,
+                            coeff=ls_in_coeff,
+                        )
+                    )
+            elif role == "ls_out":
+                if ls_out_coeff > 0:
+                    sw2_nets = _net_index_set(proj, host.sw2_net, net_remap)
+                    sw_nets = sw2_nets or _net_index_set(
+                        proj,
+                        host.sw1_net,
+                        net_remap,
+                    )
+                    p_term, n_term = path.p, path.n
+                    if sw_nets and not (_terminal_net_indices(p_term, net_remap) & sw_nets):
+                        p_term, n_term = path.n, path.p
+                    ls_legs.append(
+                        SwitchPathLeg(
+                            designator=path.designator,
+                            kind="ls_out",
+                            resistance=path.resistance,
+                            p=p_term,
+                            n=n_term,
+                            coeff=ls_out_coeff,
+                        )
+                    )
+            elif role == "inductor":
+                if inductor_path is not None:
+                    _append_error_once(
+                        result,
+                        f"PATH on {path.designator}: multiple inductors between "
+                        f"SW1 and SW2 on host {host.designator} — only one "
+                        f"inductor PATH per stage is supported",
+                    )
+                    continue
+                inductor_path = path
+                inductor_dcr = path.resistance
+
+        if (
+            host.sw1_net
+            and host.sw2_net
+            and any(
+                r in ("hs_in", "hs_out", "ls_in", "ls_out", "shunt", "inductor") for _, r in grouped
+            )
+            and inductor_path is None
+        ):
+            _append_error_once(
+                result,
+                f"REGULATOR on {host.designator}: PATH stage with SW1/SW2 "
+                f"needs exactly one inductor between those nets — none found",
+            )
+
+        # Determine inductor terminals orientation (which side is SW1, which SW2).
+        updated_in_p = host.in_p
+        updated_out_p = host.out_p
+        if inductor_path is not None:
+            sw1_nets = _net_index_set(proj, host.sw1_net, net_remap)
+            ind_p_nets = _terminal_net_indices(inductor_path.p, net_remap)
+            if ind_p_nets & sw1_nets:
+                updated_in_p = inductor_path.p
+                updated_out_p = inductor_path.n
+            else:
+                # N on SW1, or intermediate-net inductor (P toward SW1 via chain).
+                # Prefer the pad whose net is closer to SW1: if neither pad is
+                # on SW1 (shunt in between), keep schematic P→SW1 convention
+                # from chain walk (inductor is last edge; P/N already set).
+                sw2_nets = _net_index_set(proj, host.sw2_net, net_remap)
+                ind_n_nets = _terminal_net_indices(inductor_path.n, net_remap)
+                if ind_n_nets & sw1_nets:
+                    updated_in_p = inductor_path.n
+                    updated_out_p = inductor_path.p
+                elif ind_p_nets & sw2_nets:
+                    updated_in_p = inductor_path.n
+                    updated_out_p = inductor_path.p
+                else:
+                    updated_in_p = inductor_path.p
+                    updated_out_p = inductor_path.n
+
+        # Vin sense: VIN-side pad of hs_in, else original regulator IN.
+        if hs_in_spec is not None:
+            in_p_nets = _terminal_net_indices(host.in_p, net_remap)
+            if _terminal_net_indices(hs_in_spec.p, net_remap) & in_p_nets:
+                vin_sense_p = hs_in_spec.p
+            else:
+                vin_sense_p = hs_in_spec.n
+        else:
+            vin_sense_p = host.in_p
+        vin_sense_n = host.in_n
+
+        # Build the updated RegulatorSpec.
+        updated_reg = replace(
+            host,
+            in_p=updated_in_p if inductor_path else host.in_p,
+            out_p=updated_out_p if inductor_path else host.out_p,
+            switch_path_legs=tuple(ls_legs),
+            vin_sense_p=vin_sense_p,
+            vin_sense_n=vin_sense_n,
+            inductor_dcr=inductor_dcr,
+        )
+        replaced_reg_ids.add(id(host))
+
+        # Emit HS bridges as ResistorSpec.
+        new_directives.extend(hs_bridges)
+        # The updated regulator replaces the original.
+        new_directives.append(updated_reg)
+
+    # Rebuild the directive list: keep non-PATH/non-replaced-regulator as-is,
+    # replace bound regulators, drop bound PATHs.
+    rebuilt: list = []
+    for d in result.directives:
+        if isinstance(d, PathSpec):
+            if id(d) in bound_path_ids:
+                continue  # consumed by binding
+            # Unbound PATH — already errored; drop from directives.
+            continue
+        if isinstance(d, RegulatorSpec) and id(d) in replaced_reg_ids:
+            continue  # replaced by updated version in new_directives
+        rebuilt.append(d)
+    rebuilt.extend(new_directives)
+    result.directives = rebuilt

--- a/pdnsolver/problem.py
+++ b/pdnsolver/problem.py
@@ -80,7 +80,7 @@ class BaseLumped:
 
     @property
     def terminals(self) -> list[NodeID]:
-        ...
+        raise NotImplementedError
 
     @property
     def is_source(self) -> bool:
@@ -180,10 +180,18 @@ class VoltageRegulator(BaseLumped):
 
     voltage: float
     gain: float
+    # Averaged switch legs for external-FET stages (LS FETs): each entry is
+    # ``(f, t, coeff)`` with current ``coeff * i_v`` from *f* to *t*. The stamp
+    # also injects ``coeff * i_v`` at *f* as PWM compensation so KCL on the
+    # switch-node copper still leaves ``i_v`` for the high-side path.
+    switch_legs: tuple[tuple[NodeID, NodeID, float], ...] = ()
 
     @property
     def terminals(self) -> list[NodeID]:
-        return [self.v_p, self.v_n, self.s_f, self.s_t]
+        nodes = [self.v_p, self.v_n, self.s_f, self.s_t]
+        for f, t, _coeff in self.switch_legs:
+            nodes.extend((f, t))
+        return nodes
 
     @property
     def is_source(self) -> bool:

--- a/pdnsolver/solver.py
+++ b/pdnsolver/solver.py
@@ -1868,7 +1868,8 @@ def stamp_network_into_system(network: problem.Network,
             case problem.VoltageRegulator(v_p=v_p, v_n=v_n,
                                           s_f=s_f, s_t=s_t,
                                           voltage=voltage,
-                                          gain=gain):
+                                          gain=gain,
+                                          switch_legs=switch_legs):
                 i_v_p = node_indexer.node_to_global_index[v_p]
                 i_v_n = node_indexer.node_to_global_index[v_n]
                 i_s_f = node_indexer.node_to_global_index[s_f]
@@ -1890,6 +1891,17 @@ def stamp_network_into_system(network: problem.Network,
                 rows.extend((i_s_f, i_s_t))
                 cols.extend((i_v, i_v))
                 vals.extend((-gain, gain))
+                # External-FET LS (and similar) legs: I = coeff·i_v from f→t,
+                # plus +coeff·i_v at f so switch-node KCL still leaves i_v for
+                # the high-side path (averaged PWM compensation).
+                for leg_f, leg_t, coeff in switch_legs:
+                    if coeff == 0.0:
+                        continue
+                    i_f = node_indexer.node_to_global_index[leg_f]
+                    i_t = node_indexer.node_to_global_index[leg_t]
+                    rows.extend((i_f, i_t, i_f))
+                    cols.extend((i_v, i_v, i_v))
+                    vals.extend((-coeff, coeff, coeff))
             case _:
                 raise NotImplementedError(f"Unsupported node type {element}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@
 #   uv sync --group build    # adds PyInstaller for packaging
 #   uv run pytest
 #   uv run ruff check .
+#   uv run ty check
 
 [project]
 name = "fypa"
@@ -73,6 +74,7 @@ spacemouse = [
 dev = [
     "pytest==9.0.3",
     "ruff==0.15.13",
+    "ty>=0.0.79",
 ]
 # Opt-in via `uv sync --group build`. Only needed by whoever is producing
 # the PyInstaller bundle, not by end users.
@@ -123,4 +125,46 @@ ignore = [
     # imports mid-file (lazy heavy deps, conditional fallbacks). Placement is
     # intentional, so this E4 sub-rule is silenced rather than enforced.
     "E402",
+]
+
+[tool.ty.src]
+# Same spirit as ruff: keep interactive/debug surfaces out of the first
+# type-check gate. The OpenGL viewers and Qt UI predate typed adoption and
+# dominate the diagnostic count; burn them down separately.
+exclude = [
+    "fypa/altium_viewer.py",
+    "fypa/gl_mesh_viewer.py",
+    "pdnsolver/ui.py",
+    "scripts/**",
+    "altium_monkey/**",
+    # Fixture helpers build ExtractedProject via **dict; type those tests
+    # in a dedicated pass rather than blocking the library gate.
+    "tests/**",
+    # Qt enum stubs / optional SpaceMouse bindings — separate cleanup.
+    "fypa/gerber/import_ui.py",
+    "fypa/spacemouse_nav.py",
+    # Pre-existing untyped surfaces outside External-FET SMPS. Narrow later.
+    "fypa/cli.py",
+    "fypa/altium_geometry.py",
+    "fypa/altium/extract.py",
+    "fypa/altium/loader.py",
+    "fypa/rail_groups.py",
+    "fypa/solve_subprocess.py",
+    "fypa/project_file.py",
+    "fypa/paraview_export.py",
+    "fypa/editor_directives.py",
+    "fypa/caploop/**",
+    "fypa/topology/**",
+    "pdnsolver/mesh.py",
+    "pdnsolver/paraview.py",
+    "pdnsolver/solver.py",
+]
+
+[tool.ty.analysis]
+# Optional / stub-incomplete third-party surfaces.
+allowed-unresolved-imports = [
+    "scipy.spatial.**",
+    "lxml.**",
+    "lxml.etree",
+    "pynavlib.**",
 ]

--- a/tests/test_smps_external_path.py
+++ b/tests/test_smps_external_path.py
@@ -1,0 +1,659 @@
+"""External-FET SMPS (PATH + BUCKBOOST / INVERTER) annotation tests."""
+
+from __future__ import annotations
+
+import pytest
+from pathlib import Path
+
+from fypa.altium.annotations import (
+    PathSpec,
+    RegulatorSpec,
+    ResistorSpec,
+    SwitchPathLeg,
+    parse_annotations,
+)
+from fypa.altium.extract import (
+    ExtractedProject,
+    Pt2D,
+    RawNet,
+    RawPad,
+    RawPcbComponent,
+    RawSchComponent,
+    RawStackupLayer,
+)
+
+
+def _minimal_stackup() -> tuple[RawStackupLayer, ...]:
+    return (
+        RawStackupLayer(
+            layer_id=1,
+            name="Top",
+            copper_thickness_mm=0.035,
+            dielectric_thickness_mm=0.0,
+            next_layer_id=0,
+            is_plane=False,
+            plane_net_name=None,
+            mech_enabled=True,
+        ),
+    )
+
+
+def _minimal_proj(**overrides) -> ExtractedProject:
+    base: dict = {
+        "prjpcb_path": Path("t.PrjPcb"),
+        "pcbdoc_path": Path("t.PcbDoc"),
+        "tracks": (),
+        "arcs": (),
+        "vias": (),
+        "pads": (),
+        "regions": (),
+        "shape_based_regions": (),
+        "fills": (),
+        "pcb_components": (),
+        "nets": (),
+        "stackup": _minimal_stackup(),
+        "sch_components": (),
+        "compiled_netlist": None,
+    }
+    base.update(overrides)
+    return ExtractedProject(**base)  # type: ignore[arg-type]
+
+
+def _pad(comp_idx: int, pin: str, net_index: int, x: float = 0.0) -> RawPad:
+    return RawPad(
+        center=Pt2D(x, 0),
+        width_mm=1,
+        height_mm=1,
+        hole_mm=0,
+        shape=2,
+        rotation_deg=0,
+        layer_id=1,
+        net_index=net_index,
+        designator=pin,
+        component_index=comp_idx,
+        is_through_hole=False,
+        is_smt=True,
+    )
+
+
+def _pcb(des: str, x: float = 0.0) -> RawPcbComponent:
+    return RawPcbComponent(
+        designator=des,
+        center=Pt2D(x, 0),
+        rotation_deg=0.0,
+        layer_name="TOP",
+        footprint="X",
+        source_designator=des,
+    )
+
+
+# Net indices for the BUCKBOOST fixture:
+# 0=GND 1=VIN 2=SW1 3=MID (between shunt and L) 4=SW2 5=VOUT
+_GND, _VIN, _SW1, _MID, _SW2, _VOUT = 0, 1, 2, 3, 4, 5
+
+
+def _buckboost_proj(*, include_ls: bool = True):
+    if include_ls:
+        return _buckboost_proj_with_ls()
+    # Same as with_ls but without Q_LS_OUT.
+    base = _buckboost_proj_with_ls()
+    sch = tuple(c for c in base.sch_components if c.designator != "Q_LS_OUT")
+    # Remap pcb/pads: drop index 6 (Q_LS_OUT), shift LOAD from 7→6.
+    pcb = (
+        base.pcb_components[0],
+        base.pcb_components[1],
+        base.pcb_components[2],
+        base.pcb_components[3],
+        base.pcb_components[4],
+        base.pcb_components[5],
+        _pcb("LOAD", 6),
+    )
+    pads = tuple(p for p in base.pads if p.component_index not in (6, 7)) + (
+        _pad(6, "1", _VOUT),
+        _pad(6, "2", _GND),
+    )
+    return _minimal_proj(
+        nets=base.nets,
+        sch_components=sch,
+        pcb_components=pcb,
+        pads=pads,
+    )
+
+
+def _buckboost_proj_with_ls():
+    sch = (
+        RawSchComponent(
+            designator="J1",
+            schdoc_name="Pwr.SchDoc",
+            parameters={
+                "PDN_ROLE": "SOURCE",
+                "PDN_V": "12",
+                "PDN_P_NET": "VIN",
+                "PDN_N_NET": "GND",
+            },
+            pin_designators=("1", "2"),
+        ),
+        RawSchComponent(
+            designator="U2",
+            schdoc_name="Pwr.SchDoc",
+            parameters={
+                "PDN_ROLE": "REGULATOR",
+                "PDN_REGULATOR_TYPE": "SMPS",
+                "PDN_REGULATOR_EFFICIENCY": "0.9",
+                "PDN_V": "24",
+                "PDN_SMPS_TOPOLOGY": "BUCKBOOST",
+                "PDN_IN_P_NET": "VIN",
+                "PDN_IN_N_NET": "GND",
+                "PDN_OUT_P_NET": "VOUT",
+                "PDN_OUT_N_NET": "GND",
+                "PDN_SW1_NET": "SW1",
+                "PDN_SW2_NET": "SW2",
+                "PDN_IN_P_PINS": "1",
+                "PDN_IN_N_PINS": "2",
+                "PDN_OUT_P_PINS": "3",
+                "PDN_OUT_N_PINS": "4",
+            },
+            pin_designators=("1", "2", "3", "4"),
+        ),
+        RawSchComponent(
+            designator="Q_HS_IN",
+            schdoc_name="Pwr.SchDoc",
+            parameters={
+                "PDN_ROLE": "PATH",
+                "PDN_R": "10m",
+                "PDN_P_PINS": "3",
+                "PDN_N_PINS": "2",
+            },
+            pin_designators=("1", "2", "3"),
+        ),
+        RawSchComponent(
+            designator="R_SHUNT",
+            schdoc_name="Pwr.SchDoc",
+            parameters={
+                "PDN_ROLE": "PATH",
+                "PDN_R": "1m",
+                "PDN_P_PINS": "1",
+                "PDN_N_PINS": "2",
+            },
+            pin_designators=("1", "2"),
+        ),
+        RawSchComponent(
+            designator="L1",
+            schdoc_name="Pwr.SchDoc",
+            parameters={"PDN_ROLE": "PATH", "PDN_R": "7m"},
+            pin_designators=("1", "2"),
+        ),
+        RawSchComponent(
+            designator="Q_HS_OUT",
+            schdoc_name="Pwr.SchDoc",
+            parameters={
+                "PDN_ROLE": "PATH",
+                "PDN_R": "12m",
+                "PDN_P_PINS": "3",
+                "PDN_N_PINS": "2",
+            },
+            pin_designators=("1", "2", "3"),
+        ),
+        RawSchComponent(
+            designator="Q_LS_OUT",
+            schdoc_name="Pwr.SchDoc",
+            parameters={
+                "PDN_ROLE": "PATH",
+                "PDN_R": "8m",
+                "PDN_P_PINS": "3",
+                "PDN_N_PINS": "2",
+            },
+            pin_designators=("1", "2", "3"),
+        ),
+        RawSchComponent(
+            designator="LOAD",
+            schdoc_name="Pwr.SchDoc",
+            parameters={
+                "PDN_ROLE": "SINK",
+                "PDN_I": "2A",
+                "PDN_P_NET": "VOUT",
+                "PDN_N_NET": "GND",
+            },
+            pin_designators=("1", "2"),
+        ),
+    )
+    pcb = tuple(
+        _pcb(d, i)
+        for i, d in enumerate(
+            ["J1", "U2", "Q_HS_IN", "R_SHUNT", "L1", "Q_HS_OUT", "Q_LS_OUT", "LOAD"]
+        )
+    )
+    pads = (
+        _pad(0, "1", _VIN),
+        _pad(0, "2", _GND),
+        _pad(1, "1", _VIN),
+        _pad(1, "2", _GND),
+        _pad(1, "3", _VOUT),
+        _pad(1, "4", _GND),
+        _pad(2, "1", _GND),
+        _pad(2, "2", _SW1),
+        _pad(2, "3", _VIN),
+        _pad(3, "1", _SW1),
+        _pad(3, "2", _MID),
+        _pad(4, "1", _MID),
+        _pad(4, "2", _SW2),
+        _pad(5, "1", _GND),
+        _pad(5, "2", _SW2),
+        _pad(5, "3", _VOUT),
+        _pad(6, "1", _GND),
+        _pad(6, "2", _GND),
+        _pad(6, "3", _SW2),
+        _pad(7, "1", _VOUT),
+        _pad(7, "2", _GND),
+    )
+    return _minimal_proj(
+        nets=(
+            RawNet("GND"),
+            RawNet("VIN"),
+            RawNet("SW1"),
+            RawNet("MID"),
+            RawNet("SW2"),
+            RawNet("VOUT"),
+        ),
+        sch_components=sch,
+        pcb_components=pcb,
+        pads=pads,
+    )
+
+
+def test_buckboost_path_binds_and_cuts_at_inductor():
+    result = parse_annotations(_buckboost_proj_with_ls(), enabled_layers=[1])
+    assert result.ok, result.errors
+    assert not any(isinstance(d, PathSpec) for d in result.directives)
+
+    reg = next(d for d in result.directives if isinstance(d, RegulatorSpec))
+    assert reg.smps_topology == "BUCKBOOST"
+    assert abs(reg.gain - (24.0 / (12.0 * 0.9))) < 1e-6
+    assert reg.inductor_dcr == pytest.approx(0.007)
+    # IN/OUT relocated to inductor pads (MID / SW2).
+    in_nets = {p.net_index for p in reg.in_p.pins}
+    out_nets = {p.net_index for p in reg.out_p.pins}
+    assert in_nets == {_MID}
+    assert out_nets == {_SW2}
+
+    bridges = [d for d in result.directives if isinstance(d, ResistorSpec)]
+    bridge_des = {d.designator for d in bridges}
+    assert "Q_HS_IN" in bridge_des
+    assert "Q_HS_OUT" in bridge_des
+    assert "R_SHUNT" in bridge_des
+    assert "L1" not in bridge_des  # inductor is the cut, not a bridge
+
+    assert len(reg.switch_path_legs) == 1
+    leg = reg.switch_path_legs[0]
+    assert leg.kind == "ls_out"
+    assert leg.designator == "Q_LS_OUT"
+    assert leg.coeff == pytest.approx(reg.gain - 1.0)
+
+
+def test_buckboost_auto_host_without_smps_host():
+    """PATH parts bind via shared nets — no PDN_SMPS_HOST required."""
+    result = parse_annotations(_buckboost_proj(include_ls=False), enabled_layers=[1])
+    assert result.ok, result.errors
+    reg = next(d for d in result.directives if isinstance(d, RegulatorSpec))
+    assert reg.inductor_dcr is not None
+    assert not reg.switch_path_legs
+
+
+def test_internal_fet_regulator_unchanged_without_path():
+    """Regression: REGULATOR without PATH stays on controller pads."""
+    proj = _minimal_proj(
+        nets=(RawNet("GND"), RawNet("VIN"), RawNet("VOUT")),
+        sch_components=(
+            RawSchComponent(
+                designator="J1",
+                schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SOURCE",
+                    "PDN_V": "5",
+                    "PDN_P_NET": "VIN",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="U2",
+                schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_REGULATOR_TYPE": "SMPS",
+                    "PDN_REGULATOR_EFFICIENCY": "0.9",
+                    "PDN_V": "3.3",
+                    "PDN_IN_P_NET": "VIN",
+                    "PDN_IN_N_NET": "GND",
+                    "PDN_OUT_P_NET": "VOUT",
+                    "PDN_OUT_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+        ),
+        pcb_components=(_pcb("J1"), _pcb("U2", 1)),
+        pads=(
+            _pad(0, "1", 1),
+            _pad(0, "2", 0),
+            _pad(1, "1", 2),
+            _pad(1, "2", 0),
+            _pad(1, "3", 1),
+            _pad(1, "4", 0),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    reg = next(d for d in result.directives if isinstance(d, RegulatorSpec))
+    assert reg.smps_topology is None
+    assert reg.switch_path_legs == ()
+    assert {p.net_index for p in reg.in_p.pins} == {1}
+    assert {p.net_index for p in reg.out_p.pins} == {2}
+
+
+def test_inverter_topology_gain_without_upstream_vin():
+    """INVERTER: gain = 1/eff, no Vin inference, phases stay separate rails."""
+    proj = _minimal_proj(
+        nets=(
+            RawNet("GND"),
+            RawNet("VBUS"),
+            RawNet("PHASE_A"),
+            RawNet("PHASE_B"),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="J1",
+                schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SOURCE",
+                    "PDN_V": "24",
+                    "PDN_P_NET": "VBUS",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="U5",
+                schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_REGULATOR_TYPE": "SMPS",
+                    "PDN_REGULATOR_EFFICIENCY": "0.85",
+                    "PDN_SMPS_TOPOLOGY": "INVERTER",
+                    "PDN_V": "24",
+                    "PDN_IN_P_NET": "VBUS",
+                    "PDN_IN_N_NET": "GND",
+                    "PDN1_OUT_P_NET": "PHASE_A",
+                    "PDN1_OUT_N_NET": "GND",
+                    "PDN1_V": "24",
+                    "PDN2_OUT_P_NET": "PHASE_B",
+                    "PDN2_OUT_N_NET": "GND",
+                    "PDN2_V": "24",
+                },
+                pin_designators=("1", "2", "3", "4", "5"),
+            ),
+            RawSchComponent(
+                designator="J9",
+                schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SINK",
+                    "PDN1_I": "1A",
+                    "PDN1_P_NET": "PHASE_A",
+                    "PDN1_N_NET": "GND",
+                    "PDN2_I": "1A",
+                    "PDN2_P_NET": "PHASE_B",
+                    "PDN2_N_NET": "GND",
+                },
+                pin_designators=("1", "2", "4"),
+            ),
+        ),
+        pcb_components=(_pcb("J1"), _pcb("U5", 1), _pcb("J9", 2)),
+        pads=(
+            _pad(0, "1", 1),
+            _pad(0, "2", 0),
+            _pad(1, "1", 1),
+            _pad(1, "2", 0),
+            _pad(1, "3", 2),
+            _pad(1, "4", 3),
+            _pad(1, "5", 0),
+            _pad(2, "1", 2),
+            _pad(2, "2", 3),
+            _pad(2, "4", 0),
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    regs = [d for d in result.directives if isinstance(d, RegulatorSpec)]
+    assert len(regs) >= 1
+    for reg in regs:
+        assert reg.smps_topology == "INVERTER"
+        assert reg.gain == pytest.approx(1.0 / 0.85)
+        assert not reg.adaptive_gain_eligible
+    # No SERIES bridge from bus to phases → VIN and phase nets stay distinct
+    # in directive terminals (REGULATOR does not union rails).
+    assert not any(isinstance(d, ResistorSpec) for d in result.directives)
+
+
+def test_path_ambiguous_host_requires_smps_host():
+    """Two BUCKBOOST stages sharing a net name force PDN_SMPS_HOST."""
+    # Minimal: two regulators both claiming SW1=SWA — PATH on SWA is ambiguous.
+    proj = _minimal_proj(
+        nets=(
+            RawNet("GND"),
+            RawNet("VIN"),
+            RawNet("SWA"),
+            RawNet("SWB1"),
+            RawNet("SWB2"),
+            RawNet("VOUT1"),
+            RawNet("VOUT2"),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="J1",
+                schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SOURCE",
+                    "PDN_V": "12",
+                    "PDN_P_NET": "VIN",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="U1",
+                schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_V": "24",
+                    "PDN_GAIN": "2",
+                    "PDN_SMPS_TOPOLOGY": "BUCKBOOST",
+                    "PDN_IN_P_NET": "VIN",
+                    "PDN_IN_N_NET": "GND",
+                    "PDN_OUT_P_NET": "VOUT1",
+                    "PDN_OUT_N_NET": "GND",
+                    "PDN_SW1_NET": "SWA",
+                    "PDN_SW2_NET": "SWB1",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+            RawSchComponent(
+                designator="U2",
+                schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_V": "24",
+                    "PDN_GAIN": "2",
+                    "PDN_SMPS_TOPOLOGY": "BUCKBOOST",
+                    "PDN_IN_P_NET": "VIN",
+                    "PDN_IN_N_NET": "GND",
+                    "PDN_OUT_P_NET": "VOUT2",
+                    "PDN_OUT_N_NET": "GND",
+                    "PDN_SW1_NET": "SWA",
+                    "PDN_SW2_NET": "SWB2",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+            RawSchComponent(
+                designator="L1",
+                schdoc_name="Pwr.SchDoc",
+                parameters={"PDN_ROLE": "PATH", "PDN_R": "5m"},
+                pin_designators=("1", "2"),
+            ),
+        ),
+        pcb_components=(_pcb("J1"), _pcb("U1", 1), _pcb("U2", 2), _pcb("L1", 3)),
+        pads=(
+            _pad(0, "1", 1),
+            _pad(0, "2", 0),
+            _pad(1, "1", 1),
+            _pad(1, "2", 0),
+            _pad(1, "3", 5),
+            _pad(1, "4", 0),
+            _pad(2, "1", 1),
+            _pad(2, "2", 0),
+            _pad(2, "3", 6),
+            _pad(2, "4", 0),
+            _pad(3, "1", 2),
+            _pad(3, "2", 3),  # SWA ↔ SWB1 — still touches SWA
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert any("ambiguous host" in e for e in result.errors)
+
+
+def test_shunt_kelvin_pads_without_filter_warn_or_fail_cleanly():
+    """4-pin shunt: Kelvin on GND ignored when P/N nets name the power path."""
+    base = _buckboost_proj(include_ls=False)
+    sch = list(base.sch_components)
+    sch[3] = RawSchComponent(
+        designator="R_SHUNT",
+        schdoc_name="Pwr.SchDoc",
+        parameters={
+            "PDN_ROLE": "PATH",
+            "PDN_R": "1m",
+            "PDN_P_NET": "SW1",
+            "PDN_N_NET": "MID",
+        },
+        pin_designators=("1", "2", "1a", "2a"),
+    )
+    pads = list(base.pads) + [
+        _pad(3, "1a", _GND, 3.2),
+        _pad(3, "2a", _GND, 3.3),
+    ]
+    proj = _minimal_proj(
+        nets=base.nets,
+        sch_components=tuple(sch),
+        pcb_components=base.pcb_components,
+        pads=tuple(pads),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    shunt = next(
+        d for d in result.directives if isinstance(d, ResistorSpec) and d.designator == "R_SHUNT"
+    )
+    nets = {p.net_index for t in (shunt.p, shunt.n) for p in t.pins}
+    assert nets == {_SW1, _MID}
+
+
+def test_loader_stamps_switch_legs():
+    """LS coeff on SwitchPathLeg matches boost (G-1)."""
+    result = parse_annotations(_buckboost_proj_with_ls(), enabled_layers=[1])
+    assert result.ok, result.errors
+    reg = next(d for d in result.directives if isinstance(d, RegulatorSpec))
+    assert reg.switch_path_legs
+    assert reg.switch_path_legs[0].coeff == pytest.approx(reg.gain - 1.0)
+    assert isinstance(reg.switch_path_legs[0], SwitchPathLeg)
+
+
+def test_buck_topology_ls_in_coeff():
+    """BUCK with G<1 → ls_in coeff = 1-G."""
+    proj = _minimal_proj(
+        nets=(
+            RawNet("GND"),
+            RawNet("VIN"),
+            RawNet("SW1"),
+            RawNet("VOUT"),
+        ),
+        sch_components=(
+            RawSchComponent(
+                designator="J1",
+                schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "SOURCE",
+                    "PDN_V": "12",
+                    "PDN_P_NET": "VIN",
+                    "PDN_N_NET": "GND",
+                },
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="U2",
+                schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "REGULATOR",
+                    "PDN_REGULATOR_TYPE": "SMPS",
+                    "PDN_REGULATOR_EFFICIENCY": "1",
+                    "PDN_V": "5",
+                    "PDN_SMPS_TOPOLOGY": "BUCK",
+                    "PDN_IN_P_NET": "VIN",
+                    "PDN_IN_N_NET": "GND",
+                    "PDN_OUT_P_NET": "VOUT",
+                    "PDN_OUT_N_NET": "GND",
+                    "PDN_SW1_NET": "SW1",
+                    "PDN_SW2_NET": "VOUT",
+                },
+                pin_designators=("1", "2", "3", "4"),
+            ),
+            RawSchComponent(
+                designator="Q_HS",
+                schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "PATH",
+                    "PDN_R": "10m",
+                    "PDN_P_PINS": "3",
+                    "PDN_N_PINS": "2",
+                },
+                pin_designators=("1", "2", "3"),
+            ),
+            RawSchComponent(
+                designator="L1",
+                schdoc_name="Pwr.SchDoc",
+                parameters={"PDN_ROLE": "PATH", "PDN_R": "5m"},
+                pin_designators=("1", "2"),
+            ),
+            RawSchComponent(
+                designator="Q_LS",
+                schdoc_name="Pwr.SchDoc",
+                parameters={
+                    "PDN_ROLE": "PATH",
+                    "PDN_R": "8m",
+                    "PDN_P_PINS": "3",
+                    "PDN_N_PINS": "2",
+                },
+                pin_designators=("1", "2", "3"),
+            ),
+        ),
+        pcb_components=tuple(_pcb(d, i) for i, d in enumerate(["J1", "U2", "Q_HS", "L1", "Q_LS"])),
+        pads=(
+            _pad(0, "1", 1),
+            _pad(0, "2", 0),
+            _pad(1, "1", 1),
+            _pad(1, "2", 0),
+            _pad(1, "3", 3),
+            _pad(1, "4", 0),
+            _pad(2, "1", 0),
+            _pad(2, "2", 2),
+            _pad(2, "3", 1),  # HS VIN↔SW1
+            _pad(3, "1", 2),
+            _pad(3, "2", 3),  # L SW1↔VOUT(=SW2)
+            _pad(4, "1", 0),
+            _pad(4, "2", 0),
+            _pad(4, "3", 2),  # LS SW1↔GND
+        ),
+    )
+    result = parse_annotations(proj, enabled_layers=[1])
+    assert result.ok, result.errors
+    reg = next(d for d in result.directives if isinstance(d, RegulatorSpec))
+    assert reg.smps_topology == "BUCK"
+    assert reg.gain == pytest.approx(5.0 / 12.0)
+    assert len(reg.switch_path_legs) == 1
+    assert reg.switch_path_legs[0].kind == "ls_in"
+    assert reg.switch_path_legs[0].coeff == pytest.approx(1.0 - reg.gain)

--- a/uv.lock
+++ b/uv.lock
@@ -178,6 +178,7 @@ build = [
 dev = [
     { name = "pytest" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -204,6 +205,7 @@ build = [{ name = "pyinstaller" }]
 dev = [
     { name = "pytest", specifier = "==9.0.3" },
     { name = "ruff", specifier = "==0.15.13" },
+    { name = "ty", specifier = ">=0.0.79" },
 ]
 
 [[package]]
@@ -919,6 +921,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/23/e0/bd0a7e624fc5fc8636d0ad281c5b0624027dc1855218ce6a251c581d7127/triangle-20250106-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b582b342cddb660dffc6bd7d7233f66952d2a3d18ccbc097660a8e370ee38d0c", size = 2009167, upload-time = "2025-01-07T04:56:12.221Z" },
     { url = "https://files.pythonhosted.org/packages/26/3f/7c79202ec374bd122b63250d768be34674043be9b97f6bb8c115df64e880/triangle-20250106-cp312-cp312-win32.whl", hash = "sha256:9532797a15687225a0ee67619ad6f3baeb72bf193541eb96f782e41c577cc81b", size = 1407116, upload-time = "2025-01-07T05:00:13.664Z" },
     { url = "https://files.pythonhosted.org/packages/a1/a5/4a09c3f9d2687d8752c912a97f2c5086cdd83721b3b13f8288f13b771fa7/triangle-20250106-cp312-cp312-win_amd64.whl", hash = "sha256:0327032a7984a7262180ef2ddd78b36dfdcdecbc79f0f9f173732ce7c670b8ed", size = 1426720, upload-time = "2025-01-07T05:00:17.789Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.79"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/d3/4fff47468a976c7a5ded9fe350734ca09b9e8460750327f2245ea3288d5d/ty-0.0.79.tar.gz", hash = "sha256:159a1aca70edebae32be08bfba2e5d543ffd8f9f380af160e0e713e85313b733", size = 7162150, upload-time = "2026-09-07T21:51:58.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/a3/2fa5b5495fe37351d77571eb0985476461be02c822bb39ad669b9fdb5bb8/ty-0.0.79-py3-none-linux_armv6l.whl", hash = "sha256:f60d968bbc6d52b663d3df4cae647d3cc68df4a7135bd9098e8d570bf9a5e0da", size = 13557478, upload-time = "2026-09-07T21:51:14.089Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f0/1659a926d2b19351839ca64787e1531c97fbe8bf35c3c47d20954f338428/ty-0.0.79-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4c95ae0ca67483c4f1231c4b2fd332b76f212e8d93154c385d77511d90dcbd8e", size = 13163780, upload-time = "2026-09-07T21:51:17.066Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/b2/e0a8a8cf58b39f0d1f509a22550aed1e2cc12bb4a868170b43aede9fcd93/ty-0.0.79-py3-none-macosx_11_0_arm64.whl", hash = "sha256:685888adb29b6e732ee325c6b6db92a422f72f3e4031c12450728c846e5e93fe", size = 12964040, upload-time = "2026-09-07T21:51:19.818Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a7/7d8fb6c958d88a63ad932421eff8848267bb9229136ef65d9f372aa2be7a/ty-0.0.79-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0535640db5dc02f9e14bf419ad2cf3acdd49681e70f233c96e96d16cfcefc00", size = 13010025, upload-time = "2026-09-07T21:51:22.468Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/4c/94aee26446f058e67b2c8ef0b25bdc1cf555e40eb692112d7a609f30c238/ty-0.0.79-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:48cb24e21488f9d11cffa81d5a5f71f314c87383b7a5d28dabe6feaa3f3d7a34", size = 13332191, upload-time = "2026-09-07T21:51:25.031Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/21/9e7c0415fa6275500f10ce13f2bad62e03211ba5f3ea61a702d819328407/ty-0.0.79-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1a35b3b116a591a68da5958c082247f0c3a50f134d0a60ff45d060eb3d2ad612", size = 14153955, upload-time = "2026-09-07T21:51:27.421Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5f/b27b510f973a314200cfda4f0500de3c65f6caa45a590355f6acc5e96289/ty-0.0.79-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fcb760f059d660dfd5c9c6c33609478a267c3185c7448d72e6f7ff4572796bae", size = 14594578, upload-time = "2026-09-07T21:51:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/fa/0ccc2e510c1c24682ae21c836c09be6dcf0b1aacab071c51a297d301601f/ty-0.0.79-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fcdc1ae0c740f9b6d6536ffecf485616a8909bed5de88c6e870a65546a6a2d91", size = 14266409, upload-time = "2026-09-07T21:51:32.868Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c3/3a404d44e9768578daf7dfda06cba714eda6feac53272eda295947a8d4c7/ty-0.0.79-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c1e77d58e192c81b958783328b303ceda8706328a307c852ceb257505765458", size = 13658441, upload-time = "2026-09-07T21:51:35.283Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/23/b90a512055fdf6356e95c0f745cb9b443b9a4ac9d3a79f07ae6ed53ae9ca/ty-0.0.79-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a87f52183b976d9eda5fad28405b37621a265c3de5e9e279660556c715ed1805", size = 14195669, upload-time = "2026-09-07T21:51:37.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/05/d051248dcff852e8a3165a2feb164dc5b857ef237fa82e7ea2b3b7bac375/ty-0.0.79-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fb429a44bc9e90649e69f739d70db4a305102a36586a810caee00c984c379997", size = 13127929, upload-time = "2026-09-07T21:51:40.431Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/d1/60b5c980df55b1d5010a41b10d7c8cf6111b5d02ec0807f6f782bb3d88aa/ty-0.0.79-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1d857fa34d60b0981cf12ca19180ae5de70dd46306a9277bee772bb09e82ae5c", size = 13334425, upload-time = "2026-09-07T21:51:42.956Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3c/fcbfa731128f06b1c9be5074f51ce47da06842dc8f33c81e7c1c483b6e91/ty-0.0.79-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a95cffa2f30289b0b949db7611ae96ede0352f0f1d7ba07ea7cabb27616fccb9", size = 13629671, upload-time = "2026-09-07T21:51:45.467Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/00/3004a1d375c2a835c7dbf01c480205a190f24b74c8b5c849fd2dbe078d69/ty-0.0.79-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d33df0f1bdee62dc366551d35b9830b1fa2e9ee2936a437abd435f71b3fce73e", size = 13939769, upload-time = "2026-09-07T21:51:48.033Z" },
+    { url = "https://files.pythonhosted.org/packages/10/7d/f357f5768872ffa3a026707477a880aba7582af5f6c7c7eab74f61167f3d/ty-0.0.79-py3-none-win32.whl", hash = "sha256:ca266de079a187ed6f0f5b802f6fc3b26164753c7347a04daed21d86c938d33d", size = 12833644, upload-time = "2026-09-07T21:51:50.766Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f5/2a2d967be6286ee8fb626161e610fd48624ba5e6712cea932adb2d6b40b6/ty-0.0.79-py3-none-win_amd64.whl", hash = "sha256:88cb357d36ad79181015581365769fff4b1ec580cd12de83addfa98663214fd3", size = 13494258, upload-time = "2026-09-07T21:51:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/74/49b88f104f88d9757497758bf57ba53e3612442b49500d1092d4d6f1daa3/ty-0.0.79-py3-none-win_arm64.whl", hash = "sha256:d29da73f2840ae2631bc62ef8f8d509a94edea596e5b3072851f67e4729d744c", size = 13327517, upload-time = "2026-09-07T21:51:55.602Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
High-current SMPS designs often use a controller plus **external FETs**, a sense shunt, and an inductor. FYPA’s existing REGULATOR model assumes the current boundaries sit on the IC itself (internal FETs). If you instead annotate the power path as a plain `SERIES` chain (`VIN → HS → L → HS → VOUT`) while both rails are voltage-forced, the solver effectively shorts the rails through RDSon — which is exactly wrong for IR / copper analysis where the interesting current is large.
This PR extends the same `VoltageRegulator` MNA element so those stages work properly:
- New role **`PDN_ROLE=PATH`** on FETs / shunt / inductor (`PDN_R` + optional pin filters).
- Stage map on the **`REGULATOR` host**: `PDN_SMPS_TOPOLOGY`, `PDN_SW1_NET` / `PDN_SW2_NET`, usual `IN_*` / `OUT_*`.
- Auto host bind and path classification from pad–net intersection (`PDN_SMPS_HOST` only when ambiguous).
- **Inductor = cut** (no SW1↔SW2 rail merge); HS/shunt = island SERIES bridges; LS = averaged `k·i_v` stamps (not SERIES to GND).
- Topologies: `BUCK` / `BOOST` / `BUCKBOOST`, plus **`INVERTER`** for multi-phase / motor-style drivers that share the same “don’t SERIES-star the bus” problem but are not a voltage step-up/down.

So the feature is aimed at external-FET SMPS (especially high current), and as a side effect cleans up related external-FET architectures that previously needed weaker equivalents.
Docs: user guide § regulators (PATH / host vs part params) and README role table. Tests cover bind/cut, buck/boost coeffs, INVERTER, Kelvin shunt, ambiguous host, and internal-FET regression.
## Test plan
- [ ] `uv run pytest tests/test_smps_external_path.py tests/test_regulator_direction.py`
- [ ] `uv run ruff check .` and `uv run ty check`
- [ ] Annotate a buck-boost with external FETs (`PATH` + host `SW1`/`SW2`); confirm VIN and VOUT stay separate rails and path currents look plausible
- [ ] Smoke `INVERTER` multi-phase REGULATOR: DC bus and phase nets are not one SERIES mega-rail
- [ ] Regression: REGULATOR without `PATH` parts behaves as today’s internal-FET SMPS
